### PR TITLE
Adding Analogue inputs to IOMatrix and adding support for the Pilot P…

### DIFF
--- a/include/anain_prj.h
+++ b/include/anain_prj.h
@@ -33,5 +33,7 @@
    ANA_IN_ENTRY(GP_analog2,GPIOC, 3) \
    ANA_IN_ENTRY(MG1_Temp,  GPIOC, 5) \
    ANA_IN_ENTRY(MG2_Temp,  GPIOC, 4) \
+   ANA_IN_ENTRY(dummyAnal, GPIOC, 11) \
 
+//dummyAnal is used by IOMatrix class for unused functions. Must be set to a pin that has no effect
 #endif // ANAIN_PRJ_H_INCLUDED

--- a/include/iomatrix.h
+++ b/include/iomatrix.h
@@ -21,6 +21,7 @@
 
 #include "digio.h"
 #include "params.h"
+#include "anain.h"
 
 class IOMatrix
 {
@@ -33,13 +34,24 @@ class IOMatrix
          LAST
       };
 
+      enum analoguepinfuncs
+      {
+         NONE_ANAL, PILOT_PROX, LAST_ANAL
+      };
+
       static void AssignFromParams();
+      static void AssignFromParamsAnalogue();
       static DigIo* GetPin(pinfuncs f) { return functionToPin[f]; }
+      static AnaIn* GetAnaloguePin(analoguepinfuncs f) { return functionToPinAnalgoue[f]; }
 
    private:
       static DigIo* functionToPin[LAST];
       static const int numPins = 10;
       static DigIo* const paramToPin[numPins];
+
+      static AnaIn* functionToPinAnalgoue[LAST_ANAL];
+      static const int numAnaloguePins = 2;
+      static AnaIn* const paramToPinAnalgue[numAnaloguePins];
 };
 
 #endif // IOMATRIX_H

--- a/include/param_prj.h
+++ b/include/param_prj.h
@@ -114,6 +114,9 @@
     PARAM_ENTRY(CAT_IOPINS,    PWM3Func,    PINFUNCS,  0,      13,     2,      87 ) \
     PARAM_ENTRY(CAT_IOPINS,    GP12VInFunc, PINFUNCS,  0,      12,     12,     98 ) \
     PARAM_ENTRY(CAT_IOPINS,    HVReqFunc,   PINFUNCS,  0,      12,     11,     99 ) \
+    PARAM_ENTRY(CAT_IOPINS,    GPA1Func,    APINFUNCS, 0,      1,      0,      110 ) \
+    PARAM_ENTRY(CAT_IOPINS,    GPA2Func,    APINFUNCS, 0,      1,      0,      111 ) \
+    PARAM_ENTRY(CAT_IOPINS,    ppthresh,    "dig",     0,      4095,   2500,   114 ) \
     PARAM_ENTRY(CAT_SHUNT,     IsaInit,     ONOFF,     0,      1,      0,      75 ) \
     PARAM_ENTRY(CAT_SHUNT,     Type,        SHNTYPE,   0,      2,      0,      88 ) \
     PARAM_ENTRY(CAT_PWM,       Tim3_Presc,  "",        1,      72000,  719,    100 ) \
@@ -201,7 +204,7 @@
     VALUE_ENTRY(AC_Amps,       "A",                 2089 ) \
     VALUE_ENTRY(canctr,        "dig",               2091 ) \
     VALUE_ENTRY(cpuload,       "%",                 2063 ) \
-
+    VALUE_ENTRY(PPVal,         "dig",               2094 ) \
 
 //Next value Id: 2092
 
@@ -211,6 +214,7 @@
 #define PINFUNCS     "0=None, 1=ChaDeMoAlw, 2=OBCEnable, 3=HeaterEnable, 4=RunIndication, 5=WarnIndication," \
                      "6=CoolantPump, 7=NegContactor, 8=BrakeLight, 9=ReverseLight, 10=HeatReq, 11=HVRequest," \
                      "12=DCFCRequest, 13=PwmTim3"
+#define APINFUNCS    "0=None, 1=ProxPilot"
 #define SHNTYPE      "0=ISA, 1=SBOX, 2=VAG"
 #define DMODES       "0=CLOSED, 1=OPEN, 2=ERROR, 3=INVALID"
 #define POTMODES     "0=SingleChannel, 1=DualChannel"
@@ -265,7 +269,7 @@
 #define CAN_PERIOD_10MS     1
 
 #define FIRST_IO_PARAM Param::Out1Func
-
+#define FIRST_AI_PARAM Param::GPA1Func
 enum modes
 {
     MOD_OFF = 0,

--- a/src/iomatrix.cpp
+++ b/src/iomatrix.cpp
@@ -22,6 +22,11 @@ DigIo* const IOMatrix::paramToPin[] = { &DigIo::gp_out1, &DigIo::gp_out2, &DigIo
                                         &DigIo::SL1_out, &DigIo::SL2_out,
                                         &DigIo::PWM1, &DigIo::PWM2, &DigIo::PWM3,
                                         &DigIo::HV_req, &DigIo::gp_12Vin, };
+
+AnaIn* const IOMatrix::paramToPinAnalgue[] = {
+   &AnaIn::GP_analog1, &AnaIn::GP_analog2
+};
+
 DigIo* IOMatrix::functionToPin[];
 
 void IOMatrix::AssignFromParams()
@@ -34,5 +39,20 @@ void IOMatrix::AssignFromParams()
    for (int i = 0; i < numPins; i++)
    {
       functionToPin[Param::GetInt((Param::PARAM_NUM)(FIRST_IO_PARAM + i))] = paramToPin[i];
+   }
+}
+
+AnaIn* IOMatrix::functionToPinAnalgoue[];
+
+void IOMatrix::AssignFromParamsAnalogue()
+{
+   for (int i = 0; i < LAST_ANAL; i++)
+   {
+      functionToPinAnalgoue[i] = &AnaIn::dummyAnal;
+   }
+
+   for (int i = 0; i < numAnaloguePins; i++)
+   {
+      functionToPinAnalgoue[Param::GetInt((Param::PARAM_NUM)(FIRST_AI_PARAM + i))] = paramToPinAnalgue[i];
    }
 }


### PR DESCRIPTION
Use one of the now mappable analogue inputs for the Pilot Proximity pin to automatically go in to charge mode.
https://openinverter.org/wiki/BMW_I3_Fast_Charging_LIM_Module Using the resistors described here and setting the threshold for activation.