### PR TITLE
Added Deadzone for the throttle

### DIFF
--- a/include/param_prj.h
+++ b/include/param_prj.h
@@ -1,7 +1,8 @@
 /*
- * This file is part of the tumanako_vc project.
+ * This file is part of the ZombieVerter project.
  *
- * Copyright (C) 2011 Johannes Huebner <dev@johanneshuebner.com>
+ * Copyright (C) 2011-2019 Johannes Huebner <dev@johanneshuebner.com>
+ * Copyright (C) 2019-2022 Damien Maguire <info@evbmw.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#define VER 1.03.A
+#define VER 1.04.A
 
 
 /* Entries must be ordered as follows:
@@ -24,7 +25,7 @@
    2. Temporary parameters (id = 0)
    3. Display values
  */
-//Next param id (increase when adding new parameter!): 76
+//Next param id (increase when adding new parameter!): 77
 /*              category     name         unit       min     max     default id */
 #define PARAM_LIST \
     PARAM_ENTRY(CAT_SETUP,     Inverter,     INVMODES, 0,      6,      0,      5  ) \
@@ -38,26 +39,27 @@
     PARAM_ENTRY(CAT_THROTTLE,  potmax,      "dig",     0,      4095,   4095,   8  ) \
     PARAM_ENTRY(CAT_THROTTLE,  pot2min,     "dig",     0,      4095,   4095,   9  ) \
     PARAM_ENTRY(CAT_THROTTLE,  pot2max,     "dig",     0,      4095,   4095,   10 ) \
-    PARAM_ENTRY(CAT_THROTTLE,  regentravel, "%",       0,      100,    30,     60  ) \
-    PARAM_ENTRY(CAT_THROTTLE,  regenmax,    "%",       -100,   0,     -30,     61  ) \
-    PARAM_ENTRY(CAT_THROTTLE,  regenramp,   "%/10ms",  0.1,    100,    100,    68  ) \
+    PARAM_ENTRY(CAT_THROTTLE,  regentravel, "%",       0,      100,    30,     60 ) \
+    PARAM_ENTRY(CAT_THROTTLE,  regenmax,    "%",       -100,   0,     -30,     61 ) \
+    PARAM_ENTRY(CAT_THROTTLE,  regenramp,   "%/10ms",  0.1,    100,    100,    68 ) \
     PARAM_ENTRY(CAT_THROTTLE,  potmode,     POTMODES,  0,      1,      0,      11 ) \
     PARAM_ENTRY(CAT_THROTTLE,  dirmode,     DIRMODES,  0,      4,      1,      12 ) \
     PARAM_ENTRY(CAT_THROTTLE,  throtramp,   "%/10ms",  0.1,    100,    100,    13 ) \
     PARAM_ENTRY(CAT_THROTTLE,  throtramprpm,"rpm",     0,      20000,  20000,  14 ) \
-    PARAM_ENTRY(CAT_THROTTLE,  revlim,      "rpm",      0,     20000,   6000,  15 ) \
+    PARAM_ENTRY(CAT_THROTTLE,  revlim,      "rpm",     0,      20000,  6000,   15 ) \
     PARAM_ENTRY(CAT_THROTTLE,  bmslimhigh,  "%",       0,      100,    50,     17 ) \
-    PARAM_ENTRY(CAT_THROTTLE,  bmslimlow,   "%",       -100,   0,      -1,     18 ) \
+    PARAM_ENTRY(CAT_THROTTLE,  bmslimlow,   "%",      -100,    0,     -1,      18 ) \
     PARAM_ENTRY(CAT_THROTTLE,  udcmin,      "V",       0,      1000,   450,    19 ) \
     PARAM_ENTRY(CAT_THROTTLE,  udclim,      "V",       0,      1000,   520,    20 ) \
     PARAM_ENTRY(CAT_THROTTLE,  idcmax,      "A",       0,      5000,   5000,   21 ) \
-    PARAM_ENTRY(CAT_THROTTLE,  idcmin,      "A",       -5000,  0,     -5000,   22 ) \
-    PARAM_ENTRY(CAT_THROTTLE,  tmphsmax,    "°C",      50,     150,   85,      23 ) \
-    PARAM_ENTRY(CAT_THROTTLE,  tmpmmax,     "°C",      70,     300,   300,     24 ) \
-    PARAM_ENTRY(CAT_THROTTLE,  throtmax,    "%",       0,      100,   100,     25 ) \
-    PARAM_ENTRY(CAT_THROTTLE,  throtmin,    "%",       -100,   0,     -100,    26 ) \
+    PARAM_ENTRY(CAT_THROTTLE,  idcmin,      "A",      -5000,   0,     -5000,   22 ) \
+    PARAM_ENTRY(CAT_THROTTLE,  tmphsmax,    "°C",      50,     150,    85,     23 ) \
+    PARAM_ENTRY(CAT_THROTTLE,  tmpmmax,     "°C",      70,     300,    300,    24 ) \
+    PARAM_ENTRY(CAT_THROTTLE,  throtmax,    "%",       0,      100,    100,    25 ) \
+    PARAM_ENTRY(CAT_THROTTLE,  throtmin,    "%",      -100,    0,     -100,    26 ) \
+    PARAM_ENTRY(CAT_THROTTLE,  throtdead,   "%",       0,      50,     10,     76 ) \
     PARAM_ENTRY(CAT_LEXUS,     GEAR,        LOWHIGH,   0,      2,      0,      27 ) \
-    PARAM_ENTRY(CAT_LEXUS,     OilPump,     "%",       0,      100,      50,   28 ) \
+    PARAM_ENTRY(CAT_LEXUS,     OilPump,     "%",       0,      100,    50,     28 ) \
     PARAM_ENTRY(CAT_CRUISE,    cruisestep,  "rpm",     1,      1000,   200,    29 ) \
     PARAM_ENTRY(CAT_CRUISE,    cruiseramp,  "rpm/100ms",1,     1000,   20,     30 ) \
     PARAM_ENTRY(CAT_CRUISE,    regenlevel,  "",        0,      3,      2,      31 ) \
@@ -72,24 +74,24 @@
     PARAM_ENTRY(CAT_CHARGER,   Voltspnt,    "V",       0,      1000,   395,    40 ) \
     PARAM_ENTRY(CAT_CHARGER,   Pwrspnt,     "W",       0,      12000,  1500,   41 ) \
     PARAM_ENTRY(CAT_CHARGER,   IdcTerm,     "A",       0,      150,    0,      56 ) \
-    PARAM_ENTRY(CAT_CHARGER,   CCS_ICmd,    "A",       0,      150,    0,      42  ) \
-    PARAM_ENTRY(CAT_CHARGER,   CCS_ILim,    "A",       0,      350,    100,    43  ) \
-    PARAM_ENTRY(CAT_CHARGER,   CCS_SOCLim,  "%",       0,      100,    80,     44  ) \
-    PARAM_ENTRY(CAT_CHARGER,   Chgctrl,     CHGCTRL,   0,      2,      0,      45  ) \
-    PARAM_ENTRY(CAT_Heater,    Heater,      HTTYPE,    0,      2,      0,      57  ) \
-    PARAM_ENTRY(CAT_Heater,    Control,     HTCTRL,    0,      2,      0,      58  ) \
-    PARAM_ENTRY(CAT_Heater,    HeatPwr,     "W",       0,      6500,   0,      59  ) \
-    PARAM_ENTRY(CAT_CLOCK,     Set_Day,     DOW,       0,      6,      0,      46  ) \
-    PARAM_ENTRY(CAT_CLOCK,     Set_Hour,    "Hours",   0,      23,     0,      47  ) \
-    PARAM_ENTRY(CAT_CLOCK,     Set_Min,     "Mins",    0,      59,     0,      48  ) \
-    PARAM_ENTRY(CAT_CLOCK,     Set_Sec,     "Secs",    0,      59,     0,      49  ) \
-    PARAM_ENTRY(CAT_CLOCK,     Chg_Hrs,     "Hours",   0,      23,     0,      50  ) \
-    PARAM_ENTRY(CAT_CLOCK,     Chg_Min,     "Mins",    0,      59,     0,      51  ) \
-    PARAM_ENTRY(CAT_CLOCK,     Chg_Dur,     "Mins",    0,      300,    0,      52  ) \
-    PARAM_ENTRY(CAT_CLOCK,     Pre_Hrs,     "Hours",   0,      59,     0,      53  ) \
-    PARAM_ENTRY(CAT_CLOCK,     Pre_Min,     "Mins",    0,      59,     0,      54  ) \
-    PARAM_ENTRY(CAT_CLOCK,     Pre_Dur,     "Mins",    0,      60,     0,      55  ) \
-    PARAM_ENTRY(CAT_SHUNT,     ISA_INIT,     ONOFF,    0,      1,     0,       75  ) \
+    PARAM_ENTRY(CAT_CHARGER,   CCS_ICmd,    "A",       0,      150,    0,      42 ) \
+    PARAM_ENTRY(CAT_CHARGER,   CCS_ILim,    "A",       0,      350,    100,    43 ) \
+    PARAM_ENTRY(CAT_CHARGER,   CCS_SOCLim,  "%",       0,      100,    80,     44 ) \
+    PARAM_ENTRY(CAT_CHARGER,   Chgctrl,     CHGCTRL,   0,      2,      0,      45 ) \
+    PARAM_ENTRY(CAT_Heater,    Heater,      HTTYPE,    0,      2,      0,      57 ) \
+    PARAM_ENTRY(CAT_Heater,    Control,     HTCTRL,    0,      2,      0,      58 ) \
+    PARAM_ENTRY(CAT_Heater,    HeatPwr,     "W",       0,      6500,   0,      59 ) \
+    PARAM_ENTRY(CAT_CLOCK,     Set_Day,     DOW,       0,      6,      0,      46 ) \
+    PARAM_ENTRY(CAT_CLOCK,     Set_Hour,    "Hours",   0,      23,     0,      47 ) \
+    PARAM_ENTRY(CAT_CLOCK,     Set_Min,     "Mins",    0,      59,     0,      48 ) \
+    PARAM_ENTRY(CAT_CLOCK,     Set_Sec,     "Secs",    0,      59,     0,      49 ) \
+    PARAM_ENTRY(CAT_CLOCK,     Chg_Hrs,     "Hours",   0,      23,     0,      50 ) \
+    PARAM_ENTRY(CAT_CLOCK,     Chg_Min,     "Mins",    0,      59,     0,      51 ) \
+    PARAM_ENTRY(CAT_CLOCK,     Chg_Dur,     "Mins",    0,      300,    0,      52 ) \
+    PARAM_ENTRY(CAT_CLOCK,     Pre_Hrs,     "Hours",   0,      59,     0,      53 ) \
+    PARAM_ENTRY(CAT_CLOCK,     Pre_Min,     "Mins",    0,      59,     0,      54 ) \
+    PARAM_ENTRY(CAT_CLOCK,     Pre_Dur,     "Mins",    0,      60,     0,      55 ) \
+    PARAM_ENTRY(CAT_SHUNT,     ISA_INIT,     ONOFF,    0,      1,      0,      75 ) \
     VALUE_ENTRY(version,       VERSTR,  2000 ) \
     VALUE_ENTRY(opmode,        OPMODES, 2002 ) \
     VALUE_ENTRY(chgtyp,        CHGTYPS, 2003 ) \

--- a/include/throttle.h
+++ b/include/throttle.h
@@ -44,6 +44,7 @@ public:
     static float brkcruise;
     static float throtmax;
     static float throtmin;
+    static float throtdead;
     static int idleSpeed;
     static int cruiseSpeed;
     static float speedkp;

--- a/src/stm32_vcu.cpp
+++ b/src/stm32_vcu.cpp
@@ -723,6 +723,7 @@ void Param::Change(Param::PARAM_NUM paramNum)
    Throttle::regenmax = Param::GetFloat(Param::regenmax);
    Throttle::throtmax = Param::GetFloat(Param::throtmax);
    Throttle::throtmin = Param::GetFloat(Param::throtmin);
+   Throttle::throtdead = Param::GetFloat(Param::throtdead);
    Throttle::idcmin = Param::GetFloat(Param::idcmin);
    Throttle::idcmax = Param::GetFloat(Param::idcmax);
    Throttle::udcmin = FP_MUL(Param::Get(Param::udcmin), FP_FROMFLT(0.95)); //Leave some room for the notification light

--- a/src/throttle.cpp
+++ b/src/throttle.cpp
@@ -37,6 +37,7 @@ float Throttle::idleThrotLim;
 float Throttle::potnomFiltered;
 float Throttle::throtmax;
 float Throttle::throtmin;
+float Throttle::throtdead;
 float Throttle::regenRamp;
 float Throttle::throttleRamp;
 //float Throttle::throttleRamped;
@@ -127,9 +128,15 @@ float Throttle::CalcThrottle(int potval, int potIdx, bool brkpedal)
    }
    
    // substract offset, bring potval to the potmin-potmax scale and make a percentage
-   //potnom = 100.0f * ((float)(potval - potmin[potIdx]) / (float)(potmax[potIdx] - potmin[potIdx]));
-   
    potnom = NormalizeThrottle(potval, potIdx);
+   
+   // Apply the deadzone parameter. To avoid that we lose the range between
+   // 0 and throtdead, the scale of potnom is mapped from the [0.0, 100.0] scale
+   // to the [throtdead, 100.0] scale.
+   if(potnom < throtdead)
+      potnom = 0.0f;
+   else
+      potnom = (potnom - throtdead) * (100.0f / (100.0f - throtdead));
    
    return potnom;
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -135,7 +135,6 @@ float GetUserThrottleCommand()
       else // !inRange1 && !inRange2
       {
          utils::PostErrorIfRunning(ERR_THROTTLE12);
-         Param::SetInt(Param::potnom, 0);
 
          return 0.0;
       }


### PR DESCRIPTION
Bumped version number, added throtdead parameter for a deadzone of the throttle input. This avoids torque creeping at idle.

Some cleaning of the indentation and changed the copyright notice in the parameter file (this is just the beginning.)