### PR TITLE
Fix: Leaf inverter not going into run mode

### DIFF
--- a/include/anain_prj.h
+++ b/include/anain_prj.h
@@ -1,3 +1,22 @@
+/*
+ * This file is part of the ZombieVerter project.
+ *
+ * Copyright (C) 2019-2022 Damien Maguire <info@evbmw.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #ifndef ANAIN_PRJ_H_INCLUDED
 #define ANAIN_PRJ_H_INCLUDED
 
@@ -7,7 +26,7 @@
 #define SAMPLE_TIME ADC_SMPR_SMP_7DOT5CYC
 
 #define ANA_IN_LIST \
-    ANA_IN_ENTRY(throttle1, GPIOC, 0) \
+   ANA_IN_ENTRY(throttle1, GPIOC, 0) \
    ANA_IN_ENTRY(throttle2, GPIOC, 1) \
    ANA_IN_ENTRY(uaux,      GPIOB, 1) \
    ANA_IN_ENTRY(GP_analog1,GPIOC, 2) \

--- a/include/digio_prj.h
+++ b/include/digio_prj.h
@@ -1,42 +1,59 @@
+/*
+ * This file is part of the ZombieVerter project.
+ *
+ * Copyright (C) 2019-2022 Damien Maguire <info@evbmw.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #ifndef PinMode_PRJ_H_INCLUDED
 #define PinMode_PRJ_H_INCLUDED
 
 #include "hwdefs.h"
 
 #define DIG_IO_LIST \
-    DIG_IO_ENTRY(HV_req,       GPIOD, GPIO5,  PinMode::INPUT_FLT)   \
-    DIG_IO_ENTRY(start_in,    GPIOD, GPIO7,  PinMode::INPUT_FLT)   \
-    DIG_IO_ENTRY(brake_in,    GPIOA, GPIO15,  PinMode::INPUT_FLT)   \
-    DIG_IO_ENTRY(fwd_in,      GPIOB, GPIO4,  PinMode::INPUT_FLT)   \
-    DIG_IO_ENTRY(rev_in,      GPIOB, GPIO3,  PinMode::INPUT_FLT)   \
-    DIG_IO_ENTRY(dcsw_out,    GPIOC, GPIO7, PinMode::OUTPUT)      \
-    DIG_IO_ENTRY(led_out,     GPIOE, GPIO2, PinMode::OUTPUT)      \
-    DIG_IO_ENTRY(gp_out1,     GPIOD, GPIO15, PinMode::OUTPUT)      \
-    DIG_IO_ENTRY(gp_out2,     GPIOD, GPIO14, PinMode::OUTPUT)      \
-    DIG_IO_ENTRY(gp_out3,     GPIOD, GPIO13, PinMode::OUTPUT)      \
-    DIG_IO_ENTRY(sw_mode0,     GPIOD, GPIO9, PinMode::OUTPUT)      \
-    DIG_IO_ENTRY(sw_mode1,     GPIOD, GPIO8, PinMode::OUTPUT)      \
-    DIG_IO_ENTRY(lin_wake,     GPIOD, GPIO10, PinMode::OUTPUT)      \
-    DIG_IO_ENTRY(lin_nslp,     GPIOD, GPIO11, PinMode::OUTPUT)      \
-    DIG_IO_ENTRY(prec_out,     GPIOC, GPIO6,  PinMode::OUTPUT)      \
-    DIG_IO_ENTRY(inv_out,     GPIOA, GPIO8,  PinMode::OUTPUT)      \
-    DIG_IO_ENTRY(SL1_out,     GPIOC, GPIO9,  PinMode::OUTPUT)      \
-    DIG_IO_ENTRY(SL2_out,     GPIOC, GPIO8,  PinMode::OUTPUT)      \
-    DIG_IO_ENTRY(SP_out,     GPIOD, GPIO12,  PinMode::OUTPUT)      \
-    DIG_IO_ENTRY(gear1_in,   GPIOE, GPIO3,  PinMode::INPUT_FLT)   \
-    DIG_IO_ENTRY(gear2_in,   GPIOE, GPIO4,  PinMode::INPUT_FLT)   \
-    DIG_IO_ENTRY(gear3_in,   GPIOE, GPIO5,  PinMode::INPUT_FLT)   \
-    DIG_IO_ENTRY(req_out,     GPIOE, GPIO6,  PinMode::OUTPUT)      \
-    DIG_IO_ENTRY(pot1_cs,     GPIOD, GPIO3,  PinMode::OUTPUT)      \
-    DIG_IO_ENTRY(pot2_cs,     GPIOD, GPIO2,  PinMode::OUTPUT)      \
-    DIG_IO_ENTRY(mcp_cs,     GPIOB, GPIO12,  PinMode::OUTPUT)      \
-    DIG_IO_ENTRY(mcp_sby,     GPIOE, GPIO14,  PinMode::OUTPUT)      \
-    DIG_IO_ENTRY(PWM3,        GPIOB, GPIO0,  PinMode::OUTPUT)      \
-    DIG_IO_ENTRY(PWM2,        GPIOA, GPIO7,  PinMode::OUTPUT)      \
-    DIG_IO_ENTRY(PWM1,        GPIOA, GPIO6,  PinMode::OUTPUT)      \
-    DIG_IO_ENTRY(t15_digi,     GPIOD, GPIO6,  PinMode::INPUT_FLT)      \
-    DIG_IO_ENTRY(gp_12Vin,     GPIOD, GPIO4,  PinMode::INPUT_FLT)      \
-
-
+    DIG_IO_ENTRY(HV_req,    GPIOD, GPIO5,  PinMode::INPUT_FLT)   \
+    DIG_IO_ENTRY(start_in,  GPIOD, GPIO7,  PinMode::INPUT_FLT)   \
+    DIG_IO_ENTRY(brake_in,  GPIOA, GPIO15, PinMode::INPUT_FLT)   \
+    DIG_IO_ENTRY(fwd_in,    GPIOB, GPIO4,  PinMode::INPUT_FLT)   \
+    DIG_IO_ENTRY(rev_in,    GPIOB, GPIO3,  PinMode::INPUT_FLT)   \
+    DIG_IO_ENTRY(dcsw_out,  GPIOC, GPIO7,  PinMode::OUTPUT)      \
+    DIG_IO_ENTRY(led_out,   GPIOE, GPIO2,  PinMode::OUTPUT)      \
+    DIG_IO_ENTRY(gp_out1,   GPIOD, GPIO15, PinMode::OUTPUT)      \
+    DIG_IO_ENTRY(gp_out2,   GPIOD, GPIO14, PinMode::OUTPUT)      \
+    DIG_IO_ENTRY(gp_out3,   GPIOD, GPIO13, PinMode::OUTPUT)      \
+    DIG_IO_ENTRY(sw_mode0,  GPIOD, GPIO9,  PinMode::OUTPUT)      \
+    DIG_IO_ENTRY(sw_mode1,  GPIOD, GPIO8,  PinMode::OUTPUT)      \
+    DIG_IO_ENTRY(lin_wake,  GPIOD, GPIO10, PinMode::OUTPUT)      \
+    DIG_IO_ENTRY(lin_nslp,  GPIOD, GPIO11, PinMode::OUTPUT)      \
+    DIG_IO_ENTRY(prec_out,  GPIOC, GPIO6,  PinMode::OUTPUT)      \
+    DIG_IO_ENTRY(inv_out,   GPIOA, GPIO8,  PinMode::OUTPUT)      \
+    DIG_IO_ENTRY(SL1_out,   GPIOC, GPIO9,  PinMode::OUTPUT)      \
+    DIG_IO_ENTRY(SL2_out,   GPIOC, GPIO8,  PinMode::OUTPUT)      \
+    DIG_IO_ENTRY(SP_out,    GPIOD, GPIO12, PinMode::OUTPUT)      \
+    DIG_IO_ENTRY(gear1_in,  GPIOE, GPIO3,  PinMode::INPUT_FLT)   \
+    DIG_IO_ENTRY(gear2_in,  GPIOE, GPIO4,  PinMode::INPUT_FLT)   \
+    DIG_IO_ENTRY(gear3_in,  GPIOE, GPIO5,  PinMode::INPUT_FLT)   \
+    DIG_IO_ENTRY(req_out,   GPIOE, GPIO6,  PinMode::OUTPUT)      \
+    DIG_IO_ENTRY(pot1_cs,   GPIOD, GPIO3,  PinMode::OUTPUT)      \
+    DIG_IO_ENTRY(pot2_cs,   GPIOD, GPIO2,  PinMode::OUTPUT)      \
+    DIG_IO_ENTRY(mcp_cs,    GPIOB, GPIO12, PinMode::OUTPUT)      \
+    DIG_IO_ENTRY(mcp_sby,   GPIOE, GPIO14, PinMode::OUTPUT)      \
+    DIG_IO_ENTRY(PWM3,      GPIOB, GPIO0,  PinMode::OUTPUT)      \
+    DIG_IO_ENTRY(PWM2,      GPIOA, GPIO7,  PinMode::OUTPUT)      \
+    DIG_IO_ENTRY(PWM1,      GPIOA, GPIO6,  PinMode::OUTPUT)      \
+    DIG_IO_ENTRY(t15_digi,  GPIOD, GPIO6,  PinMode::INPUT_FLT)   \
+    DIG_IO_ENTRY(gp_12Vin,  GPIOD, GPIO4,  PinMode::INPUT_FLT)   \
 
 #endif // PinMode_PRJ_H_INCLUDED

--- a/include/hwdefs.h
+++ b/include/hwdefs.h
@@ -1,3 +1,22 @@
+/*
+ * This file is part of the ZombieVerter project.
+ *
+ * Copyright (C) 2019-2022 Damien Maguire <info@evbmw.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #ifndef HWDEFS_H_INCLUDED
 #define HWDEFS_H_INCLUDED
 

--- a/include/leafinv.h
+++ b/include/leafinv.h
@@ -1,8 +1,8 @@
 /*
- * This file is part of the tumanako_vc project.
+ * This file is part of the ZombieVeter project.
  *
  * Copyright (C) 2020 Johannes Huebner <dev@johanneshuebner.com>
- *                      Damien Maguire <info@evbmw.com>
+ *               2021-2022 Damien Maguire <info@evbmw.com>
  * Yes I'm really writing software now........run.....run away.......
  *
  * This program is free software: you can redistribute it and/or modify
@@ -20,6 +20,7 @@
  */
 #ifndef LEAFINV_H
 #define LEAFINV_H
+
 #include <stdint.h>
 #include "my_fp.h"
 #include "inverter.h"

--- a/include/outlanderinverter.h
+++ b/include/outlanderinverter.h
@@ -1,7 +1,8 @@
 /*
- * This file is part of the tumanako_vc project.
+ * This file is part of the ZombieVerter project.
  *
- * Copyright (C) 2018 Johannes Huebner <dev@johanneshuebner.com>
+ * Copyright (C) 2021-2022  Johannes Huebner <dev@johanneshuebner.com>
+ * 	                        Damien Maguire <info@evbmw.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,16 +16,15 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */#ifndef OUTLANDERINVERTER_H
+ */
+#ifndef OUTLANDERINVERTER_H
 #define OUTLANDERINVERTER_H
 
 #include <inverter.h>
 
-
 class OutlanderInverter : public Inverter
 {
 public:
-   /** Default constructor */
    OutlanderInverter();
    void DecodeCAN(int id, uint32_t data[2]);
    void Task10Ms();
@@ -37,8 +37,6 @@ public:
    int GetInverterState() { return error; }
 
 private:
-   static void nissan_crc(uint8_t *data, uint8_t polynomial);
-   static int8_t fahrenheit_to_celsius(uint16_t fahrenheit);
    uint8_t run10ms;
    uint32_t lastRecv;
    int16_t speed;
@@ -47,10 +45,6 @@ private:
    bool error;
    uint16_t voltage;
    uint32_t final_torque_request;
-
-   protected:
-
-   private:
 };
 
 #endif // OUTLANDERINVERTER_H

--- a/include/param_prj.h
+++ b/include/param_prj.h
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#define VER 1.07.A
+#define VER 1.08.A
 
 
 /* Entries must be ordered as follows:
@@ -92,85 +92,85 @@
     PARAM_ENTRY(CAT_CLOCK,     Pre_Min,     "Mins",    0,      59,     0,      54 ) \
     PARAM_ENTRY(CAT_CLOCK,     Pre_Dur,     "Mins",    0,      60,     0,      55 ) \
     PARAM_ENTRY(CAT_SHUNT,     ISA_INIT,     ONOFF,    0,      1,      0,      75 ) \
-    VALUE_ENTRY(version,       VERSTR,  2000 ) \
-    VALUE_ENTRY(opmode,        OPMODES, 2002 ) \
-    VALUE_ENTRY(chgtyp,        CHGTYPS, 2003 ) \
-    VALUE_ENTRY(lasterr,       errorListString,  2004 ) \
-    VALUE_ENTRY(status,        STATUS,  2005 ) \
-    VALUE_ENTRY(udc,           "V",     2006 ) \
-    VALUE_ENTRY(udc2,          "V",     2007 ) \
-    VALUE_ENTRY(udc3,          "V",     2008 ) \
-    VALUE_ENTRY(deltaV,        "V",     2009 ) \
-    VALUE_ENTRY(INVudc,        "V",     2010 ) \
-    VALUE_ENTRY(power,         "kW",    2011 ) \
-    VALUE_ENTRY(idc,           "A",     2012 ) \
-    VALUE_ENTRY(KWh,           "kwh",   2013 ) \
-    VALUE_ENTRY(AMPh,          "Ah",    2014 ) \
-    VALUE_ENTRY(SOC,           "%",     2015 ) \
-    VALUE_ENTRY(speed,         "rpm",   2016 ) \
-    VALUE_ENTRY(Veh_Speed,     "kph",   2017 ) \
-    VALUE_ENTRY(torque,        "dig",   2018 ) \
-    VALUE_ENTRY(pot,           "dig",   2019 ) \
-    VALUE_ENTRY(pot2,          "dig",   2020 ) \
-    VALUE_ENTRY(potbrake,      "dig",   2021 ) \
-    VALUE_ENTRY(brakepressure, "dig",   2022 ) \
-    VALUE_ENTRY(potnom,        "%",     2023 ) \
-    VALUE_ENTRY(dir,           DIRS,    2024 ) \
-    VALUE_ENTRY(inv,           INVMODES,2025 ) \
-    VALUE_ENTRY(veh,           VEHMODES,2026 ) \
-    VALUE_ENTRY(inv_can,       CAN_DEV, 2071) \
-    VALUE_ENTRY(veh_can,       CAN_DEV, 2072) \
-    VALUE_ENTRY(shunt_can,     CAN_DEV, 2073) \
-    VALUE_ENTRY(lim_can,       CAN_DEV, 2074) \
-    VALUE_ENTRY(charger_can,   CAN_DEV, 2075) \
-    VALUE_ENTRY(Charger,       CHGMODS, 2027 ) \
-    VALUE_ENTRY(tmphs,         "°C",    2028 ) \
-    VALUE_ENTRY(tmpm,          "°C",    2029 ) \
-    VALUE_ENTRY(tmpaux,        "°C",    2030 ) \
-    VALUE_ENTRY(uaux,          "V",     2031 ) \
-    VALUE_ENTRY(canio,         CANIOS,  2032 ) \
-    VALUE_ENTRY(cruisespeed,   "rpm",   2033 ) \
-    VALUE_ENTRY(cruisestt,     CRUISESTATES,2034 ) \
-    VALUE_ENTRY(din_cruise,    ONOFF,   2035 ) \
-    VALUE_ENTRY(din_start,     ONOFF,   2036 ) \
-    VALUE_ENTRY(din_brake,     ONOFF,   2037 ) \
-    VALUE_ENTRY(din_forward,   ONOFF,   2038 ) \
-    VALUE_ENTRY(din_reverse,   ONOFF,   2039 ) \
-    VALUE_ENTRY(din_bms,       ONOFF,   2040 ) \
-    VALUE_ENTRY(din_12Vgp,     ONOFF,   2071 ) \
-    VALUE_ENTRY(handbrk,       ONOFF,   2041 ) \
-    VALUE_ENTRY(Gear1,         ONOFF,   2042 ) \
-    VALUE_ENTRY(Gear2,         ONOFF,   2043 ) \
-    VALUE_ENTRY(Gear3,         ONOFF,   2044 ) \
-    VALUE_ENTRY(T15Stat,       ONOFF,   2045 ) \
-    VALUE_ENTRY(InvStat,       ONOFF,   2046 ) \
-    VALUE_ENTRY(GearFB,        LOWHIGH, 2047 ) \
-    VALUE_ENTRY(CableLim,      "A",     2048 ) \
-    VALUE_ENTRY(PilotLim,      "A",     2049 ) \
-    VALUE_ENTRY(PlugDet,       ONOFF,   2050 ) \
-    VALUE_ENTRY(PilotTyp,      PLTMODES,2051 ) \
-    VALUE_ENTRY(CCS_I_Avail,   "A",     2052 ) \
-    VALUE_ENTRY(CCS_V_Avail,   "V",     2053 ) \
-    VALUE_ENTRY(CCS_I,         "A",     2054 ) \
-    VALUE_ENTRY(CCS_Ireq,      "A",     2068 ) \
-    VALUE_ENTRY(CCS_V,         "V",     2055 ) \
-    VALUE_ENTRY(CCS_V_Min,     "V",     2056 ) \
-    VALUE_ENTRY(CCS_V_Con,     "V",     2057 ) \
-    VALUE_ENTRY(hvChg,         ONOFF,   2058 ) \
-    VALUE_ENTRY(CCS_COND,      CCS_STATUS,2059 ) \
-    VALUE_ENTRY(CCS_State,     "s",     2060 ) \
-    VALUE_ENTRY(CP_DOOR,       DMODES,  2061 ) \
-    VALUE_ENTRY(CCS_Contactor, ONOFF,   2062 ) \
-    VALUE_ENTRY(Day,           DOW,     2064 ) \
-    VALUE_ENTRY(Hour,          "H",     2065 ) \
-    VALUE_ENTRY(Min,           "M",     2066 ) \
-    VALUE_ENTRY(Sec,           "S",     2067 ) \
-    VALUE_ENTRY(ChgT,          "M",     2068 ) \
-    VALUE_ENTRY(HeatReq,       ONOFF,   2069 ) \
-    VALUE_ENTRY(Test,          ONOFF,   2070 ) \
-    VALUE_ENTRY(MG2Raw,          "dig",   2078 ) \
-    VALUE_ENTRY(MG1Raw,          "dig",   2079 ) \
-    VALUE_ENTRY(cpuload,       "%",     2063 ) \
+    VALUE_ENTRY(version,       VERSTR,              2000 ) \
+    VALUE_ENTRY(opmode,        OPMODES,             2002 ) \
+    VALUE_ENTRY(chgtyp,        CHGTYPS,             2003 ) \
+    VALUE_ENTRY(lasterr,       errorListString,     2004 ) \
+    VALUE_ENTRY(status,        STATUS,              2005 ) \
+    VALUE_ENTRY(udc,           "V",                 2006 ) \
+    VALUE_ENTRY(udc2,          "V",                 2007 ) \
+    VALUE_ENTRY(udc3,          "V",                 2008 ) \
+    VALUE_ENTRY(deltaV,        "V",                 2009 ) \
+    VALUE_ENTRY(INVudc,        "V",                 2010 ) \
+    VALUE_ENTRY(power,         "kW",                2011 ) \
+    VALUE_ENTRY(idc,           "A",                 2012 ) \
+    VALUE_ENTRY(KWh,           "kwh",               2013 ) \
+    VALUE_ENTRY(AMPh,          "Ah",                2014 ) \
+    VALUE_ENTRY(SOC,           "%",                 2015 ) \
+    VALUE_ENTRY(speed,         "rpm",               2016 ) \
+    VALUE_ENTRY(Veh_Speed,     "kph",               2017 ) \
+    VALUE_ENTRY(torque,        "dig",               2018 ) \
+    VALUE_ENTRY(pot,           "dig",               2019 ) \
+    VALUE_ENTRY(pot2,          "dig",               2020 ) \
+    VALUE_ENTRY(potbrake,      "dig",               2021 ) \
+    VALUE_ENTRY(brakepressure, "dig",               2022 ) \
+    VALUE_ENTRY(potnom,        "%",                 2023 ) \
+    VALUE_ENTRY(dir,           DIRS,                2024 ) \
+    VALUE_ENTRY(inv,           INVMODES,            2025 ) \
+    VALUE_ENTRY(veh,           VEHMODES,            2026 ) \
+    VALUE_ENTRY(inv_can,       CAN_DEV,             2071 ) \
+    VALUE_ENTRY(veh_can,       CAN_DEV,             2072 ) \
+    VALUE_ENTRY(shunt_can,     CAN_DEV,             2073 ) \
+    VALUE_ENTRY(lim_can,       CAN_DEV,             2074 ) \
+    VALUE_ENTRY(charger_can,   CAN_DEV,             2075 ) \
+    VALUE_ENTRY(Charger,       CHGMODS,             2027 ) \
+    VALUE_ENTRY(tmphs,         "°C",                2028 ) \
+    VALUE_ENTRY(tmpm,          "°C",                2029 ) \
+    VALUE_ENTRY(tmpaux,        "°C",                2030 ) \
+    VALUE_ENTRY(uaux,          "V",                 2031 ) \
+    VALUE_ENTRY(canio,         CANIOS,              2032 ) \
+    VALUE_ENTRY(cruisespeed,   "rpm",               2033 ) \
+    VALUE_ENTRY(cruisestt,     CRUISESTATES,        2034 ) \
+    VALUE_ENTRY(din_cruise,    ONOFF,               2035 ) \
+    VALUE_ENTRY(din_start,     ONOFF,               2036 ) \
+    VALUE_ENTRY(din_brake,     ONOFF,               2037 ) \
+    VALUE_ENTRY(din_forward,   ONOFF,               2038 ) \
+    VALUE_ENTRY(din_reverse,   ONOFF,               2039 ) \
+    VALUE_ENTRY(din_bms,       ONOFF,               2040 ) \
+    VALUE_ENTRY(din_12Vgp,     ONOFF,               2071 ) \
+    VALUE_ENTRY(handbrk,       ONOFF,               2041 ) \
+    VALUE_ENTRY(Gear1,         ONOFF,               2042 ) \
+    VALUE_ENTRY(Gear2,         ONOFF,               2043 ) \
+    VALUE_ENTRY(Gear3,         ONOFF,               2044 ) \
+    VALUE_ENTRY(T15Stat,       ONOFF,               2045 ) \
+    VALUE_ENTRY(InvStat,       ONOFF,               2046 ) \
+    VALUE_ENTRY(GearFB,        LOWHIGH,             2047 ) \
+    VALUE_ENTRY(CableLim,      "A",                 2048 ) \
+    VALUE_ENTRY(PilotLim,      "A",                 2049 ) \
+    VALUE_ENTRY(PlugDet,       ONOFF,               2050 ) \
+    VALUE_ENTRY(PilotTyp,      PLTMODES,            2051 ) \
+    VALUE_ENTRY(CCS_I_Avail,   "A",                 2052 ) \
+    VALUE_ENTRY(CCS_V_Avail,   "V",                 2053 ) \
+    VALUE_ENTRY(CCS_I,         "A",                 2054 ) \
+    VALUE_ENTRY(CCS_Ireq,      "A",                 2068 ) \
+    VALUE_ENTRY(CCS_V,         "V",                 2055 ) \
+    VALUE_ENTRY(CCS_V_Min,     "V",                 2056 ) \
+    VALUE_ENTRY(CCS_V_Con,     "V",                 2057 ) \
+    VALUE_ENTRY(hvChg,         ONOFF,               2058 ) \
+    VALUE_ENTRY(CCS_COND,      CCS_STATUS,          2059 ) \
+    VALUE_ENTRY(CCS_State,     "s",                 2060 ) \
+    VALUE_ENTRY(CP_DOOR,       DMODES,              2061 ) \
+    VALUE_ENTRY(CCS_Contactor, ONOFF,               2062 ) \
+    VALUE_ENTRY(Day,           DOW,                 2064 ) \
+    VALUE_ENTRY(Hour,          "H",                 2065 ) \
+    VALUE_ENTRY(Min,           "M",                 2066 ) \
+    VALUE_ENTRY(Sec,           "S",                 2067 ) \
+    VALUE_ENTRY(ChgT,          "M",                 2068 ) \
+    VALUE_ENTRY(HeatReq,       ONOFF,               2069 ) \
+    VALUE_ENTRY(Test,          ONOFF,               2070 ) \
+    VALUE_ENTRY(MG2Raw,        "dig",               2078 ) \
+    VALUE_ENTRY(MG1Raw,        "dig",               2079 ) \
+    VALUE_ENTRY(cpuload,       "%",                 2063 ) \
 
 
 //Next value Id: 2080

--- a/include/throttle.h
+++ b/include/throttle.h
@@ -1,7 +1,8 @@
 /*
- * This file is part of the tumanako_vc project.
+ * This file is part of the ZombieVerter project.
  *
- * Copyright (C) 2012 Johannes Huebner <contact@johanneshuebner.com>
+ * Copyright (C) 2012-2020 Johannes Huebner <dev@johanneshuebner.com> 
+ *               2021-2022 Damien Maguire <info@evbmw.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -66,7 +67,6 @@ private:
     static int speedFiltered;
     static float potnomFiltered;
     static float brkRamped;
-    static float throttleRamped;
 };
 
 #endif // THROTTLE_H

--- a/src/leafinv.cpp
+++ b/src/leafinv.cpp
@@ -1,7 +1,8 @@
 /*
- *
+ * This file is part of the ZombieVerter project.
+ * 
  * Copyright (C) 2020 Johannes Huebner <dev@johanneshuebner.com>
- *                      Damien Maguire <info@evbmw.com>
+ *               2021-2022 Damien Maguire <info@evbmw.com>
  * Yes I'm really writing software now........run.....run away.......
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/outlanderinverter.cpp
+++ b/src/outlanderinverter.cpp
@@ -1,7 +1,8 @@
 /*
- * This file is part of the stm32-vcu project.
+ * This file is part of the ZombieVerter project.
  *
- * Copyright (C) 2021 Johannes Huebner <dev@johanneshuebner.com>
+ * Copyright (C) 2021-2022  Johannes Huebner <dev@johanneshuebner.com>
+ * 	                        Damien Maguire <info@evbmw.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/throttle.cpp
+++ b/src/throttle.cpp
@@ -1,7 +1,8 @@
 /*
- * This file is part of the tumanako_vc project.
+ * This file is part of the ZombieVerter project.
  *
- * Copyright (C) 2012 Johannes Huebner <contact@johanneshuebner.com>
+ * Copyright (C) 2012-2020 Johannes Huebner <dev@johanneshuebner.com> 
+ *               2021-2022 Damien Maguire <info@evbmw.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -40,7 +41,6 @@ float Throttle::throtmin;
 float Throttle::throtdead;
 float Throttle::regenRamp;
 float Throttle::throttleRamp;
-//float Throttle::throttleRamped;
 int Throttle::bmslimhigh;
 int Throttle::bmslimlow;
 float Throttle::udcmin;


### PR DESCRIPTION
Fix: Added 10ms inverter task call to the main 10ms task, fixing the Leaf inverter. Removed doubled defines from stm32_vcu.cpp (present in param_prj.h). Removed double check if-else for VAG. Updated some comments and copyright notices and cleaned up some indentations. (No changes to the binary resulting from all changes except the aforementioned fix)