### PR TITLE
CableTest: Don't wait for voltage go to 0V but to <50V

### DIFF
--- a/src/i3LIM.cpp
+++ b/src/i3LIM.cpp
@@ -71,6 +71,7 @@ static ChargeRequest CHG_Req=ChargeRequest::EndCharge;  //observed values 0 when
 static ChargeReady CHG_Ready=ChargeReady::NotRdy;  //indicator to the LIM that we are ready to charge. observed values 0 when not charging , 1 when commanded to charge. only 2 bits used.
 static uint8_t CONT_Ctrl=0;  //4 bits with DC ccs contactor command.
 static uint8_t CCSI_Spnt=0;
+static uint8_t LastSeenOpmode = 0xff;
 
 void i3LIMClass::handle3B4(uint32_t data[2])  //Lim data
 
@@ -286,11 +287,16 @@ void i3LIMClass::Send200msMessages(CanHardware* can)
 
 
 
+      uint8_t opmode = Param::GetInt(Param::opmode);
 //if(Param::GetInt(Param::opmode)==MOD_RUN) bytes[0] = 0xfb;//f1=no obd reset. fb=obd reset.
 //if(Param::GetInt(Param::opmode)!=MOD_RUN) bytes[0] = 0xf1;//f1=no obd reset. fb=obd reset.
       bytes[0] = 0xf1;
+      if (opmode == MOD_RUN && LastSeenOpmode != MOD_RUN)
+          bytes[0] = 0xfb;//f1=no obd reset. fb=obd reset.
       bytes[1] = 0xff;
       can->Send(0x3e8, (uint32_t*)bytes,2);
+
+      LastSeenOpmode = opmode;
 
       bytes[0] = 0xc0;//engine info? rex?
       bytes[1] = 0xf9;

--- a/src/i3LIM.cpp
+++ b/src/i3LIM.cpp
@@ -624,8 +624,8 @@ i3LIMChargingState i3LIMClass::Control_Charge(bool RunCh)
             CHG_Ready=ChargeReady::Rdy;
             CHG_Pwr=44000/25;//39kw approx power
             CCSI_Spnt=0;//No current
-            if(Cont_Volts<=50)lim_stateCnt++; //we wait for the contactor voltage to drop under 50v to indicate end of cable test
-            if(lim_stateCnt>20)
+            /*if(Cont_Volts<=50)*/lim_stateCnt++; //we wait for the contactor voltage to drop under 50v to indicate end of cable test
+            if(lim_stateCnt>10)
             {
                if(CCS_Iso==0x1) lim_state++; //next state after 2 secs if we have valid iso test
                lim_stateCnt=0;

--- a/src/i3LIM.cpp
+++ b/src/i3LIM.cpp
@@ -700,7 +700,7 @@ i3LIMChargingState i3LIMClass::Control_Charge(bool RunCh)
             CHG_Pwr=44000/25;//49kw approx power
             //we chill out here charging.
 
-            if((!RunCh)||CCS_IntStat==0x02)//if we have a request to terminate from the web ui or the evse then move to next state.
+            if((!RunCh)||CCS_IntStat==0x02||CCS_IntStat==0x0f)//if we have a request to terminate from the web ui or the evse then move to next state.
             {
                FC_Cur=0;//set current to 0
                lim_state++; //move to state 7 (shutdown)

--- a/src/i3LIM.cpp
+++ b/src/i3LIM.cpp
@@ -407,6 +407,10 @@ void i3LIMClass::Send100msMessages(CanHardware* can)
 
    uint16_t Wh_Local=Param::GetInt(Param::BattCap);
    CHG_Pwr=(CHG_Pwr & 0xFFF);
+   // one more check that we never ever request more A than available
+   FC_Cur = std::min<int16_t>(FC_Cur, Param::GetInt(Param::CCS_I_Avail));
+   FC_Cur = std::min<int16_t>(FC_Cur, Param::GetInt(Param::CCS_ILim));
+
    bytes[0] = Wh_Local & 0xFF;  //Battery Wh lowbyte
    bytes[1] = Wh_Local >> 8;  //BAttery Wh high byte
    bytes[2] = (((uint8_t)CHG_Status<<4)|((uint8_t)CHG_Req));  //charge status in bits 4-7.goes to 1 then 2.8 secs later to 2. Plug locking???. Charge request in lower nibble. 1 when charging. 0 when not charging.

--- a/src/i3LIM.cpp
+++ b/src/i3LIM.cpp
@@ -809,6 +809,10 @@ void i3LIMClass::CCS_Pwr_Con()    //here we control ccs charging during state 6.
    if(CCS_Ilim==0x1)CCSI_Spnt--;//decrement if current limit flag is set
    if(CCS_Plim==0x1)CCSI_Spnt--;//decrement if Power limit flag is set
 
+   // force once more that we stay within our maximum bounds
+   if(CCSI_Spnt>=Tmp_ICCS_Avail)CCSI_Spnt=Tmp_ICCS_Avail; //never exceed available current
+   if(CCSI_Spnt>Tmp_ICCS_Lim)CCSI_Spnt=Tmp_ICCS_Lim; //clamp setpoint to current lim paramater.
+
    Param::SetInt(Param::CCS_Ireq,CCSI_Spnt);
 }
 


### PR DESCRIPTION
And then wait it to be like that for two seconds. Switch to next state then.

Efacec charger was continuing to the next state when we were still waiting for the cable test voltage to drop to 0V.