### PR TITLE
i3LIM: Give contactors time to close before starting energy transfer

### DIFF
--- a/src/i3LIM.cpp
+++ b/src/i3LIM.cpp
@@ -619,59 +619,59 @@ Charge phase 4,
     }
         break;
 
-             case 4:
+        case 4:
         {
-    Chg_Phase=ChargePhase::Subpoena;//precharge phase in this state
-    CONT_Ctrl=0x0; //dc contactor mode control required in DC
-    FC_Cur=0;//ccs current request from web ui for now.
- // EOC_Time=0x1E;//end of charge timer
-  CHG_Status=ChargeStatus::Init;
-  CHG_Req=ChargeRequest::Charge;
-  CHG_Ready=ChargeReady::Rdy;
-  CHG_Pwr=44000/25;//49kw approx power
-    CCSI_Spnt=0;//No current
+            Chg_Phase = ChargePhase::Subpoena; //precharge phase in this state
+            CONT_Ctrl = 0x0;                   //dc contactor mode control required in DC
+            FC_Cur = 0;                        //ccs current request from web ui for now.
+                                               // EOC_Time=0x1E;//end of charge timer
+            CHG_Status = ChargeStatus::Init;
+            CHG_Req = ChargeRequest::Charge;
+            CHG_Ready = ChargeReady::Rdy;
+            CHG_Pwr = 44000 / 25; //49kw approx power
+            CCSI_Spnt = 0;        //No current
 
-        if((Param::GetInt(Param::udc)-Cont_Volts)<20)
-        {
-           lim_stateCnt++; //we wait for the contactor voltage to be 20v or less diff to main batt v
+            if ((Param::GetInt(Param::udc) - Cont_Volts) < 20)
+            {
+                lim_stateCnt++; //we wait for the contactor voltage to be 20v or less diff to main batt v
+            }
+            else
+            {
+                // If the contactor voltage wanders out of range start again
+                lim_stateCnt = 0;
+            }
 
+            // Wait for contactor voltage to be stable for 4 seconds
+            if (lim_stateCnt > 10)
+            {
+                lim_state++; //next state after 4 secs
+                lim_stateCnt = 0;
+            }
         }
-
-        if(lim_stateCnt>10)//need to close con at pch stage
-        {
-           lim_state++; //next state after 4 secs
-           lim_stateCnt=0;
-           CONT_Ctrl=0x2; //dc contactor to close mode
-        }
-
-    }
         break;
-    case 5:
+        case 5:
         {
-        lim_state++; //just go to 6.
-        /*
-    Chg_Phase=ChargePhase::EnergyTransfer;
-    CONT_Ctrl=0x2; //dc contactor to close mode
-    FC_Cur=0;//ccs current request from web ui for now.
-  EOC_Time=0xFE;//end of charge timer
-  CHG_Status=ChargeStatus::Rdy;
- // CHG_Status=ChargeStatus::Rdy; //test here
-  CHG_Req=ChargeRequest::Charge;
-  CHG_Ready=ChargeReady::Rdy;
-  CHG_Pwr=44000/25;//49kw approx power
-  CCSI_Spnt=0;//No current
+             //precharge phase in this state but voltage close enough to close contactors
+            Chg_Phase = ChargePhase::Subpoena;
+            CONT_Ctrl = 0x2;                   //dc contactor closed
+            FC_Cur = 0;                        //ccs current request from web ui for now.
+                                               // EOC_Time=0x1E;//end of charge timer
+            CHG_Status = ChargeStatus::Init;
+            CHG_Req = ChargeRequest::Charge;
+            CHG_Ready = ChargeReady::Rdy;
+            CHG_Pwr = 44000 / 25; //49kw approx power
+            CCSI_Spnt = 0;        //No current
 
-        lim_stateCnt++;
-        if(lim_stateCnt>10) //wait 2 seconds
-        {
-           lim_state++; //next state after 2 secs
-           lim_stateCnt=0;
+            // Contactors closed for 4 seconds before proceeding
+            if (lim_stateCnt > 10)
+            {
+                lim_state++; //next state after 4 secs
+                lim_stateCnt = 0;
+            }
         }
-*/
-    }
         break;
 
-      case 6:
+        case 6:
         {
     Chg_Phase=ChargePhase::EnergyTransfer;
     CONT_Ctrl=0x2; //dc contactor to close mode


### PR DESCRIPTION
During the ChargePhase::Subpoena (pre-charge) we wait
for the contactor voltage to get within an acceptable range.
Once this happens the contactors are requested to close.
We should give time for the contactors to close before
moving to the ChargePhase::EnergyTransfer.

There is a possibility during lim_state 4 that the contactor
voltage drifts outside the acceptable range before we close
the contactors. If this happens reset the timer until it comes
back inside the range.