### PR TITLE
Added a final range check for finalSpnt

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -319,7 +319,13 @@ float ProcessThrottle(int speed)
    {
       ErrorMessage::Post(ERR_TMPMMAX);
    }
-
+   
+   // make sure the torque percentage is NEVER out of range
+   if (finalSpnt < -100.0f)
+      finalSpnt = -100.0f;
+   else if (finalSpnt > 100.0f)
+      finalSpnt = 100.0f;
+   
    Param::SetFloat(Param::potnom, finalSpnt);
 
    return finalSpnt;


### PR DESCRIPTION
No matter what the previous functions are doing, it should never lead to a torque request outside of the range [-100.0, 100.0]. This could lead to wrap arounds or "funny" behavior with the inverters.