### PR TITLE
i3LIM:Proceed to Energy Transfer when contactors report closed

### DIFF
--- a/include/param_prj.h
+++ b/include/param_prj.h
@@ -129,6 +129,7 @@
     VALUE_ENTRY(CCS_COND,      CCS_STATUS,  2211 ) \
     VALUE_ENTRY(CCS_State,      "s",  2213 ) \
     VALUE_ENTRY(CP_DOOR,   dmodes,   2212 ) \
+    VALUE_ENTRY(CCS_Contactor,   ONOFF,   2214 ) \
     VALUE_ENTRY(cpuload,      "%",     2035 ) \
 
 //Next value Id: 2080


### PR DESCRIPTION
Report the CCS contactor state as a read-only parameter.
Use the change in CCS contactor state to advance out of
Subpoena/pre-charge and into the EnergyTransfer phase
rather than wait for a fixed period of time.

This fixes a bug where the code would get stuck in lim_state
== 5 because lim_stateCnt was not being incremented so
the timer waiting for contactors to close never completed.

Tests:
 - Compile tested only