### PR TITLE
Leaf DC/DC fixes and cleanup

### DIFF
--- a/include/leafinv.h
+++ b/include/leafinv.h
@@ -42,8 +42,6 @@ public:
 private:
    static void nissan_crc(uint8_t *data, uint8_t polynomial);
    static int8_t fahrenheit_to_celsius(uint16_t fahrenheit);
-   uint8_t run10ms;
-   uint8_t run100ms;
    uint32_t lastRecv;
    int16_t speed;
    int16_t inv_temp;

--- a/include/param_prj.h
+++ b/include/param_prj.h
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#define VER 1.09.A
+#define VER 1.09.D
 
 
 /* Entries must be ordered as follows:

--- a/include/param_prj.h
+++ b/include/param_prj.h
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#define VER 1.08.A
+#define VER 1.09.A
 
 
 /* Entries must be ordered as follows:

--- a/src/leafinv.cpp
+++ b/src/leafinv.cpp
@@ -214,16 +214,13 @@ void LeafINV::Task10Ms()
    // 2016: 6E
    //outFrame.data.bytes[1] = 0x6E;
 
-   // Requested torque (signed 12-bit value + always 0x0 in low nibble)
-   if (opmode != MOD_RUN) final_torque_request=0;//override any torque commands if not in run mode.
-   static int16_t last_logged_final_torque_request = 0;
-
-   if(final_torque_request != last_logged_final_torque_request)
-   {
-      last_logged_final_torque_request = final_torque_request;
-
+   // override any torque commands if not in run mode.
+   if (opmode != MOD_RUN)
+   { 
+      final_torque_request = 0;
    }
 
+   // Requested torque (signed 12-bit value + always 0x0 in low nibble)
    if(final_torque_request >= -2048 && final_torque_request <= 2047)
    {
       bytes[2] = ((final_torque_request < 0) ? 0x80 : 0) |((final_torque_request >> 4) & 0x7f);

--- a/src/stm32_vcu.cpp
+++ b/src/stm32_vcu.cpp
@@ -317,7 +317,7 @@ static void Ms200Task(void)
 
 static void Ms100Task(void)
 {
-    DigIo::led_out.Toggle();
+   DigIo::led_out.Toggle();
    iwdg_reset();
    float cpuLoad = scheduler->GetCpuLoad() / 10.0f;
    Param::SetFloat(Param::cpuload, cpuLoad);
@@ -338,11 +338,16 @@ static void Ms100Task(void)
         DigIo::PWM2.Clear();
      }
 
-   if(targetChgint == ChargeInterfaces::Leaf_PDM) //Leaf Gen2 PDM charger/DCDC/Chademo
+   // Leaf Gen2 PDM Charger/DCDC/Chademo
+   if(targetChgint == ChargeInterfaces::Leaf_PDM && 
+      targetInverter != InvModes::Leaf_Gen1) 
    {
-      if (opmode == MOD_CHARGE)
+      // If the Leaf PDM is in the system, always send the appropriate CAN
+      //  messages to make it happy, EXCEPT if we already sent the messages
+      //  (when Leaf Inverter is present).
+      if (opmode == MOD_RUN || opmode == MOD_CHARGE)
       {
-         leafInv.Task100Ms(); //send leaf 100ms msgs if we are using the pdm and in charge mode
+         leafInv.Task100Ms();
       }
    }
 
@@ -448,11 +453,18 @@ static void Ms10Task(void)
 
    ErrorMessage::SetTime(rtc_get_counter_val());
 
-   if(targetChgint == ChargeInterfaces::Leaf_PDM) //Leaf Gen2 PDM charger/DCDC/Chademo
+   // Leaf Gen2 PDM Charger/DCDC/Chademo
+   if(targetChgint == ChargeInterfaces::Leaf_PDM && 
+      targetInverter != InvModes::Leaf_Gen1) 
    {
-      if (opmode == MOD_CHARGE)
+      // If the Leaf PDM is in the system, always send the appropriate CAN
+      //  messages to make it happy, EXCEPT if we already sent the messages
+      //  (when Leaf Inverter is present).
+      if (opmode == MOD_RUN || opmode == MOD_CHARGE)
       {
-         leafInv.Task10Ms();//send leaf 10ms msgs if we are using the pdm and in charge mode
+         // don't send any torque (well.. there's no Leaf inverter)
+         leafInv.SetTorque(0);
+         leafInv.Task10Ms();
       }
    }
 


### PR DESCRIPTION
Increased Version number to 1.09.D

Changed the stm32_vcu.cpp such that the Leaf tasks are called in RUN mode as well when the Leaf PDM is configured as charger to keep the DC/DC converter running but avoiding a double call if the Leaf inverter AND PDM are used.