### PR TITLE
Adding RPM for VAG and 0x288 which turns off the traction control light

### DIFF
--- a/include/Can_VAG.h
+++ b/include/Can_VAG.h
@@ -14,6 +14,7 @@ class Can_VAG
 
 public:
     static void SendVAG100msMessage();
+    static void SendVAG10msMessage(int rpm);
 
 private:
 

--- a/src/Can_VAG.cpp
+++ b/src/Can_VAG.cpp
@@ -17,3 +17,18 @@ void Can_VAG::SendVAG100msMessage()
     seqCtr = (seqCtr + 1) & 0x3;
     ctr = (ctr + 1) & 0xF;
 }
+
+void Can_VAG::SendVAG10msMessage(int rpm)
+{
+   uint8_t byte3 = ((rpm * 4) >> 8) & 0xFF;
+   uint8_t byte4 = (rpm * 4) & 0xFF;
+   uint8_t canData[8] = { 0, 0, 0, byte3, byte4, 0, 0, 0 };
+   Can::GetInterface(1)->Send(0x280, (uint32_t*)canData, 8); //Send on CAN2
+
+   //contains temperature, traction control light was on without the message, content doesnt 
+   //seem to matter.
+   canData[3] = 0;
+   canData[4] = 0;
+   Can::GetInterface(1)->Send(0x288, (uint32_t*)canData, 8); //Send on CAN2
+
+}

--- a/src/stm32_vcu.cpp
+++ b/src/stm32_vcu.cpp
@@ -281,6 +281,10 @@ static void Ms10Task(void)
         BMW_E65Class::absdsc(Param::Get(Param::din_brake));
         if(E65Vehicle.getTerminal15())
             BMW_E65Class::Tacho(Param::GetInt(Param::speed));//only send tach message if we are starting
+    } 
+    else if (targetVehicle == VAG)
+    {
+        Can_VAG::SendVAG10msMessage(Param::GetInt(Param::speed));
     }
 
     //////////////////////////////////////////////////


### PR DESCRIPTION
Content of 0x288 doesn't seem to matter for the traction/ESP control light just requires the ID to be present.