### PR TITLE
Update i3LIM charger to use enums rather than raw values

### DIFF
--- a/include/i3LIM.h
+++ b/include/i3LIM.h
@@ -10,6 +10,13 @@
 #include "params.h"
 #include "stm32_can.h"
 
+enum class i3LIMChargingState
+{
+    No_Chg,
+    AC_Chg,
+    DC_Chg
+};
+
 class i3LIMClass
 {
 
@@ -23,9 +30,7 @@ static void handle272(uint32_t data[2]);
 static void Send200msMessages();
 static void Send100msMessages();
 static void Send10msMessages();
-static uint8_t Control_Charge();
-
-
+static i3LIMChargingState Control_Charge();
 private:
 static void CCS_Pwr_Con();
 

--- a/src/i3LIM.cpp
+++ b/src/i3LIM.cpp
@@ -55,12 +55,6 @@ static ChargeReady CHG_Ready=ChargeReady::NotRdy;  //indicator to the LIM that w
 static uint8_t CONT_Ctrl=0;  //4 bits with DC ccs contactor command.
 static uint8_t CCSI_Spnt=0;
 
-
-
-#define No_Chg 0x0
-#define AC_Chg 0x1
-#define DC_Chg 0x2
-
 void i3LIMClass::handle3B4(uint32_t data[2])  //Lim data
 
 {
@@ -429,7 +423,7 @@ vin_ctr++;
 
 }
 
-uint8_t i3LIMClass::Control_Charge()
+i3LIMChargingState i3LIMClass::Control_Charge()
 {
     int opmode = Param::GetInt(Param::opmode);
     if (opmode != MOD_RUN)  //only do this if we are not in run mode
@@ -448,7 +442,7 @@ if (Param::GetBool(Param::PlugDet)&&(CP_Mode==0x1||CP_Mode==0x2))  //if we have 
   CHG_Pwr=6500/25;//approx 6.5kw ac
 
 
-    if(!Param::GetBool(Param::Chgctrl))return AC_Chg;//set ac charge mode if we are enabled on webui
+    if(!Param::GetBool(Param::Chgctrl))return i3LIMChargingState::AC_Chg;//set ac charge mode if we are enabled on webui
 
 if(Param::GetBool(Param::Chgctrl))
 {
@@ -462,7 +456,7 @@ if(Param::GetBool(Param::Chgctrl))
   CHG_Req=ChargeRequest::EndCharge;
   CHG_Ready=ChargeReady::NotRdy;
   CHG_Pwr=0;
-    return No_Chg;//set no charge mode if we are disabled on webui and in state 9 of dc machine
+    return i3LIMChargingState::No_Chg;//set no charge mode if we are disabled on webui and in state 9 of dc machine
 }
 
 }
@@ -700,11 +694,11 @@ Charge phase 4,
     CONT_Ctrl=0x0; //dc contactor to open mode
     FC_Cur=0;//current command to 0
   EOC_Time=0xFE;//end of charge timer
-  CHG_Status=ChargeStatus::NotRdy;
+  CHG_Status=ChargeStatus::Init;
   CHG_Req=ChargeRequest::EndCharge;
   CHG_Ready=ChargeReady::NotRdy;
   CHG_Pwr=0;//0 power
-       return No_Chg;
+       return i3LIMChargingState::No_Chg;
 
     }
         break;
@@ -712,8 +706,8 @@ Charge phase 4,
 
     }
 
-if(!Param::GetBool(Param::Chgctrl))return DC_Chg;//set dc charge mode if we are enabled on webui
-if(Param::GetBool(Param::Chgctrl)&&lim_state==9)return No_Chg;//set no charge mode if we are disabled on webui and in state 9 of dc machine
+if(!Param::GetBool(Param::Chgctrl))return i3LIMChargingState::DC_Chg;//set dc charge mode if we are enabled on webui
+if(Param::GetBool(Param::Chgctrl)&&lim_state==9)return i3LIMChargingState::No_Chg;//set no charge mode if we are disabled on webui and in state 9 of dc machine
 
 }
 
@@ -731,11 +725,11 @@ if (!Param::GetBool(Param::PlugDet))  //if we  plug remove shut down
   CHG_Req=ChargeRequest::EndCharge;
   CHG_Ready=ChargeReady::NotRdy;
   CHG_Pwr=0;
-    return No_Chg;
+    return i3LIMChargingState::No_Chg;
 }
 }
     // If nothing matches then we aren't charging
-    return No_Chg;
+    return i3LIMChargingState::No_Chg;
 }
 
 

--- a/src/stm32_vcu.cpp
+++ b/src/stm32_vcu.cpp
@@ -44,8 +44,6 @@ static uint8_t Lexus_Gear;
 static uint16_t Lexus_Oil;
 static uint16_t maxRevs;
 static uint32_t oldTime;
-uint8_t LIMmode=0;
-
 
 // Instantiate Classes
 BMW_E65Class E65Vehicle;
@@ -78,36 +76,35 @@ static void Ms200Task(void)
        if (opmode == MOD_OFF)
     {
         Param::SetInt(Param::chgtyp,OFF);
-      LIMmode=i3LIMClass::Control_Charge();
-      if(LIMmode==0x2)   //DC charge mode
+      auto LIMmode=i3LIMClass::Control_Charge();
+      if(LIMmode==i3LIMChargingState::DC_Chg)   //DC charge mode
       {
             chargeMode = true;
             chargeModeDC = true;   //DC charge mode
           Param::SetInt(Param::chgtyp,DCFC);
       }
-      if(LIMmode==0x1)
+      if(LIMmode==i3LIMChargingState::AC_Chg)
       {
           chargeMode = true;   //AC charge mode
           Param::SetInt(Param::chgtyp,AC);
       }
 
-      if(LIMmode==0x0) chargeMode = false;  //no charge mode
+      if(LIMmode==i3LIMChargingState::No_Chg) chargeMode = false;  //no charge mode
     }
 
     if (opmode == MOD_CHARGE)
     {
-        LIMmode=i3LIMClass::Control_Charge();
-
-      if((LIMmode==0x0)&&(Param::GetInt(Param::chgtyp)==AC)&&(chargerClass::HVreq==false))// if we are in AC charge mode,have no hv request and shutdown from the lim then end chg mode
-
+        auto LIMmode=i3LIMClass::Control_Charge();
+        // if we are in AC charge mode,have no hv request and shutdown from the lim then end chg mode
+        if((LIMmode==i3LIMChargingState::No_Chg)&&(Param::GetInt(Param::chgtyp)==AC)&&(chargerClass::HVreq==false))
         {
             chargeMode = false;  //no charge mode
             Param::SetInt(Param::chgtyp,OFF);
 
         }
 
-         if((LIMmode==0x0)&&(Param::GetInt(Param::chgtyp)==DCFC))// if we are in DC charge mode and shutdown from the lim then end chg mode
-
+        // if we are in DC charge mode and shutdown from the lim then end chg mode
+        if((LIMmode==i3LIMChargingState::No_Chg)&&(Param::GetInt(Param::chgtyp)==DCFC))
         {
             chargeMode = false;  //no charge mode
             chargeModeDC = false;   //DC charge mode off


### PR DESCRIPTION
This series of commits converts values within the i3LIM module which have a fixed set of values to use enumerated types rather than a raw value with #defined constants. This gives the compiler more opportunities to stop errors and, I think, makes the code clearer and easier to maintain.