### PR TITLE
Modular BMS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ OBJSL		= $(BINARY).o hwinit.o stm32scheduler.o params.o terminal.o terminal_prj.
            Can_E39.o Can_VAG.o Can_OI.o MCP2515.o CANSPI.o outlanderinverter.o canhardware.o canmap.o \
            param_save.o errormessage.o stm32_can.o leafinv.o utils.o terminalcommands.o i3LIM.o \
            chademo.o amperaheater.o amperacharger.o subaruvehicle.o iomatrix.o bmw_sbox.o NissanPDM.o teslaCharger.o extCharger.o vag_sbox.o \
+           daisychainbms.o simpbms.o
            
            
 OBJS     = $(patsubst %.o,$(OUT_DIR)/%.o, $(OBJSL))
@@ -78,7 +79,7 @@ ${OUT_DIR}:
 
 $(BINARY): $(OBJS) $(LDSCRIPT)
 	@printf "  LD      $(subst $(shell pwd)/,,$(@))\n"
-	$(Q)$(LD) $(LDFLAGS) -o $(BINARY) $(OBJS) -lopencm3_stm32f1
+	$(Q)$(LD) $(LDFLAGS) -o $(BINARY) $(OBJS) -lopencm3_stm32f1 -lm
 
 $(OUT_DIR)/%.o: %.c Makefile
 	@printf "  CC      $(subst $(shell pwd)/,,$(@))\n"

--- a/include/bms.h
+++ b/include/bms.h
@@ -39,7 +39,13 @@ class BMS
       virtual void DecodeCAN(int, uint8_t *) {};
       virtual void DeInit() {};
       virtual float MaxChargeCurrent() { return 9999.0; };
-      virtual void Task100Ms() {};
+      virtual void Task100Ms() {
+            Param::SetInt(Param::BMS_ChargeLim, MaxChargeCurrent());
+            Param::SetFloat(Param::BMS_Vmin, 0);
+            Param::SetFloat(Param::BMS_Vmax, 0);
+            Param::SetFloat(Param::BMS_Tmin, 0);
+            Param::SetFloat(Param::BMS_Tmax, 0);
+      };
       virtual void SetCanInterface(CanHardware* c) { can = c; }
    protected:
       CanHardware* can;

--- a/include/bms.h
+++ b/include/bms.h
@@ -1,0 +1,47 @@
+/*
+ * This file is part of the ZombieVerter project.
+ *
+ * Copyright (C) 2022 Charlie Smurthwaite
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef BMS_H
+#define BMS_H
+#include <stdint.h>
+
+/* This is an interface for a BMS to provide minimal data required
+ * for safe battery charging.  The BMS must be able to provide the
+ * following data:
+ *   1. Maximum and minimum cell voltages
+ *   2. Maximum and minimum cell or module temperatures
+ * Each BMS module must log the above data as well as provide a
+ * function to return whether charging is permitted and the maximum
+ * charge current.
+ * The function Task100Ms() will be called every 100ms and should
+ * be used to implement a timeout for receiving fata from the BMS.
+ */
+
+class BMS
+{
+   public:
+      virtual void DecodeCAN(int, uint8_t *) {};
+      virtual void DeInit() {};
+      virtual float MaxChargeCurrent() { return 9999.0; };
+      virtual void Task100Ms() {};
+      virtual void SetCanInterface(CanHardware* c) { can = c; }
+   protected:
+      CanHardware* can;
+};
+#endif // BMS_H

--- a/include/daisychainbms.h
+++ b/include/daisychainbms.h
@@ -1,0 +1,45 @@
+/*
+ * This file is part of the ZombieVerter project.
+ *
+ * Copyright (C) 2022 Charlie Smurthwaite
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef DAISYCHAINBMS_H
+#define DAISYCHAINBMS_H
+#include <stdint.h>
+
+class DaisychainBMS: public BMS
+{
+   public:
+      virtual void SetCanInterface(CanHardware* c);
+      void DecodeCAN(int id, uint8_t * data);
+      float MaxChargeCurrent();
+      void Task100Ms();
+   private:
+      bool BMSDataValid();
+      bool ChargeAllowed();
+      float temperature(uint16_t adc);
+      int timeoutCounter[2];
+      uint16_t minCell[2] = {0, 0};
+      uint16_t maxCell[2] = {0, 0};
+      uint16_t minTemp[2] = {0, 0};
+      uint16_t maxTemp[2] = {0, 0};
+      float minCellV = 0;
+      float maxCellV = 0;
+      float minTempC = 0;
+      float maxTempC = 0;
+};
+#endif // DAISYCHAINBMS_H

--- a/include/param_prj.h
+++ b/include/param_prj.h
@@ -25,7 +25,7 @@
    2. Temporary parameters (id = 0)
    3. Display values
  */
-//Next param id (increase when adding new parameter!): 89
+//Next param id (increase when adding new parameter!): 96
 /*              category     name         unit       min     max     default id */
 #define PARAM_LIST \
     PARAM_ENTRY(CAT_SETUP,     Inverter,     INVMODES, 0,      6,      0,      5  ) \
@@ -36,6 +36,7 @@
     PARAM_ENTRY(CAT_SETUP,     ShuntCan,     CAN_DEV,  0,      1,      0,      72 ) \
     PARAM_ENTRY(CAT_SETUP,     LimCan,       CAN_DEV,  0,      1,      0,      73 ) \
     PARAM_ENTRY(CAT_SETUP,     ChargerCan,   CAN_DEV,  0,      1,      1,      74 ) \
+    PARAM_ENTRY(CAT_SETUP,     BMSCan,       CAN_DEV,  0,      1,      1,      89 ) \
     PARAM_ENTRY(CAT_THROTTLE,  potmin,      "dig",     0,      4095,   0,      7  ) \
     PARAM_ENTRY(CAT_THROTTLE,  potmax,      "dig",     0,      4095,   4095,   8  ) \
     PARAM_ENTRY(CAT_THROTTLE,  pot2min,     "dig",     0,      4095,   4095,   9  ) \
@@ -79,6 +80,12 @@
     PARAM_ENTRY(CAT_CHARGER,   CCS_SOCLim,  "%",       0,      100,    80,     44 ) \
     PARAM_ENTRY(CAT_CHARGER,   SOCFC,       "%",       0,      100,    50,     79 ) \
     PARAM_ENTRY(CAT_CHARGER,   Chgctrl,     CHGCTRL,   0,      2,      0,      45 ) \
+    PARAM_ENTRY(CAT_BMS,       BMS_Mode,    BMSMODES,  0,      3,      0,      90 ) \
+    PARAM_ENTRY(CAT_BMS,       BMS_Timeout,  "sec",    1,      120,    10,     91 ) \
+    PARAM_ENTRY(CAT_BMS,       BMS_VminLimit, "V",     0,      10,     3.0,    92 ) \
+    PARAM_ENTRY(CAT_BMS,       BMS_VmaxLimit, "V",     0,      10,     4.2,    93 ) \
+    PARAM_ENTRY(CAT_BMS,       BMS_TminLimit, "°C",    -100,   100,    5,      94 ) \
+    PARAM_ENTRY(CAT_BMS,       BMS_TmaxLimit, "°C",    -100,   100,    50,     95 ) \
     PARAM_ENTRY(CAT_HEATER,    Heater,      HTTYPE,    0,      2,      0,      57 ) \
     PARAM_ENTRY(CAT_HEATER,    Control,     HTCTRL,    0,      2,      0,      58 ) \
     PARAM_ENTRY(CAT_HEATER,    HeatPwr,     "W",       0,      6500,   0,      59 ) \
@@ -117,6 +124,11 @@
     VALUE_ENTRY(KWh,           "kwh",               2013 ) \
     VALUE_ENTRY(AMPh,          "Ah",                2014 ) \
     VALUE_ENTRY(SOC,           "%",                 2015 ) \
+    VALUE_ENTRY(BMS_Vmin,      "V",                 2084 ) \
+    VALUE_ENTRY(BMS_Vmax,      "V",                 2085 ) \
+    VALUE_ENTRY(BMS_Tmin,      "°C",                2086 ) \
+    VALUE_ENTRY(BMS_Tmax,      "°C",                2087 ) \
+    VALUE_ENTRY(BMS_ChargeLim, "A",                 2088 ) \
     VALUE_ENTRY(speed,         "rpm",               2016 ) \
     VALUE_ENTRY(Veh_Speed,     "kph",               2017 ) \
     VALUE_ENTRY(torque,        "dig",               2018 ) \
@@ -177,7 +189,7 @@
     VALUE_ENTRY(cpuload,       "%",                 2063 ) \
 
 
-//Next value Id: 2084
+//Next value Id: 2089
 
 
 #define VERSTR STRINGIFY(4=VER)
@@ -191,6 +203,7 @@
 #define INVMODES     "0=Leaf_Gen1, 1=GS450H, 2=UserCAN, 3=OpenI, 4=Prius_Gen3, 5=Outlander, 6=GS300H"
 #define PLTMODES     "0=Absent, 1=ACStd, 2=ACchg, 3=Error, 4=CCS_Not_Rdy, 5=CCS_Rdy, 6=Static"
 #define VEHMODES     "0=BMW_E46, 1=BMW_E65, 2=Classic, 3=None, 5=BMW_E39, 6=VAG, 7=Subaru"
+#define BMSMODES     "0=Off, 1=SimpBMS, 2=TiDaisychainSingle, 3=TiDaisychainDual"
 #define OPMODES      "0=Off, 1=Run, 2=Precharge, 3=PchFail, 4=Charge"
 #define DOW          "0=Sun, 1=Mon, 2=Tue, 3=Wed, 4=Thu, 5=Fri, 6=Sat"
 #define CHGTYPS      "0=Off, 1=AC, 2=DCFC"
@@ -222,6 +235,7 @@
 #define CAT_SETUP    "General Setup"
 #define CAT_CLOCK    "RTC Module"
 #define CAT_HEATER   "Heater Module"
+#define CAT_BMS      "Battery Management"
 #define CAT_CRUISE   "Cruise Control"
 #define CAT_LEXUS    "Gearbox Control"
 #define CAT_CHARGER  "Charger Control"
@@ -298,6 +312,14 @@ enum HeatType
     Noheater = 0,
     AmpHeater = 1,
     VW = 2
+};
+
+enum BMSModes
+{
+    BMSModeNoBMS = 0,
+    BMSModeSimpBMS = 1,
+    BMSModeDaisychainSingleBMS = 2,
+    BMSModeDaisychainDualBMS = 3
 };
 
 enum ChargeControl

--- a/include/simpbms.h
+++ b/include/simpbms.h
@@ -1,0 +1,41 @@
+/*
+ * This file is part of the ZombieVerter project.
+ *
+ * Copyright (C) 2022 Charlie Smurthwaite
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef SIMPBMS_H
+#define SIMPBMS_H
+#include <stdint.h>
+
+class SimpBMS: public BMS
+{
+   public:
+      virtual void SetCanInterface(CanHardware* c);
+      void DecodeCAN(int id, uint8_t * data);
+      float MaxChargeCurrent();
+      void Task100Ms();
+   private:
+      bool BMSDataValid();
+      bool ChargeAllowed();
+      int chargeCurrentLimit = 0;
+      int timeoutCounter = 0;
+      float minCellV = 0;
+      float maxCellV = 0;
+      float minTempC = 0;
+      float maxTempC = 0;
+};
+#endif // SIMPBMS_H

--- a/include/stm32_vcu.h
+++ b/include/stm32_vcu.h
@@ -69,6 +69,9 @@
 #include "extCharger.h"
 #include "amperaCharger.h"
 #include "noHeater.h"
+#include "bms.h"
+#include "simpbms.h"
+#include "daisychainbms.h"
 
 #define PRECHARGE_TIMEOUT 5  //5s
 

--- a/src/daisychainbms.cpp
+++ b/src/daisychainbms.cpp
@@ -1,0 +1,140 @@
+/*
+ * This file is part of the ZombieVerter project.
+ *
+ * Copyright (C) 2022 Charlie Smurthwaite
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <math.h>
+#include "stm32_vcu.h"
+
+/*
+ * This module receives messages from catphish's DaisychainBMS and updates
+ * the BMS_MinV, BMS_MaxV, BMS_MinT and BMS_MaxT parameters with the received
+ * values. It also implements a timeout to indicate whether the BMS is actively
+ * sending data or not. This data can be used to safely stop any charging
+ * process if the BMS is not working correctly.
+ */
+
+void DaisychainBMS::SetCanInterface(CanHardware* c)
+{
+   can = c;
+   can->RegisterUserMessage(0x4f1); // Primary BMS
+   can->RegisterUserMessage(0x4f5); // Secondary BMS
+}
+
+bool DaisychainBMS::BMSDataValid() {
+   // Return false if primary BMS is not sending data.
+   if(timeoutCounter[0] < 1) return false;
+
+   // Return false if we're in dual BMS mode and second BMS is not sending data.
+   if(Param::GetInt(Param::BMS_Mode) == BMSModes::BMSModeDaisychainDualBMS)
+      if(timeoutCounter[1] < 1) return false;
+
+   return true;
+}
+
+// Return whether charging is currently permitted.
+bool DaisychainBMS::ChargeAllowed()
+{
+   if(!BMSDataValid()) return false;
+
+   // Refuse to charge if the voltage or temperature is out of range.
+   if(maxCellV > Param::GetFloat(Param::BMS_VmaxLimit)) return false;
+   if(minCellV < Param::GetFloat(Param::BMS_VminLimit)) return false;
+   if(maxTempC > Param::GetFloat(Param::BMS_TmaxLimit)) return false;
+   if(minTempC < Param::GetFloat(Param::BMS_TminLimit)) return false;
+
+   // Otherwise, charging is permitted.
+   return true;
+}
+
+// Calculate temperature from ADC value.
+float DaisychainBMS::temperature(uint16_t adc)
+{
+   float r = 0.0000000347363427499292f * adc * adc - 0.001025770762903f * adc + 2.68235340614337f;
+   float t = log(r) * -30.5280964239816f + 95.6841501312447f;
+   return t;
+}
+
+float DaisychainBMS::MaxChargeCurrent()
+{
+   if(!ChargeAllowed()) return 0;
+   return 9998.0;
+}
+
+// Process voltage and temperature message from TI Daisychain BMS.
+void DaisychainBMS::DecodeCAN(int id, uint8_t *data)
+{
+   int bms = -1;
+   if (id == 0x4f1) bms = 0;
+   if (id == 0x4f5) bms = 1;
+   if (bms == -1) return;
+
+   maxCell[bms] = data[1] | (data[0] << 8);
+   minCell[bms] = data[3] | (data[2] << 8);
+   maxTemp[bms] = data[5] | (data[4] << 8);
+   minTemp[bms] = data[7] | (data[6] << 8);
+   
+   timeoutCounter[bms] = Param::GetInt(Param::BMS_Timeout) * 10;
+
+   if(Param::GetInt(Param::BMS_Mode) == BMSModes::BMSModeDaisychainDualBMS)
+   {
+      // Dual BMS mode.
+      if(minCell[0] < minCell[1]) minCellV = minCell[0] / 13107.0;
+      else                        minCellV = minCell[1] / 13107.0;
+      
+      if(maxCell[0] > maxCell[1]) maxCellV = maxCell[0] / 13107.0;
+      else                        maxCellV = maxCell[1] / 13107.0;
+
+      if(minTemp[0] > minTemp[1]) minTempC = temperature(minTemp[0]);
+      else                        minTempC = temperature(minTemp[1]);
+
+      if(maxTemp[0] < maxTemp[1]) maxTempC = temperature(maxTemp[0]);
+      else                        maxTempC = temperature(maxTemp[1]);
+   }
+   else
+   {
+      // Single BMS mode.
+      minCellV = minCell[0] / 13107.0;
+      maxCellV = maxCell[0] / 13107.0;
+      minTempC = temperature(minTemp[0]);
+      maxTempC = temperature(maxTemp[0]);
+   }
+}
+
+void DaisychainBMS::Task100Ms()
+{
+   // Decrement timeout counters.
+   if(timeoutCounter[0] > 0) timeoutCounter[0]--;
+   if(timeoutCounter[1] > 0) timeoutCounter[1]--;
+
+   // Update informational parameters.
+   Param::SetInt(Param::BMS_ChargeLim, MaxChargeCurrent());
+
+   if(BMSDataValid()) {
+      Param::SetFloat(Param::BMS_Vmin, minCellV);
+      Param::SetFloat(Param::BMS_Vmax, maxCellV);
+      Param::SetFloat(Param::BMS_Tmin, minTempC);
+      Param::SetFloat(Param::BMS_Tmax, maxTempC);
+   }
+   else
+   {
+      Param::SetFloat(Param::BMS_Vmin, 0);
+      Param::SetFloat(Param::BMS_Vmax, 0);
+      Param::SetFloat(Param::BMS_Tmin, 0);
+      Param::SetFloat(Param::BMS_Tmax, 0);
+   }
+}

--- a/src/simpbms.cpp
+++ b/src/simpbms.cpp
@@ -1,0 +1,113 @@
+/*
+ * This file is part of the ZombieVerter project.
+ *
+ * Copyright (C) 2022 Charlie Smurthwaite
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "stm32_vcu.h"
+/*
+ * This module receives messages from SimpBMS and updates the
+ * BMS_MinV, BMS_MaxV, BMS_MinT and BMS_MaxT parameters with the
+ * received values. It also implements a timeout to indicate whether
+ * the BMS is actively sending data or not. This data can be
+ * used to safely stop any charging process if the BMS is not
+ * working correctly.
+ */
+
+void SimpBMS::SetCanInterface(CanHardware* c)
+{
+   can = c;
+   can->RegisterUserMessage(0x373);
+   can->RegisterUserMessage(0x351);
+}
+
+bool SimpBMS::BMSDataValid() {
+   // Return false if primary BMS is not sending data.
+   if(timeoutCounter < 1) return false;
+   return true;
+}
+
+// Return whether charging is currently permitted.
+bool SimpBMS::ChargeAllowed()
+{
+   // Refuse to charge if the BMS is not sending data.
+   if(!BMSDataValid()) return false;
+
+   // Refuse to charge if the voltage or temperature is out of range.
+   if(maxCellV > Param::GetFloat(Param::BMS_VmaxLimit)) return false;
+   if(minCellV < Param::GetFloat(Param::BMS_VminLimit)) return false;
+   if(maxTempC > Param::GetFloat(Param::BMS_TmaxLimit)) return false;
+   if(minTempC < Param::GetFloat(Param::BMS_TminLimit)) return false;
+
+   // Refuse to charge if the current limit is zero.
+   if(chargeCurrentLimit < 0.5) return false;
+
+   // Otherwise, charging is permitted.
+   return true;
+}
+
+// Return the maximum charge current allowed by the BMS.
+float SimpBMS::MaxChargeCurrent()
+{
+   if(!ChargeAllowed()) return 0;
+   return chargeCurrentLimit / 1000.0;
+}
+
+// Process voltage and temperature message from SimpBMS.
+void SimpBMS::DecodeCAN(int id, uint8_t *data)
+{
+   if (id == 0x373)
+   {
+      int minCell = data[0] | (data[1] << 8);
+      int maxCell = data[2] | (data[3] << 8);
+      int minTemp = data[4] | (data[5] << 8);
+      int maxTemp = data[6] | (data[7] << 8);
+
+      minCellV = minCell / 1000.0;
+      maxCellV = maxCell / 1000.0;
+      minTempC = minTemp - 273;
+      maxTempC = maxTemp - 273;
+
+      // Reset timeout counter to the full timeout value
+      timeoutCounter = Param::GetInt(Param::BMS_Timeout) * 10;
+   }
+   else if (id == 0x351)
+   {
+      chargeCurrentLimit = data[2] | (data[3] << 8);
+   }
+}
+
+void SimpBMS::Task100Ms() {
+   // Decrement timeout counter.
+   if(timeoutCounter > 0) timeoutCounter--;
+
+   // Update informational parameters.
+   Param::SetInt(Param::BMS_ChargeLim, MaxChargeCurrent());
+
+   if(BMSDataValid()) {
+      Param::SetFloat(Param::BMS_Vmin, minCellV);
+      Param::SetFloat(Param::BMS_Vmax, maxCellV);
+      Param::SetFloat(Param::BMS_Tmin, minTempC);
+      Param::SetFloat(Param::BMS_Tmax, maxTempC);
+   }
+   else
+   {
+      Param::SetFloat(Param::BMS_Vmin, 0);
+      Param::SetFloat(Param::BMS_Vmax, 0);
+      Param::SetFloat(Param::BMS_Tmin, 0);
+      Param::SetFloat(Param::BMS_Tmax, 0);
+   }
+}


### PR DESCRIPTION
This pull request is a work in progress. It aims to add modular BMS support to Zombieverter.

Current goals are as follows:
* Fully modular architecture with selectable BMS hardware
* Receive cell voltage data from BMS
* Receive cell temperature data from BMS
* Inhibit charging if indicated by configurable voltage and temperature limits
* Inhibit charging if indicated by BMS
* Limit charge rate if indicated by BMS

Possible future goals:
* Limit discharge rate if indicated by BMS
* State of charge calculation using fused shunt and BMS data