### PR TITLE
Filter out overlapping 0x200 and 0x220 messages when using SBOX and a BMW CSC master on same canbus

### DIFF
--- a/src/bmw_sbox.cpp
+++ b/src/bmw_sbox.cpp
@@ -116,9 +116,10 @@ void SBOX::handle200(uint32_t data[2])  //SBOX Current
 
 {
    uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
-   Amperes = ((bytes[2] << 16) | (bytes[1] << 8) | (bytes[0]));
-   Amperes = (Amperes<<8) >> 8;//extend sign bit as its a 24 bit signed value in a 32bit int! AAAHHHHHH!
-
+   if (!((bytes[7] == 0) && (bytes[5] == 0))) { //Filters for the Sbox message (as the BMW PHEV BMS Master also sends an 0x200 msg)
+       Amperes = ((bytes[2] << 16) | (bytes[1] << 8) | (bytes[0]));
+       Amperes = (Amperes<<8) >> 8;//extend sign bit as its a 24 bit signed value in a 32bit int! AAAHHHHHH!
+   }
 }
 
 void SBOX::handle210(uint32_t data[2])  //SBOX battery voltage

--- a/src/bmw_sbox.cpp
+++ b/src/bmw_sbox.cpp
@@ -134,9 +134,10 @@ void SBOX::handle220(uint32_t data[2]) //SBOX Output voltage
 
 {
    uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
-   Voltage2=((bytes[2] << 16) | (bytes[1] << 8) | (bytes[0]));
-   Voltage2 = (Voltage2<<8) >> 8;//extend sign bit as its a 24 bit signed value in a 32bit int! AAAHHHHHH!
-
+   if (!((bytes[7] == 0) && (bytes[5] == 0))) { //Filters for the Sbox message (as the BMW PHEV BMS Master also sends an 0x220 msg)
+      Voltage2=((bytes[2] << 16) | (bytes[1] << 8) | (bytes[0]));
+      Voltage2 = (Voltage2<<8) >> 8;//extend sign bit as its a 24 bit signed value in a 32bit int! AAAHHHHHH!
+   }
 }
 
 void SBOX::ControlContactors(int opmode, CanHardware* can)


### PR DESCRIPTION
This is needed when using a BMW PHEV CSC master on the same bus as the Sbox as it also sends messages on 0x200 (Current) and 0x220 (Post contactor voltage). Working OK on my test setup at least. Please could you merge if this looks OK - Thanks