### PR TITLE
Make the CanMap device configurable.

### DIFF
--- a/include/param_prj.h
+++ b/include/param_prj.h
@@ -25,7 +25,7 @@
    2. Temporary parameters (id = 0)
    3. Display values
  */
-//Next param id (increase when adding new parameter!): 97
+//Next param id (increase when adding new parameter!): 98
 /*              category     name         unit       min     max     default id */
 #define PARAM_LIST \
     PARAM_ENTRY(CAT_SETUP,     Inverter,     INVMODES, 0,      6,      0,      5  ) \
@@ -38,6 +38,7 @@
     PARAM_ENTRY(CAT_SETUP,     ChargerCan,   CAN_DEV,  0,      1,      1,      74 ) \
     PARAM_ENTRY(CAT_SETUP,     BMSCan,       CAN_DEV,  0,      1,      1,      89 ) \
     PARAM_ENTRY(CAT_SETUP,     OBD2Can,      CAN_DEV,  0,      1,      0,      96 ) \
+    PARAM_ENTRY(CAT_SETUP,     CanMapCan,    CAN_DEV,  0,      1,      0,      97 ) \
     PARAM_ENTRY(CAT_THROTTLE,  potmin,      "dig",     0,      4095,   0,      7  ) \
     PARAM_ENTRY(CAT_THROTTLE,  potmax,      "dig",     0,      4095,   4095,   8  ) \
     PARAM_ENTRY(CAT_THROTTLE,  pot2min,     "dig",     0,      4095,   4095,   9  ) \

--- a/src/stm32_vcu.cpp
+++ b/src/stm32_vcu.cpp
@@ -783,7 +783,13 @@ extern "C" int main(void)
    FunctionPointerCallback canCb(CanCallback, SetCanFilters);
    Stm32Can c(CAN1, CanHardware::Baud500);
    Stm32Can c2(CAN2, CanHardware::Baud500, true);
-   CanMap cm(&c);
+   Stm32Can *CanMapDev = &c;
+   if (Param::GetInt(Param::CanMapCan) == 0) {
+      CanMapDev = &c;
+   } else { 
+      CanMapDev = &c2;
+   }
+   CanMap cm(CanMapDev);
 
    // Set up CAN 1 callback and messages to listen for
    c.AddReceiveCallback(&canCb);


### PR DESCRIPTION
Make it possible to control where the CanMap messages are being sent.  Feel free to pick a better name.  This will also require a reset if you ever change it. 