### PR TITLE
Regen+rear outlander

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ OBJSL		= $(BINARY).o hwinit.o stm32scheduler.o params.o terminal.o terminal_prj.
            param_save.o errormessage.o stm32_can.o leafinv.o utils.o terminalcommands.o i3LIM.o \
            chademo.o amperaheater.o amperacharger.o subaruvehicle.o iomatrix.o bmw_sbox.o NissanPDM.o teslaCharger.o extCharger.o vag_sbox.o \
            daisychainbms.o simpbms.o outlanderCharger.o Can_OBD2.o cansdo.o TeslaDCDC.o BMW_E31.o F30_Lever.o \
-           CPC.o ElconCharger.o
+           CPC.o ElconCharger.o RearOutlanderinverter.o
 		   
            
 OBJS     = $(patsubst %.o,$(OUT_DIR)/%.o, $(OBJSL))

--- a/Makefile
+++ b/Makefile
@@ -40,13 +40,13 @@ LDFLAGS  = -Llibopencm3/lib -T$(LDSCRIPT) -march=armv7 -nostartfiles -Wl,--gc-se
 OBJSL		= $(BINARY).o hwinit.o stm32scheduler.o params.o terminal.o terminal_prj.o \
            my_string.o digio.o my_fp.o printf.o anain.o throttle.o isa_shunt.o BMW_E65.o GS450H.o temp_meas.o \
            Can_E39.o Can_VAG.o Can_OI.o MCP2515.o CANSPI.o outlanderinverter.o canhardware.o canmap.o \
-           param_save.o errormessage.o stm32_can.o linbus.o leafinv.o utils.o terminalcommands.o i3LIM.o \
+           param_save.o errormessage.o stm32_can.o leafinv.o utils.o terminalcommands.o i3LIM.o \
            chademo.o amperaheater.o amperacharger.o subaruvehicle.o iomatrix.o bmw_sbox.o NissanPDM.o teslaCharger.o extCharger.o vag_sbox.o \
-           daisychainbms.o simpbms.o outlanderCharger.o Can_OBD2.o cansdo.o TeslaDCDC.o BMW_E31.o F30_Lever.o VWheater.o
-
-
+           daisychainbms.o simpbms.o outlanderCharger.o Can_OBD2.o cansdo.o TeslaDCDC.o BMW_E31.o F30_Lever.o \
+           CPC.o ElconCharger.o
+		   
+           
 OBJS     = $(patsubst %.o,$(OUT_DIR)/%.o, $(OBJSL))
-DEPENDS  = $(patsubst %.o,obj/%.d, $(OBJSL))
 vpath %.c src/ libopeninv/src/
 vpath %.cpp src/ libopeninv/src/
 
@@ -81,8 +81,6 @@ ${OUT_DIR}:
 $(BINARY): $(OBJS) $(LDSCRIPT)
 	@printf "  LD      $(subst $(shell pwd)/,,$(@))\n"
 	$(Q)$(LD) $(LDFLAGS) -o $(BINARY) $(OBJS) -lopencm3_stm32f1 -lm
-
--include $(DEPENDS)
 
 $(OUT_DIR)/%.o: %.c Makefile
 	@printf "  CC      $(subst $(shell pwd)/,,$(@))\n"

--- a/include/BMW_E31.h
+++ b/include/BMW_E31.h
@@ -27,14 +27,13 @@
 #include "vehicle.h"
 #include "digio.h"
 #include "utils.h"
-#include "stm32_can.h"
 
 class Bmw_E31: public Vehicle
 {
 
 public:
    void SetCanInterface(CanHardware* c);
-   void Task10Ms();
+   void Task10Ms() {};
    void Task100Ms();
    void Task1Ms();
    void SetRevCounter(int s);
@@ -48,8 +47,6 @@ private:
    uint16_t speed;
    uint32_t timerPeriod;
    bool timerIsRunning=false;
-   void EGSMsg43F(int8_t gear);
-   void EGSMsg43B();
 
 };
 

--- a/include/BMW_E65.h
+++ b/include/BMW_E65.h
@@ -25,15 +25,25 @@ public:
    bool Start() { return terminal15On; }
    bool GetGear(Vehicle::gear& outGear);
    void DashOff();
+   void handle130(uint32_t data[2]);
+   void handle192(uint32_t data[2]);
+   void handle480(uint32_t data[2]);
+   void SetE90(bool e90) { isE90 = e90; }
+   void Engine_Data();
 
 private:
    void SendAbsDscMessages(bool Brake_In);
 
    bool terminal15On;
+   bool terminalROn;
+   bool terminal50On;
    bool dashInit;
    Vehicle::gear gear;
    int revCounter;
    float temperature;
+   bool  CANWake;
+   bool  StartButt;
+   bool isE90;
 };
 
 #endif /* BMW_E65_h */

--- a/include/CPC.h
+++ b/include/CPC.h
@@ -1,0 +1,33 @@
+#ifndef CPC_h
+#define CPC_h
+
+/*  This library supports the Charge Port Controller CAN interface
+	2024 - Tom de Bree
+*/
+
+#include <stdint.h>
+#include "my_fp.h"
+#include "params.h"
+#include "stm32_can.h"
+#include "chargerint.h"
+#include "my_math.h"
+
+class CPCClass: public Chargerint
+{
+
+public:
+      void SetCanInterface(CanHardware* c);
+      void DecodeCAN(int id, uint32_t data[2]);
+      void Task10Ms();
+      void Task100Ms();
+      void Task200Ms();
+      bool DCFCRequest(bool RunCh);
+      bool ACRequest(bool RunCh);
+
+private:
+static void handle357(uint32_t data[2]);
+
+static void Chg_Timers();
+};
+
+#endif /* CPC_h */

--- a/include/ElconCharger.h
+++ b/include/ElconCharger.h
@@ -1,0 +1,32 @@
+
+#ifndef ElconCharger_h
+#define ElconCharger_h
+
+/*  This library supports the various Elcon charger protocol based chargers
+
+*/
+
+#include <stdint.h>
+#include "my_fp.h"
+#include "params.h"
+#include "chargerhw.h"
+#include "my_math.h"
+
+class ElconCharger: public Chargerhw
+{
+
+public:
+void DecodeCAN(int id, uint32_t data[2]);
+void Task200Ms();
+bool ControlCharge(bool RunCh, bool ACReq);
+void SetCanInterface(CanHardware* c);
+/*
+static void handle108(uint32_t data[2]);
+static bool HVreq;
+static void Send100msMessages(bool ChRun, CanHardware* can);
+*/
+private:
+
+};
+
+#endif /* ElconCharger_h */

--- a/include/ElconCharger.h
+++ b/include/ElconCharger.h
@@ -20,6 +20,7 @@ void DecodeCAN(int id, uint32_t data[2]);
 void Task200Ms();
 bool ControlCharge(bool RunCh, bool ACReq);
 void SetCanInterface(CanHardware* c);
+void handle18FF50E5(uint32_t data[2]);
 /*
 static void handle108(uint32_t data[2]);
 static bool HVreq;

--- a/include/NoInverter.h
+++ b/include/NoInverter.h
@@ -1,0 +1,23 @@
+#ifndef NoInverter_h
+#define NoInverter_h
+
+/*  Dummy library for when no Inverter interface is used.
+
+*/
+#include <inverter.h>
+
+class NoInverterClass: public Inverter
+{
+
+public:
+   void SetTorque(float torquePercent) {torquePercent = torquePercent;}
+   float GetMotorTemperature(){return(0);}
+   float GetInverterTemperature() {return(0);}
+   float GetInverterVoltage() {return(0);}
+   float GetMotorSpeed(){return(0);}
+   int GetInverterState() {return(0);}
+private:
+
+};
+
+#endif

--- a/include/heater.h
+++ b/include/heater.h
@@ -19,7 +19,6 @@ public:
    virtual void DeInit() {} //called when switching to another heater, similar to a destructor
    virtual void SetCanInterface(CanHardware* c) { can = c; }
 
-
 protected:
    CanHardware* can;
 };

--- a/include/hwinit.h
+++ b/include/hwinit.h
@@ -31,7 +31,6 @@ extern "C"
 void clock_setup(void);
 void usart_setup(void);
 void usart2_setup(void);
-void usart1_setup(void);
 void nvic_setup(void);
 void rtc_setup(void);
 void tim_setup(void);

--- a/include/no_Lever.h
+++ b/include/no_Lever.h
@@ -31,8 +31,6 @@ class no_Lever: public Shifter
 {
 public:
 
-
-
 private:
 
 };

--- a/include/param_prj.h
+++ b/include/param_prj.h
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#define VER 2.05.A
+#define VER 2.10.T
 
 
 /* Entries must be ordered as follows:
@@ -25,10 +25,10 @@
    2. Temporary parameters (id = 0)
    3. Display values
  */
-//Next param id (increase when adding new parameter!): 109
+//Next param id (increase when adding new parameter!): 124
 /*              category     name         unit       min     max     default id */
 #define PARAM_LIST \
-    PARAM_ENTRY(CAT_SETUP,     Inverter,     INVMODES, 0,      7,      0,      5  ) \
+    PARAM_ENTRY(CAT_SETUP,     Inverter,     INVMODES, 0,      8,      0,      5  ) \
     PARAM_ENTRY(CAT_SETUP,     Vehicle,      VEHMODES, 0,      8,      0,      6  ) \
     PARAM_ENTRY(CAT_SETUP,     Transmission, TRNMODES, 0,      1,      0,      78 ) \
     PARAM_ENTRY(CAT_SETUP,   interface,   CHGINT,    0,      3,      0,      39 ) \
@@ -47,8 +47,9 @@
     PARAM_ENTRY(CAT_THROTTLE,  potmax,      "dig",     0,      4095,   4095,   8  ) \
     PARAM_ENTRY(CAT_THROTTLE,  pot2min,     "dig",     0,      4095,   4095,   9  ) \
     PARAM_ENTRY(CAT_THROTTLE,  pot2max,     "dig",     0,      4095,   4095,   10 ) \
-    PARAM_ENTRY(CAT_THROTTLE,  regentravel, "%",       0,      100,    30,     60 ) \
-    PARAM_ENTRY(CAT_THROTTLE,  regenmax,    "%",       -100,   0,     -30,     61 ) \
+    PARAM_ENTRY(CAT_THROTTLE,  regenrpm, "rpm",       0,      10000,    1500,     60 ) \
+    PARAM_ENTRY(CAT_THROTTLE,  regenmax,    "%",       -100,   0,     -10,     61 ) \
+    PARAM_ENTRY(CAT_THROTTLE,  regenBrake,    "%",       -100,   0,     -10,     122 ) \
     PARAM_ENTRY(CAT_THROTTLE,  regenramp,   "%/10ms",  0.1,    100,    100,    68 ) \
     PARAM_ENTRY(CAT_THROTTLE,  potmode,     POTMODES,  0,      1,      0,      11 ) \
     PARAM_ENTRY(CAT_THROTTLE,  dirmode,     DIRMODES,  0,      4,      1,      12 ) \
@@ -65,6 +66,7 @@
     PARAM_ENTRY(CAT_THROTTLE,  tmpmmax,     "°C",      70,     300,    300,    24 ) \
     PARAM_ENTRY(CAT_THROTTLE,  throtmax,    "%",       0,      100,    100,    25 ) \
     PARAM_ENTRY(CAT_THROTTLE,  throtmin,    "%",      -100,    0,     -100,    26 ) \
+    PARAM_ENTRY(CAT_THROTTLE,  throtmaxRev,    "%",       0,      100,    30,    123 ) \
     PARAM_ENTRY(CAT_THROTTLE,  throtdead,   "%",       0,      50,     10,     76 ) \
     PARAM_ENTRY(CAT_LEXUS,     Gear,        LOWHIGH,   0,      2,      0,      27 ) \
     PARAM_ENTRY(CAT_LEXUS,     OilPump,     "%",       0,      100,    50,     28 ) \
@@ -227,7 +229,7 @@
 #define POTMODES     "0=SingleChannel, 1=DualChannel"
 #define BTNSWITCH    "0=Button, 1=Switch, 2=CAN"
 #define DIRMODES     "0=Button, 1=Switch, 2=ButtonReversed, 3=SwitchReversed, 4=DefaultForward"
-#define INVMODES     "0=None, 1=Leaf_Gen1, 2=GS450H, 3=UserCAN, 4=OpenI, 5=Prius_Gen3, 6=Outlander, 7=GS300H"
+#define INVMODES     "0=None, 1=Leaf_Gen1, 2=GS450H, 3=UserCAN, 4=OpenI, 5=Prius_Gen3, 6=Outlander, 7=GS300H 8=RearOutlander"
 #define PLTMODES     "0=Absent, 1=ACStd, 2=ACchg, 3=Error, 4=CCS_Not_Rdy, 5=CCS_Rdy, 6=Static"
 #define VEHMODES     "0=BMW_E46, 1=BMW_E65, 2=Classic, 3=None, 5=BMW_E39, 6=VAG, 7=Subaru, 8=BMW_E31"
 #define BMSMODES     "0=Off, 1=SimpBMS, 2=TiDaisychainSingle, 3=TiDaisychainDual"
@@ -318,7 +320,8 @@ enum InvModes
     OpenI = 4,
     Prius_Gen3 = 5,
     Outlander = 6,
-    GS300H = 7
+    GS300H = 7,
+    RearOutlander = 8
 };
 
 enum ChargeModes

--- a/include/param_prj.h
+++ b/include/param_prj.h
@@ -25,12 +25,14 @@
    2. Temporary parameters (id = 0)
    3. Display values
  */
-//Next param id (increase when adding new parameter!): 110
+//Next param id (increase when adding new parameter!): 109
 /*              category     name         unit       min     max     default id */
 #define PARAM_LIST \
-    PARAM_ENTRY(CAT_SETUP,     Inverter,     INVMODES, 0,      6,      0,      5  ) \
+    PARAM_ENTRY(CAT_SETUP,     Inverter,     INVMODES, 0,      7,      0,      5  ) \
     PARAM_ENTRY(CAT_SETUP,     Vehicle,      VEHMODES, 0,      8,      0,      6  ) \
     PARAM_ENTRY(CAT_SETUP,     Transmission, TRNMODES, 0,      1,      0,      78 ) \
+    PARAM_ENTRY(CAT_SETUP,   interface,   CHGINT,    0,      3,      0,      39 ) \
+     PARAM_ENTRY(CAT_SETUP,   chargemodes, CHGMODS,   0,      6,      0,      37 ) \
     PARAM_ENTRY(CAT_SETUP,     InverterCan,  CAN_DEV,  0,      1,      0,      70 ) \
     PARAM_ENTRY(CAT_SETUP,     VehicleCan,   CAN_DEV,  0,      1,      1,      71 ) \
     PARAM_ENTRY(CAT_SETUP,     ShuntCan,     CAN_DEV,  0,      1,      0,      72 ) \
@@ -59,7 +61,7 @@
     PARAM_ENTRY(CAT_THROTTLE,  udclim,      "V",       0,      1000,   520,    20 ) \
     PARAM_ENTRY(CAT_THROTTLE,  idcmax,      "A",       0,      5000,   5000,   21 ) \
     PARAM_ENTRY(CAT_THROTTLE,  idcmin,      "A",      -5000,   0,     -5000,   22 ) \
-    PARAM_ENTRY(CAT_THROTTLE,  tmphsmax,    "°C",      50,     300,    85,     23 ) \
+    PARAM_ENTRY(CAT_THROTTLE,  tmphsmax,    "°C",      50,     150,    85,     23 ) \
     PARAM_ENTRY(CAT_THROTTLE,  tmpmmax,     "°C",      70,     300,    300,    24 ) \
     PARAM_ENTRY(CAT_THROTTLE,  throtmax,    "%",       0,      100,    100,    25 ) \
     PARAM_ENTRY(CAT_THROTTLE,  throtmin,    "%",      -100,    0,     -100,    26 ) \
@@ -73,9 +75,7 @@
     PARAM_ENTRY(CAT_CONTACT,   cruiselight, ONOFF,     0,      1,      0,      33 ) \
     PARAM_ENTRY(CAT_CONTACT,   errlights,   ERRLIGHTS, 0,      255,    0,      34 ) \
     PARAM_ENTRY(CAT_COMM,      CAN3Speed,   CAN3Spd,   0,      1,      0,      77 ) \
-    PARAM_ENTRY(CAT_CHARGER,   chargemodes, CHGMODS,   0,      5,      0,      37 ) \
     PARAM_ENTRY(CAT_CHARGER,   BattCap,     "kWh",     0.1,    250,    22,     38 ) \
-    PARAM_ENTRY(CAT_CHARGER,   interface,   CHGINT,    0,      2,      0,      39 ) \
     PARAM_ENTRY(CAT_CHARGER,   Voltspnt,    "V",       0,      1000,   395,    40 ) \
     PARAM_ENTRY(CAT_CHARGER,   Pwrspnt,     "W",       0,      12000,  1500,   41 ) \
     PARAM_ENTRY(CAT_CHARGER,   IdcTerm,     "A",       0,      150,    0,      56 ) \
@@ -84,6 +84,8 @@
     PARAM_ENTRY(CAT_CHARGER,   CCS_SOCLim,  "%",       0,      100,    80,     44 ) \
     PARAM_ENTRY(CAT_CHARGER,   SOCFC,       "%",       0,      100,    50,     79 ) \
     PARAM_ENTRY(CAT_CHARGER,   Chgctrl,     CHGCTRL,   0,      2,      0,      45 ) \
+    PARAM_ENTRY(CAT_CHARGER,   ChgAcVolt,   "Vac",     0,      250,   240,     120 ) \
+    PARAM_ENTRY(CAT_CHARGER,   ChgEff,     "%",       0,      100,   90,      121) \
     PARAM_ENTRY(CAT_DCDC,      DCdc_Type,   DCDCTYPES, 0,      1,      0,      105 ) \
     PARAM_ENTRY(CAT_DCDC,      DCSetPnt,    "V",       9,      15,     14,     106 ) \
     PARAM_ENTRY(CAT_BMS,       BMS_Mode,    BMSMODES,  0,      3,      0,      90 ) \
@@ -95,7 +97,6 @@
     PARAM_ENTRY(CAT_HEATER,    Heater,      HTTYPE,    0,      2,      0,      57 ) \
     PARAM_ENTRY(CAT_HEATER,    Control,     HTCTRL,    0,      2,      0,      58 ) \
     PARAM_ENTRY(CAT_HEATER,    HeatPwr,     "W",       0,      6500,   0,      59 ) \
-    PARAM_ENTRY(CAT_HEATER,    HeatPercnt,  "%",       0,      100,    0,      109 ) \
     PARAM_ENTRY(CAT_CLOCK,     Set_Day,     DOW,       0,      6,      0,      46 ) \
     PARAM_ENTRY(CAT_CLOCK,     Set_Hour,    "Hours",   0,      23,     0,      47 ) \
     PARAM_ENTRY(CAT_CLOCK,     Set_Min,     "Mins",    0,      59,     0,      48 ) \
@@ -210,11 +211,8 @@
     VALUE_ENTRY(cpuload,       "%",                 2063 ) \
     VALUE_ENTRY(PPVal,         "dig",               2094 ) \
     VALUE_ENTRY(BrkVacVal,     "dig",               2095 ) \
-    VALUE_ENTRY(tmpheater,     "°C",                2096 ) \
-    VALUE_ENTRY(udcheater,     "V",                 2097 ) \
-    VALUE_ENTRY(powerheater,   "W",                 2098 ) \
 
-//Next value Id: 2099
+//Next value Id: 2096
 
 
 
@@ -229,7 +227,7 @@
 #define POTMODES     "0=SingleChannel, 1=DualChannel"
 #define BTNSWITCH    "0=Button, 1=Switch, 2=CAN"
 #define DIRMODES     "0=Button, 1=Switch, 2=ButtonReversed, 3=SwitchReversed, 4=DefaultForward"
-#define INVMODES     "0=Leaf_Gen1, 1=GS450H, 2=UserCAN, 3=OpenI, 4=Prius_Gen3, 5=Outlander, 6=GS300H"
+#define INVMODES     "0=None, 1=Leaf_Gen1, 2=GS450H, 3=UserCAN, 4=OpenI, 5=Prius_Gen3, 6=Outlander, 7=GS300H"
 #define PLTMODES     "0=Absent, 1=ACStd, 2=ACchg, 3=Error, 4=CCS_Not_Rdy, 5=CCS_Rdy, 6=Static"
 #define VEHMODES     "0=BMW_E46, 1=BMW_E65, 2=Classic, 3=None, 5=BMW_E39, 6=VAG, 7=Subaru, 8=BMW_E31"
 #define BMSMODES     "0=Off, 1=SimpBMS, 2=TiDaisychainSingle, 3=TiDaisychainDual"
@@ -251,9 +249,9 @@
 #define CDMSTAT      "1=Charging, 2=Malfunction, 4=ConnLock, 8=BatIncomp, 16=SystemMalfunction, 32=Stop"
 #define HTTYPE       "0=None, 1=Ampera, 2=VW"
 #define HTCTRL       "0=Disable, 1=Enable, 2=Timer"
-#define CHGMODS      "0=Off, 1=EXT_DIGI, 2=Volt_Ampera, 3=Leaf_PDM, 4=TeslaOI, 5=Out_lander"
+#define CHGMODS      "0=Off, 1=EXT_DIGI, 2=Volt_Ampera, 3=Leaf_PDM, 4=TeslaOI, 5=Out_lander 6=Elcon"
 #define CHGCTRL      "0=Enable, 1=Disable, 2=Timer"
-#define CHGINT       "0=Unused, 1=i3LIM, 2=Chademo"
+#define CHGINT       "0=Unused, 1=i3LIM, 2=Chademo, 3=CPC"
 #define CAN3Spd      "0=k33.3, 1=k500"
 #define TRNMODES     "0=Manual, 1=Auto"
 #define CAN_DEV      "0=CAN1, 1=CAN2"
@@ -313,13 +311,14 @@ enum _dirmodes
 
 enum InvModes
 {
-    Leaf_Gen1 = 0,
-    GS450H = 1,
-    UserCAN = 2,
-    OpenI = 3,
-    Prius_Gen3 = 4,
-    Outlander = 5,
-    GS300H = 6
+    NoInv =0,
+    Leaf_Gen1 = 1,
+    GS450H = 2,
+    UserCAN = 3,
+    OpenI = 4,
+    Prius_Gen3 = 5,
+    Outlander = 6,
+    GS300H = 7
 };
 
 enum ChargeModes
@@ -329,15 +328,16 @@ enum ChargeModes
     Volt_Ampera = 2,
     Leaf_PDM = 3,
     TeslaOI = 4,
-    Out_lander = 5
-
+    Out_lander = 5,
+    Elcon = 6
 };
 
 enum ChargeInterfaces
 {
     Unused = 0,
     i3LIM = 1,
-    Chademo = 2
+    Chademo = 2,
+    CPC = 3
 };
 
 enum HeatType

--- a/include/rearoutlanderinverter.h
+++ b/include/rearoutlanderinverter.h
@@ -1,0 +1,55 @@
+/*
+ * This file is part of the ZombieVerter project.
+ *
+ * Copyright (C) 2021-2022  Johannes Huebner <dev@johanneshuebner.com>
+ * 	                        Damien Maguire <info@evbmw.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef REAROUTLANDERINVERTER_H
+#define REAROUTLANDERINVERTER_H
+
+#include <inverter.h>
+
+class RearOutlanderInverter : public Inverter
+{
+public:
+   RearOutlanderInverter();
+   void SetCanInterface(CanHardware* c);
+   void DecodeCAN(int id, uint32_t data[2]);
+   void Task10Ms();
+   void Task100Ms();
+   void SetTorque(float torque);
+   float GetMotorTemperature() { return motor_temp; }
+   float GetInverterTemperature() { return inv_temp; }
+   float GetInverterVoltage() { return voltage; }
+   float GetMotorSpeed() { return speed; }
+   int GetInverterState() { return error; }
+
+private:
+   uint8_t run10ms;
+   uint32_t lastRecv;
+   int16_t inv_temp;
+   int16_t speed;
+   int16_t voltage;
+   int16_t motor_temp;
+   bool error;
+   uint32_t final_torque_request;
+   static float temp_1, temp_2;
+
+   static void handle289(uint32_t data[2]);
+   static void handle299(uint32_t data[2]);
+};
+
+#endif // REAROUTLANDERINVERTER_H

--- a/include/stm32_vcu.h
+++ b/include/stm32_vcu.h
@@ -81,13 +81,13 @@
 #include "shifter.h"
 #include "F30_Lever.h"
 #include "no_Lever.h"
-#include "VWheater.h"
-#include "linbus.h"
+#include "CPC.h"
+#include "NoInverter.h"
+#include "ElconCharger.h"
 
 #define PRECHARGE_TIMEOUT 5  //5s
 
 #define PRINT_JSON 0
-
 
 typedef union {
     struct {

--- a/include/stm32_vcu.h
+++ b/include/stm32_vcu.h
@@ -84,6 +84,7 @@
 #include "CPC.h"
 #include "NoInverter.h"
 #include "ElconCharger.h"
+#include "rearoutlanderinverter.h"
 
 #define PRECHARGE_TIMEOUT 5  //5s
 

--- a/include/throttle.h
+++ b/include/throttle.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of the ZombieVerter project.
  *
- * Copyright (C) 2012-2020 Johannes Huebner <dev@johanneshuebner.com> 
+ * Copyright (C) 2012-2020 Johannes Huebner <dev@johanneshuebner.com>
  *               2021-2022 Damien Maguire <info@evbmw.com>
  *
  * This program is free software: you can redistribute it and/or modify
@@ -22,6 +22,7 @@
 #define THROTTLE_H
 
 #include "my_fp.h"
+#include "utils.h"
 
 class Throttle
 {
@@ -39,11 +40,13 @@ public:
     static void RegenRampDown(float& finalSpnt, int speed);
     static int potmin[2];
     static int potmax[2];
-    static float regenTravel;
+    static float regenRpm;
     static float brknompedal;
     static float regenmax;
+    static float regenBrake;
     static float brkcruise;
     static float throtmax;
+    static float throtmaxRev;
     static float throtmin;
     static float throtdead;
     static int idleSpeed;

--- a/src/BMW_E31.cpp
+++ b/src/BMW_E31.cpp
@@ -32,7 +32,7 @@
 //We use this as an init function
 void Bmw_E31::SetCanInterface(CanHardware* c)
 {
-   can = c;
+   c = c;
    tim_setup();//Fire up timer one...
    timer_disable_counter(TIM1);//...but disable until needed
    //note we are trying to reuse the lexus gs450h oil pump pwm output here to drive the tach
@@ -79,93 +79,11 @@ void Bmw_E31::DecodeCAN(int id, uint32_t* data)
     }
 }
 
-void Bmw_E31::EGSMsg43B()  //EGS1
-{
-
-   uint8_t bytes[3];
-
-   bytes[0]=0x46;
-   bytes[1]=0x00;
-   bytes[2]=0x00;
-
-   can->Send(0x43B, (uint32_t*)bytes,3);
-}
-
-void Bmw_E31::EGSMsg43F(int8_t gear)
-{
-   //Can bus data packet values to be sent
-   uint8_t bytes[8];
-   // Source: https://www.bimmerforums.com/forum/showthread.php?1887229-E46-Can-bus-project&p=30055342#post30055342
-   // byte 0 = 0x81 //doesn't do anything to the ike
-   bytes[0] = 0x81;
-   // byte 1 = 0x01 where;
-   // 01 = first gear
-   // 02= second gear
-   // 03 = third gear
-   // 04 = fourth gear
-   // 05 = D
-   // 06 = N
-   // 07 = R
-   // 08 = P
-   // 09 = 5
-   // 0A = 6
-   switch (gear)
-   {
-   case -1 /* Reverse */:
-      bytes[1] = 0x07;
-      break;
-   case 0 /* Neutral */:
-      bytes[1] = 0x06;
-      break;
-   case 1 /* Drive */:
-      bytes[1] = 0x05;
-      break;
-   default:
-      bytes[1] = 0x08;
-      break;
-   }
-
-   // byte 2 = 0xFF where;
-   // FF = no display
-   // 00 = E
-   // 39 = M
-   // 40 = S
-   bytes[2] = 0xFF;
-
-   // byte 3 = 0xFF //doesn't do anything to the ike
-   bytes[3] = 0xFF;
-
-   // byte 4 = 0x00 //doesn't do anything to the ike
-   bytes[4] = 0x00;
-
-   // byte 5 = 0x80 where;
-   // 80 = clears the gear warning picture - all other values bring it on
-   bytes[5] = 0x80;
-
-   // byte 6 = 0xFF //doesn't do anything to the ike
-   bytes[6] = 0xFF;
-
-   // byte 7 = 0x00 //doesn't do anything to the ike
-   bytes[7] = 0xFF;
-
-   can->Send(0x43F, bytes, 8);
-}
-
  void Bmw_E31::Task1Ms()
 {
 
 
 }
-
-
- void Bmw_E31::Task10Ms()
-{
-   EGSMsg43B();//EGS1
-   if (Param::GetBool(Param::Transmission))
-      EGSMsg43F(Param::GetInt(Param::dir));
-
-}
-
 
 void Bmw_E31::Task100Ms()
 {

--- a/src/BMW_E65.cpp
+++ b/src/BMW_E65.cpp
@@ -7,6 +7,8 @@ uint8_t  Gcount; //gear display counter byte
 uint8_t shiftPos=0xe1; //contains byte to display gear position on dash.default to park
 uint8_t gear_BA=0x03; //set to park as initial condition
 uint8_t mthCnt;
+uint8_t C1D00 = 0x00;  //0x1D0 counter
+uint8_t C1D01 = 0x00;  //0x1D0 counter
 uint8_t A80=0xbe;//0x0A8 first counter byte
 uint8_t A81=0x00;//0x0A8 second counter byte
 uint8_t A90=0xe9;//0x0A9 first counter byte
@@ -17,206 +19,364 @@ uint8_t BA6=0x80;//0x0BA second counter byte(byte 6)
 
 void BMWE65::SetCanInterface(CanHardware* c)
 {
-   can = c;
+    can = c;
 
-   can->RegisterUserMessage(0x130);//E65 CAS
-   can->RegisterUserMessage(0x192);//E65 Shifter
+    can->RegisterUserMessage(0x130);//E65 CAS
+    can->RegisterUserMessage(0x192);//E65 Shifter
+    can->RegisterUserMessage(0x480);//Network Management
 }
 /////////////////////////////////////////////////////////////////////////////////////////////////////
 ///////Handle incomming pt can messages from the car here
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 void BMWE65::DecodeCAN(int id, uint32_t* data)
 {
-   uint8_t* bytes = (uint8_t*)data;
 
-   switch (id)
-   {
-      case 0x130:
-         if ((bytes[0] == 0x45) || (bytes[0] == 0x55))
-         {
+    switch (id)
+    {
+    case 0x130:
+        BMWE65::handle130(data);
+        break;
+
+    case 0x192:
+        BMWE65::handle192(data);
+        break;
+
+    case 0x480:
+        BMWE65::handle480(data);
+        break;
+
+    default:
+        break;
+    }
+}
+
+void BMWE65::handle130(uint32_t data[2])
+{
+    uint8_t* bytes = (uint8_t*)data;
+    /*
+        if ((bytes[0] == 0x45) || (bytes[0] == 0x55))
+        {
             // 0x45 is run, 0x55 is engine crank request
             terminal15On = true;
-         }
-         else
-         {
+        }
+        else
+        {
             terminal15On = false;
-         }
-         break;
-      case 0x192:
-         uint32_t GLeaver = data[0] & 0x00ffffff;  //unsigned int to contain result of message 0x192. Gear selector lever position
+        }
+      */
+    if ((bytes[0] & 0x01) > 0)
+    {
+        terminalROn = true;
+    }
+    else
+    {
+        terminalROn = false;
+    }
 
-         switch (GLeaver)
-         {
-            case 0x80506a:  //park button pressed
-               this->gear = PARK;
-               gear_BA = 0x03;
-               shiftPos = 0xe1;
-               break;
-            case 0x80042d: //R+ position
-               this->gear = REVERSE;
-               gear_BA = 0x02;
-               shiftPos = 0xd2;
-               break;
-            case 0x800374:  //D+ pressed
-               this->gear = DRIVE;
-               gear_BA = 0x08;
-               shiftPos = 0x78;
-               break;
-            case 0x80006a:  //not pressed
-            case 0x800147:  //R position
-            case 0x800259:  //D pressed
-            case 0x81006a:  //Left Back button pressed
-            case 0x82006a:  //Left Front button pressed
-            case 0x84006a:  //right Back button pressed
-            case 0x88006a:  //right Front button pressed
-            case 0xa0006a:  //  S-M-D button pressed
-               break;
-            }
-         break;
-   }
+    if ((bytes[0] & 0x04) > 0)
+    {
+        terminal15On = true;
+    }
+    else
+    {
+        terminal15On = false;
+    }
+
+    if ((bytes[0] & 0x10) > 0)
+    {
+        terminal50On = true;
+    }
+    else
+    {
+        terminal50On = false;
+    }
+
+    if ((bytes[2] & 0x08) > 0)
+    {
+        StartButt = true;
+    }
+    else
+    {
+        StartButt = false;
+    }
+}
+
+void BMWE65::handle192(uint32_t data[2])
+{
+    uint32_t GLeaver = data[0] & 0x00ffffff;  //unsigned int to contain result of message 0x192. Gear selector lever position
+
+    switch (GLeaver)
+    {
+    case 0x80506a:  //park button pressed
+        this->gear = PARK;
+        gear_BA = 0x03;
+        shiftPos = 0xe1;
+        break;
+    case 0x80042d: //R+ position
+        this->gear = REVERSE;
+        gear_BA = 0x02;
+        shiftPos = 0xd2;
+        break;
+    case 0x800374:  //D+ pressed
+        this->gear = DRIVE;
+        gear_BA = 0x08;
+        shiftPos = 0x78;
+        break;
+    case 0x80006a:  //not pressed
+    case 0x800147:  //R position
+    case 0x800259:  //D pressed
+    case 0x81006a:  //Left Back button pressed
+    case 0x82006a:  //Left Front button pressed
+    case 0x84006a:  //right Back button pressed
+    case 0x88006a:  //right Front button pressed
+    case 0xa0006a:  //  S-M-D button pressed
+        break;
+    }
+}
+
+void BMWE65::handle480(uint32_t data[2])
+{
+    uint8_t* bytes = (uint8_t*)data;
+
+    if (bytes[1] == 0x32)
+    {
+        CANWake = false;
+    }
+    else
+    {
+        CANWake = true;
+    }
 }
 
 void BMWE65::Task10Ms()
 {
-   if (Ready())
-   {
-      uint32_t data[2];
-      int rpm = MAX(750, revCounter) * 4; // rpm value for E65
+    if(CANWake)
+    {
+        if (Ready())
+        {
+            uint32_t data[2];
+            int rpm = MAX(750, revCounter) * 4; // rpm value for E65
 
-      data[0] = 0xff595f;
-      data[1] = 0x99800000 | rpm;
-      can->Send(0x0AA, data); //Send on CAN2
-   }
+            data[0] = 0xff595f;
+            data[1] = 0x99800000 | rpm;
+            can->Send(0x0AA, data); //Send on CAN2
+        }
 
-   SendAbsDscMessages(Param::GetBool(Param::din_brake));
+        SendAbsDscMessages(Param::GetBool(Param::din_brake));
+    }
 }
 
 void BMWE65::Task100Ms()
 {
-   uint32_t data[2];
+    if(CANWake)
+    {
+        uint32_t data[2];
 
-   data[0] = 0x8261; //sets max rpm on tach (temp thing)
+        data[0] = 0x8261; //sets max rpm on tach (temp thing)
 
-   /////////////////this can id must be sent once at T15 on to fire up the instrument cluster/////////////////////////
-   if (!this->dashInit)
-   {
-      for (int i = 0; i < 3; i++)
-      {
-         can->Send(0x332, data, 2); //Send on CAN2
-      }
-      this->dashInit=true;
-   }
+        /////////////////this can id must be sent once at T15 on to fire up the instrument cluster/////////////////////////
+        if (!this->dashInit)
+        {
+            for (int i = 0; i < 3; i++)
+            {
+                can->Send(0x332, data, 2); //Send on CAN2
+            }
+            this->dashInit=true;
+        }
+
+        BMWE65::Engine_Data();
+    }
 }
 
 void BMWE65::Task200Ms()
 {
-   uint8_t bytes[8];
+    if(CANWake)
+    {
+
+        if (isE90)
+        {
+            //update shitPos
+            int selectedDir = Param::GetInt(Param::dir);
+
+            if (selectedDir == 0)
+            {
+                //neutral/park
+                this->gear = PARK;
+                gear_BA = 0x03;
+                shiftPos = 0xe1;
+            }
+            else if (selectedDir == -1)
+            {
+                //reverse
+                this->gear = REVERSE;
+                gear_BA = 0x02;
+                shiftPos = 0xd2;
+            }
+            else if (selectedDir == 1)
+            {
+                //forward
+                this->gear = DRIVE;
+                gear_BA = 0x08;
+                shiftPos = 0x78;
+            }
+
+        }
+
+        uint8_t bytes[8];
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-   bytes[0]=shiftPos;  //e1=P  78=D  d2=R  b4=N
-   bytes[1]=0x0c;
-   bytes[2]=0x8f;
-   bytes[3]=Gcount;
-   bytes[4]=0xf0;
+        bytes[0]=shiftPos;  //e1=P  78=D  d2=R  b4=N
+        bytes[1]=0x0c;
+        bytes[2]=0x8f;
+        bytes[3]=Gcount;
+        bytes[4]=0xf0;
 
 
-   can->Send(0x1D2, (uint32_t*)bytes,5); //Send on CAN2
-   ///////////////////////////
-   //Byte 3 is a counter running from 0D through to ED and then back to 0D///
-   //////////////////////////////////////////////
+        can->Send(0x1D2, (uint32_t*)bytes,5); //Send on CAN2
+        ///////////////////////////
+        //Byte 3 is a counter running from 0D through to ED and then back to 0D///
+        //////////////////////////////////////////////
 
-   Gcount=Gcount+0x10;
-   if (Gcount==0xED)
-   {
-      Gcount=0x0D;
-   }
+        Gcount=Gcount+0x10;
+        if (Gcount==0xED)
+        {
+            Gcount=0x0D;
+        }
+    }
 }
 
 void BMWE65::DashOff()
 {
-   this->dashInit=false;
+    this->dashInit=false;
 }
 
 void BMWE65::SendAbsDscMessages(bool Brake_In)
 {
 
 //////////send abs/dsc messages////////////////////////
-   uint8_t a8_brake;
-   uint8_t bytes[8];
+    uint8_t a8_brake;
+    uint8_t bytes[8];
 
-   if(Brake_In)
-   {
-      a8_brake=0x64;
-   }
+    if(Brake_In)
+    {
+        a8_brake=0x64;
+    }
 
-   else
-   {
-      a8_brake=0x04;
-   }
+    else
+    {
+        a8_brake=0x04;
+    }
 
-   int16_t check_A8 = (A81+0x21+0xe0+0x21+0x1f+0x0f+a8_brake+0xa8);
-   check_A8 = (check_A8 / 0x100)+ (check_A8 & 0xff);
-   check_A8 = check_A8 & 0xff;
+    int16_t check_A8 = (A81+0x21+0xe0+0x21+0x1f+0x0f+a8_brake+0xa8);
+    check_A8 = (check_A8 / 0x100)+ (check_A8 & 0xff);
+    check_A8 = check_A8 & 0xff;
 
-   bytes[0]=check_A8;  //checksum
-   bytes[1]=A81; //counter byte
-   bytes[2]=0x21;
-   bytes[3]=0xe0;
-   bytes[4]=0x21;
-   bytes[5]=0x1f;
-   bytes[6]=0x0f;
-   bytes[7]=a8_brake;  //brake off =0x04 , brake on = 0x64.
+    bytes[0]=check_A8;  //checksum
+    bytes[1]=A81; //counter byte
+    bytes[2]=0x21;
+    bytes[3]=0xe0;
+    bytes[4]=0x21;
+    bytes[5]=0x1f;
+    bytes[6]=0x0f;
+    bytes[7]=a8_brake;  //brake off =0x04 , brake on = 0x64.
 
-   can->Send(0x0A8, bytes, 8); //Send on CAN2
+    can->Send(0x0A8, bytes, 8); //Send on CAN2
 
-   bytes[0]=A90; //first counter byte
-   bytes[1]=A91; //second counter byte
-   bytes[2]=0x79;
-   bytes[3]=0xdf;
-   bytes[4]=0x1d;
-   bytes[5]=0xc7;
-   bytes[6]=0xe0;
-   bytes[7]=0x21;
+    bytes[0]=A90; //first counter byte
+    bytes[1]=A91; //second counter byte
+    bytes[2]=0x79;
+    bytes[3]=0xdf;
+    bytes[4]=0x1d;
+    bytes[5]=0xc7;
+    bytes[6]=0xe0;
+    bytes[7]=0x21;
 
-   can->Send(0x0A9, bytes, 8); //Send on CAN2
+    can->Send(0x0A9, bytes, 8); //Send on CAN2
 
-   int16_t check_BA = (gear_BA+0xff+0x0f+BA6+0x0ba);
-   check_BA = (check_BA / 0x100)+ (check_BA & 0xff);
-   check_BA = check_BA & 0xff;
+    int16_t check_BA = (gear_BA+0xff+0x0f+BA6+0x0ba);
+    check_BA = (check_BA / 0x100)+ (check_BA & 0xff);
+    check_BA = check_BA & 0xff;
 
-   bytes[0]=gear_BA; //was just 0x03
-   bytes[1]=0xff;
-   bytes[2]=0x0f;
-   bytes[3]=0x00;
-   bytes[4]=0x00;
-   bytes[5]=check_BA; //BA5; //counter byte 5
-   bytes[6]=BA6; //counter byte 6
+    bytes[0]=gear_BA; //was just 0x03
+    bytes[1]=0xff;
+    bytes[2]=0x0f;
+    bytes[3]=0x00;
+    bytes[4]=0x00;
+    bytes[5]=check_BA; //BA5; //counter byte 5
+    bytes[6]=BA6; //counter byte 6
 
-   can->Send(0x0BA, bytes, 7); //Send on CAN2
+    can->Send(0x0BA, bytes, 7); //Send on CAN2
 
 ////////////////////////////////////////
 ////here we increment the abs/dsc msg counters
 
-   A80++;
-   A81++;
-   A90++;
-   A91++;
-   BA5++;
-   BA6++;
+    A80++;
+    A81++;
+    A90++;
+    A91++;
+    BA5++;
+    BA6++;
 
-   if (BA5==0x5C) //reload initial condition
-   {
-      A80=0xbe;//0x0A8 first counter byte
-      A81=0x00;//0x0A8 second counter byte
-      A90=0xe9;//0x0A9 first counter byte
-      A91=0x00;//0x0A9 second counter byte
-      BA5=0x4d;//0x0BA first counter byte(byte 5)
-      BA6=0x80;//0x0BA second counter byte(byte 6)
-   }
+    if (BA5==0x5C) //reload initial condition
+    {
+        A80=0xbe;//0x0A8 first counter byte
+        A81=0x00;//0x0A8 second counter byte
+        A90=0xe9;//0x0A9 first counter byte
+        A91=0x00;//0x0A9 second counter byte
+        BA5=0x4d;//0x0BA first counter byte(byte 5)
+        BA6=0x80;//0x0BA second counter byte(byte 6)
+    }
+
+}
+
+void BMWE65::Engine_Data()
+{
+    uint8_t bytes[8];
+
+    uint8_t EngRun = 0x00;
+
+    if (Param::GetInt(Param::opmode) == MOD_RUN)
+    {
+        EngRun = 0x60;
+        bytes[4] = 0x9C;
+        bytes[5] = 0x9E;
+    }
+    else
+    {
+        bytes[4] = 0x00;
+        bytes[5] = 0x00;
+    }
+
+    bytes[0] = 0x3C;            //Engine Coolant Temp
+    bytes[1] = 0xFF;            //Engine Oil Temp
+    bytes[2] = EngRun | C1D00;  //Counter
+    bytes[3] = 0xC3;
+
+    bytes[6] = 0xCD;
+    bytes[7] = 0x82;  //Idle Traget
+
+    can->Send(0x1D0,bytes,8); //Send on CAN2
+
+    if (C1D00 == C1D01)
+{
+    C1D00++;
+    if (C1D00 == 0x0F)
+        {
+            C1D00 = 0x00;
+        }
+    }
+    else
+    {
+        C1D01 = C1D00;
+    }
 
 }
 
 bool BMWE65::GetGear(Vehicle::gear& outGear)
 {
-   outGear = gear;    //send the shifter pos
-   return true; //Let caller know we set a valid gear
+    if (isE90)
+    {
+        return false;
+    }
+    outGear = gear;    //send the shifter pos
+    return true; //Let caller know we set a valid gear
 }

--- a/src/CPC.cpp
+++ b/src/CPC.cpp
@@ -1,0 +1,189 @@
+#include <CPC.h>
+static uint8_t ChargePort_IsoStop = 0;
+static uint16_t ChargePort_ACLimit = 0;
+static uint8_t ChargePort_Status = 0;
+static uint8_t ChargePort_Plug = 0;
+static uint8_t ChargePort_Lock = 0;
+
+static bool ChargePort_ReadyCharge = false;
+static bool PlusPres = false;
+static bool RX_357Pres = false;
+static bool ChargeAllow = false;
+
+static uint8_t CP_Mode=0;
+static uint8_t Timer_1Sec=0;
+static uint8_t Timer_60Sec=0;
+
+static uint8_t Cnt400 = 0;
+
+static uint8_t ChargePortStatus =0;
+#define Disconnected 0x0
+#define PluggedIn 0x1
+#define Charging 0x2
+#define PlugButton 0x3
+#define PlugError 0x4
+
+
+
+void CPCClass::SetCanInterface(CanHardware* c)
+{
+    can = c;
+
+    can->RegisterUserMessage(0x357);
+}
+
+void CPCClass::DecodeCAN(int id, uint32_t* data)
+{
+
+    switch(id)
+    {
+    case 0x357:
+        CPCClass::handle357(data);
+        break;
+
+
+    default:
+        break;
+
+    }
+}
+
+void CPCClass::handle357(uint32_t data[2])  //Lim data
+{
+    uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
+
+    ChargePort_IsoStop = bytes[0];
+    ChargePort_ACLimit = bytes[2] * 256 + bytes[1];
+    ChargePort_Status = bytes[3];
+    ChargePort_Plug = bytes[4];
+    ChargePort_Lock = bytes[5];
+
+    //IsoMonStop = ChargePort_IsoStop;
+
+    RX_357Pres = true;
+
+    Param::SetInt(Param::PilotLim,ChargePort_ACLimit);
+
+    Param::SetInt(Param::CableLim,ChargePort_ACLimit);
+
+    uint16_t ACpow = GetInt(Param::ChgAcVolt) * ChargePort_ACLimit; //calculate Max AC power available
+
+    ACpow = GetInt(Param::ChgEff) *0.01 *  ACpow; //Compensate for charger efficiency
+
+    Param::SetInt(Param::Pwrspnt,ACpow); //write limit to parameter
+
+
+    if (ChargePort_Plug == 2 || ChargePort_Plug == 3|| ChargePort_Status != 0x00) //Check Plug is inserted
+    {
+        ChargePortStatus = PluggedIn;
+        PlusPres = true;
+    }
+    else
+    {
+        ChargePortStatus = Disconnected;
+        PlusPres = false;
+
+    }
+
+    if(ChargePort_Status == 0x03)//check ac connected and ready to charge
+    {
+        ChargePort_ReadyCharge = true;
+    }
+    else
+    {
+        ChargePort_ReadyCharge = false;
+    }
+
+
+    //0=Absent, 1=ACStd, 2=ACchg, 3=Error
+    CP_Mode = ChargePortStatus;
+
+    if (ChargePort_Status == 0x03)
+    {
+        CP_Mode = 2;
+    }
+
+    if (ChargePort_Status == 0x07 || ChargePort_Plug == 0x03)
+    {
+        ChargePortStatus = PlugError;
+        CP_Mode =3;
+        ChargePort_ReadyCharge = false;
+    }
+
+    Param::SetInt(Param::PlugDet,PlusPres);
+    Param::SetInt(Param::PilotTyp,CP_Mode);
+}
+
+
+void CPCClass::Task10Ms()
+{
+
+}
+
+
+void CPCClass::Task200Ms()
+{
+    uint8_t bytes[8]; //CAN bytes
+
+    Cnt400++;
+
+    if(Cnt400 == 2)
+    {
+        Cnt400 =0;
+
+
+        if(ChargeAllow == true)
+        {
+            bytes[0] = 0x01; //allow starting
+        }
+        else
+        {
+            bytes[0] = 0x02; //stop charge
+        }
+        bytes[1] = 0x00;
+        bytes[2] = 0x00;
+        bytes[3] = 0x00;
+        bytes[4] = 0x00;
+        bytes[5] = 0x00;
+        bytes[6] = 0x00;
+        bytes[7] = 0x00;
+
+        can->Send(0x358, (uint32_t*)bytes,8); //
+    }
+}
+
+void CPCClass::Task100Ms()
+{
+
+}
+
+void CPCClass::Chg_Timers()
+{
+    Timer_1Sec--;   //decrement the loop counter
+
+    if(Timer_1Sec==0)   //1 second has elapsed
+    {
+        Timer_1Sec=5;
+        Timer_60Sec--;  //decrement the 1 minute counter
+        if(Timer_60Sec==0)
+        {
+            Timer_60Sec=60;
+        }
+
+    }
+}
+
+bool CPCClass::DCFCRequest(bool RunCh)
+{
+    RunCh = RunCh;
+    return false; //No DC Charging support
+}
+
+bool CPCClass::ACRequest(bool RunCh)
+{
+    ChargeAllow = RunCh;
+    if (ChargePort_ReadyCharge == false){return false;}
+    else{return true;}
+    //return ChargePort_ReadyCharge; //No AC Charging support right now
+}
+

--- a/src/ElconCharger.cpp
+++ b/src/ElconCharger.cpp
@@ -1,0 +1,83 @@
+#include <ElconCharger.h>
+
+static bool ChRun=false;
+static uint16_t HVvolts=0;
+static uint16_t HVspnt=0;
+static uint16_t HVpwr=0;
+static uint16_t HVcur=0;
+static uint16_t calcpwr=0;
+static uint16_t ChargerHVbatteryVolts =0;
+static uint16_t ChargerHVcurrent = 0;
+static uint8_t ChargerStatus = 0;
+
+void ElconCharger::SetCanInterface(CanHardware* c)
+{
+    can = c;
+
+    can->RegisterUserMessage(0x18FF50E5);
+
+}
+
+void ElconCharger::DecodeCAN(int id, uint32_t data[2])
+{
+    uint8_t* bytes = (uint8_t*)data;
+    if (id == 0x18FF50E5)
+    {
+        ChargerHVbatteryVolts = (bytes[0] * 256 + bytes[1]) * 0.1;
+        ChargerHVcurrent = (bytes[2] * 256 + bytes[3]) * 0.1;
+        ChargerStatus = bytes[4];
+    }
+}
+
+void ElconCharger::Task200Ms()
+{
+    uint8_t bytes[8];
+    if(ChRun == true)
+    {
+        HVvolts=Param::GetInt(Param::udc);
+        HVspnt=Param::GetInt(Param::Voltspnt);
+        HVpwr=Param::GetInt(Param::Pwrspnt);
+
+        HVcur = Param::GetInt(Param::BMS_ChargeLim);//BMS charge current limit but needs to be power for most AC charger types.
+        if(HVcur > 1000)
+        {
+            calcpwr = 12000;
+        }
+        else
+        {
+            calcpwr = HVcur*HVvolts;
+        }
+
+        HVpwr=MIN(HVpwr,calcpwr);
+
+        HVcur = HVpwr / HVvolts;
+
+
+        bytes[0] = (HVspnt*10)>>8;//HV voltage setpoint highbyte
+        bytes[1] = (HVspnt*10)&0xFF;//HV voltage setpoint lowbyte
+        bytes[2] = (HVcur*10)>>8;//HV current setpoint highbyte
+        bytes[3] = (HVcur*10)&0xFF;//HV current setpoint lowbyte
+        bytes[4] = 0x00;
+        bytes[5] = 0x00;
+        bytes[6] = 0x00;
+        bytes[7] = 0x00;
+    }
+
+    can->Send(0x1806E5F4, (uint32_t*)bytes,8);
+}
+
+
+bool ElconCharger::ControlCharge(bool RunCh, bool ACReq)
+{
+    if(RunCh == true && ACReq == true)//check okay to keep charging, Elcon is dumb charger so no handling required here.
+    {
+        ChRun = ACReq;
+        return true;
+
+    }
+    else
+    {
+        return false;
+    }
+}
+

--- a/src/ElconCharger.cpp
+++ b/src/ElconCharger.cpp
@@ -20,13 +20,23 @@ void ElconCharger::SetCanInterface(CanHardware* c)
 
 void ElconCharger::DecodeCAN(int id, uint32_t data[2])
 {
-    uint8_t* bytes = (uint8_t*)data;
-    if (id == 0x18FF50E5)
+    switch (id)
     {
-        ChargerHVbatteryVolts = (bytes[0] * 256 + bytes[1]) * 0.1;
-        ChargerHVcurrent = (bytes[2] * 256 + bytes[3]) * 0.1;
-        ChargerStatus = bytes[4];
+    case 0x18FF50E5:
+        ElconCharger::handle18FF50E5(data);
+        break;
+
+    default:
+        break;
     }
+}
+
+void ElconCharger::handle18FF50E5(uint32_t data[2])
+{
+    uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes.
+    ChargerHVbatteryVolts = (bytes[0] * 256 + bytes[1]) * 0.1;
+    ChargerHVcurrent = (bytes[2] * 256 + bytes[3]) * 0.1;
+    ChargerStatus = bytes[4];
 }
 
 void ElconCharger::Task200Ms()

--- a/src/GS450H.cpp
+++ b/src/GS450H.cpp
@@ -523,15 +523,15 @@ void GS450HClass::Task1Ms()
          htm_data[26]=(mg2_torque/2) & 0xFF; //positive is forward
          htm_data[27]=((mg2_torque/2)>>8) & 0xFF;
       }
-
+*/
       //This data has moved!
 
-      htm_data[85]=(-5000)&0xFF;  // regen ability of battery
-      htm_data[86]=((-5000)>>8);
+      htm_data[79]=(-5000)&0xFF;  // regen ability of battery
+      htm_data[80]=((-5000)>>8);
 
-      htm_data[87]=(-10000)&0xFF;  // discharge ability of battery
-      htm_data[88]=((-10000)>>8);
-
+      htm_data[81]=(10000)&0xFF;  // discharge ability of battery
+      htm_data[82]=((10000)>>8);
+/*
       //checksum
      if(++frame_count & 0x01)
       {

--- a/src/GS450H.cpp
+++ b/src/GS450H.cpp
@@ -350,7 +350,6 @@ void GS450HClass::Task1Ms()
          statusInv=1;
          dc_bus_voltage=(((mth_data[100]|mth_data[101]<<8)-5)/2);
          temp_inv_water=(mth_data[42]|mth_data[43]<<8);
-         if(temp_inv_water>120) temp_inv_water=120;//bodge to prevernt overtemp wrap until is fixed properly.
          temp_inv_inductor=(mth_data[86]|mth_data[87]<<8);
          mg1_speed=mth_data[6]|mth_data[7]<<8;
          mg2_speed=mth_data[38]|mth_data[39]<<8;

--- a/src/RearOutlanderinverter.cpp
+++ b/src/RearOutlanderinverter.cpp
@@ -1,0 +1,111 @@
+/*
+ * This file is part of the ZombieVerter project.
+ *
+ * Copyright (C) 2021-2022  Johannes Huebner <dev@johanneshuebner.com>
+ * 	                        Damien Maguire <info@evbmw.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "rearoutlanderinverter.h"
+#include "my_math.h"
+#include "params.h"
+
+RearOutlanderInverter::RearOutlanderInverter()
+{
+   //ctor
+}
+
+void RearOutlanderInverter::SetCanInterface(CanHardware* c)
+{
+   can = c;
+
+   can->RegisterUserMessage(0x289);//Outlander Inv Msg
+   can->RegisterUserMessage(0x299);//Outlander Inv Msg
+   can->RegisterUserMessage(0x733);//Outlander Inv Msg
+}
+
+void RearOutlanderInverter::DecodeCAN(int id, uint32_t data[2])
+{
+   uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
+   switch (id)
+   {
+   case 0x289:
+      //speed = (((data[0] >> 8)& 0xFF00) | ((data[0] >> 24) & 0x0FF)) - 20000;
+      //voltage = ((data[1] & 0xFF) << 8) | ((data[1] >> 8) & 0xFF);
+      speed = (bytes[2] * 256 | bytes[3]) - 20000;
+      voltage = (bytes[4] * 256) + bytes[5];
+      break;
+   case 0x299:
+      //motor_temp = bytes[0] -40;
+      inv_temp = ((bytes[1]-40) + (bytes[4] - 40)) / 2;
+      break;
+   case 0x733:
+      motor_temp = bytes[0] -40; //
+      break;
+
+
+   }
+}
+
+
+
+void RearOutlanderInverter::SetTorque(float torquePercent)
+{
+   final_torque_request = (((torquePercent * 2000) / 100.0f ) * -1) + 10000; // *-1 reverses torque direction
+
+
+   Param::SetInt(Param::torque,final_torque_request);//post processed final torque value sent to inv to web interface
+}
+
+void RearOutlanderInverter::Task10Ms()
+{
+   run10ms++;
+
+   //Run every 50 ms
+   if (run10ms == 5)
+   {
+      uint32_t data[2];
+      run10ms = 0;
+
+      data[0] = (final_torque_request & 0xff)<<24 | (final_torque_request & 0xff00)<<8; // swap high and low bytes and shift 16 bit left
+	  // enable inverter. Byte 6 0x0 to disable inverter, 0x3 for drive ( torque > 0 )
+	  data[1] = (final_torque_request == 10000 ? 0x00 : 0x03)<<16;
+
+      can->Send(0x287, data, 8);
+   }
+}
+
+void RearOutlanderInverter::Task100Ms()
+{
+  int opmode = Param::GetInt(Param::opmode);
+  if(opmode==MOD_RUN)
+      {
+    uint32_t data[8];
+
+   data[0] = 0x00000030;
+   data[1] = 0x00000000;
+
+   can->Send(0x371, data, 8);
+
+   data[0] = 0x39140000; // inverter enabled B2 0x10 - 0x1F
+
+   can->Send(0x285, data, 8);
+
+   data[0] = 0x3D000000;
+   data[1] = 0x00210000;
+
+   can->Send(0x286, data, 8);
+
+      }
+}

--- a/src/hwinit.cpp
+++ b/src/hwinit.cpp
@@ -57,7 +57,6 @@ void clock_setup(void)
    rcc_periph_clock_enable(RCC_GPIOE);
    rcc_periph_clock_enable(RCC_USART3);
    rcc_periph_clock_enable(RCC_USART2);//GS450H Inverter Comms
-   rcc_periph_clock_enable(RCC_USART1);//LIN Comms
    rcc_periph_clock_enable(RCC_TIM1); //GS450H oil pump pwm
    rcc_periph_clock_enable(RCC_TIM2); //GS450H 500khz usart clock
    rcc_periph_clock_enable(RCC_TIM3); //PWM outputs
@@ -121,24 +120,6 @@ void usart2_setup(void)
    usart_set_flow_control(USART2, USART_FLOWCONTROL_NONE);
    usart_enable(USART2);
 }
-
-void usart1_setup(void)
-{
-   /* Setup GPIO pin GPIO_USART1_TX and GPIO_USART1_RX. */
-   gpio_set_mode(GPIOA, GPIO_MODE_OUTPUT_50_MHZ,
-                 GPIO_CNF_OUTPUT_ALTFN_PUSHPULL, GPIO_USART1_TX);
-   gpio_set_mode(GPIOA, GPIO_MODE_INPUT,
-                 GPIO_CNF_INPUT_FLOAT, GPIO_USART1_RX);
-   usart_set_baudrate(USART1, 19200);
-   usart_set_databits(USART1, 8);
-   usart_set_stopbits(USART1, USART_STOPBITS_1);
-   usart_set_mode(USART1, USART_MODE_TX_RX);
-   usart_set_parity(USART1, USART_PARITY_NONE);
-   usart_set_flow_control(USART1, USART_FLOWCONTROL_NONE);
-   usart_enable(USART1);
-}
-
-
 
 /**
 * Enable Timer refresh and break interrupts

--- a/src/i3LIM.cpp
+++ b/src/i3LIM.cpp
@@ -2,37 +2,37 @@
 
 enum class ChargeStatus : uint8_t
 {
-   // no led
-   NotRdy = 0x0,
+    // no led
+    NotRdy = 0x0,
 
-   // dc ccs mode
-   Init = 0x1,
+    // dc ccs mode
+    Init = 0x1,
 
-   Rdy = 0x2
+    Rdy = 0x2
 };
 
 enum class ChargeRequest : uint8_t
 {
-   EndCharge = 0x0,
-   Charge = 0x1
+    EndCharge = 0x0,
+    Charge = 0x1
 };
 
 enum class ChargeReady : uint8_t
 {
-   NotRdy = 0x0,
-   Rdy = 0x1
+    NotRdy = 0x0,
+    Rdy = 0x1
 };
 
 enum class ChargePhase : uint8_t
 {
-   Standby = 0x0,
-   Initialisation = 0x1,
-   Subpoena = 0x2,
-   EnergyTransfer = 0x3,
-   Shutdown = 0x4,
-   CableTest = 0x9,
-   Reserved = 0xE,
-   InvalidSignal = 0xF
+    Standby = 0x0,
+    Initialisation = 0x1,
+    Subpoena = 0x2,
+    EnergyTransfer = 0x3,
+    Shutdown = 0x4,
+    CableTest = 0x9,
+    Reserved = 0xE,
+    InvalidSignal = 0xF
 };
 
 
@@ -74,13 +74,13 @@ static uint8_t CCSI_Spnt=0;
 
 void i3LIMClass::SetCanInterface(CanHardware* c)
 {
-   can = c;
+    can = c;
 
-   can->RegisterUserMessage(0x3B4);
-   can->RegisterUserMessage(0x272);
-   can->RegisterUserMessage(0x29E);
-   can->RegisterUserMessage(0x2B2);
-   can->RegisterUserMessage(0x2EF);
+    can->RegisterUserMessage(0x3B4);
+    can->RegisterUserMessage(0x272);
+    can->RegisterUserMessage(0x29E);
+    can->RegisterUserMessage(0x2B2);
+    can->RegisterUserMessage(0x2EF);
 }
 
 void i3LIMClass::DecodeCAN(int id, uint32_t* data)
@@ -89,23 +89,23 @@ void i3LIMClass::DecodeCAN(int id, uint32_t* data)
     switch(id)
     {
     case 0x3B4:
-    i3LIMClass::handle3B4(data);
-    break;
+        i3LIMClass::handle3B4(data);
+        break;
     case 0x272:
-    i3LIMClass::handle272(data);
-    break;
+        i3LIMClass::handle272(data);
+        break;
     case 0x29E:
-    i3LIMClass::handle29E(data);
-    break;
+        i3LIMClass::handle29E(data);
+        break;
     case 0x2B2:
-    i3LIMClass::handle2B2(data);
-    break;
+        i3LIMClass::handle2B2(data);
+        break;
     case 0x2EF:
-    i3LIMClass::handle2EF(data);
-    break;
+        i3LIMClass::handle2EF(data);
+        break;
 
     default:
-    break;
+        break;
 
     }
 }
@@ -113,132 +113,147 @@ void i3LIMClass::DecodeCAN(int id, uint32_t* data)
 void i3LIMClass::handle3B4(uint32_t data[2])  //Lim data
 
 {
-   /*
-   0x3B4 D4 low nible: status pilot
-   0=no pilot
-   1=10-96%PWM not charge ready
-   2=10-96%PWM charge ready
-   3=error
-   4=5% not charge ready
-   5=5% charge ready
-   6=pilot static
-   */
+    /*
+    0x3B4 D4 low nible: status pilot
+    0=no pilot
+    1=10-96%PWM not charge ready
+    2=10-96%PWM charge ready
+    3=error
+    4=5% not charge ready
+    5=5% charge ready
+    6=pilot static
+    */
 
-   uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
-   uint8_t CP_Amps=bytes[0];
-   Param::SetInt(Param::PilotLim,CP_Amps);
-   uint8_t PP_Amps=bytes[1];
-   Param::SetInt(Param::CableLim,PP_Amps);
-   bool PP=(bytes[2]&0x1);
-   Param::SetInt(Param::PlugDet,PP);
-   CP_Mode=(bytes[4]&0x7);
+    uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
+    uint8_t CP_Amps=bytes[0];
+    Param::SetInt(Param::PilotLim,CP_Amps);
+    uint8_t PP_Amps=bytes[1];
+    Param::SetInt(Param::CableLim,PP_Amps);
+    bool PP=(bytes[2]&0x1);
+    Param::SetInt(Param::PlugDet,PP);
+    CP_Mode=(bytes[4]&0x7);
 
-   Param::SetInt(Param::PilotTyp,CP_Mode);
+    Param::SetInt(Param::PilotTyp,CP_Mode);
 
-   Cont_Volts=bytes[7]*2;
-   // Cont_Volts=FP_MUL(Cont_Volts,2);
-   Param::SetInt(Param::CCS_V_Con,Cont_Volts);//voltage measured on the charger side of the hv ccs contactors in the car
-   ChargeType=bytes[6];
+
+    uint8_t ChargePort_ACLimit = CP_Amps;
+
+    if(PP_Amps < CP_Amps)
+    {
+        ChargePort_ACLimit = PP_Amps;
+    }
+
+    uint16_t ACpow = GetInt(Param::ChgAcVolt) * ChargePort_ACLimit; //calculate Max AC power available
+
+    ACpow = GetInt(Param::ChgEff) *0.01 *  ACpow; //Compensate for charger efficiency
+
+    Param::SetInt(Param::Pwrspnt,ACpow); //write limit to parameter
+
+
+    Cont_Volts=bytes[7]*2;
+    // Cont_Volts=FP_MUL(Cont_Volts,2);
+    Param::SetInt(Param::CCS_V_Con,Cont_Volts);//voltage measured on the charger side of the hv ccs contactors in the car
+    ChargeType=bytes[6];
 
 }
 
 void i3LIMClass::handle29E(uint32_t data[2])  //Lim data. Available current and voltage from the ccs charger
 
 {
-   uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
-   uint16_t V_Avail=((bytes[2]<<8)|(bytes[1]));
-   V_Avail=FP_TOINT(FP_DIV(V_Avail,10));
-   Param::SetInt(Param::CCS_V_Avail,V_Avail);//available voltage from ccs charger
+    uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
+    uint16_t V_Avail=((bytes[2]<<8)|(bytes[1]));
+    V_Avail=FP_TOINT(FP_DIV(V_Avail,10));
+    Param::SetInt(Param::CCS_V_Avail,V_Avail);//available voltage from ccs charger
 
-   uint16_t I_Avail=((bytes[4]<<8)|(bytes[3]));
-   I_Avail=FP_TOINT(FP_DIV(I_Avail,10));
-   Param::SetInt(Param::CCS_I_Avail,I_Avail);//available current from ccs charger
+    uint16_t I_Avail=((bytes[4]<<8)|(bytes[3]));
+    I_Avail=FP_TOINT(FP_DIV(I_Avail,10));
+    Param::SetInt(Param::CCS_I_Avail,I_Avail);//available current from ccs charger
 
-   CCS_Iso = (bytes[0]>>6)&0x03;
-   CCS_IntStat = (bytes[0]>>2)&0x0f;
-   Param::SetInt(Param::CCS_COND,CCS_IntStat);//update evse condition on webui
+    CCS_Iso = (bytes[0]>>6)&0x03;
+    CCS_IntStat = (bytes[0]>>2)&0x0f;
+    Param::SetInt(Param::CCS_COND,CCS_IntStat);//update evse condition on webui
 
 }
 
 void i3LIMClass::handle2B2(uint32_t data[2])  //Lim data. Current and Votage as measured by the ccs charger
 
 {
-   uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
-   uint16_t CCS_Vmeas=((bytes[1]<<8)|(bytes[0]));
-   CCS_Vmeas=FP_TOINT(FP_DIV(CCS_Vmeas,10));
-   Param::SetInt(Param::CCS_V,CCS_Vmeas);//Voltage measurement from ccs charger
+    uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
+    uint16_t CCS_Vmeas=((bytes[1]<<8)|(bytes[0]));
+    CCS_Vmeas=FP_TOINT(FP_DIV(CCS_Vmeas,10));
+    Param::SetInt(Param::CCS_V,CCS_Vmeas);//Voltage measurement from ccs charger
 
-   uint16_t CCS_Imeas=((bytes[3]<<8)|(bytes[2]));
-   CCS_Imeas=FP_TOINT(FP_DIV(CCS_Imeas,10));
-   Param::SetInt(Param::CCS_I,CCS_Imeas);//Current measurement from ccs charger
-   [[maybe_unused]] uint8_t Batt_Cmp=bytes[4]&0xc0;    //battrery compatability flag from charger? upper two bits of byte 4.
+    uint16_t CCS_Imeas=((bytes[3]<<8)|(bytes[2]));
+    CCS_Imeas=FP_TOINT(FP_DIV(CCS_Imeas,10));
+    Param::SetInt(Param::CCS_I,CCS_Imeas);//Current measurement from ccs charger
+    [[maybe_unused]] uint8_t Batt_Cmp=bytes[4]&0xc0;    //battrery compatability flag from charger? upper two bits of byte 4.
 
-   CCS_Ilim = (bytes[5]>>4)&0x03;
-   CCS_Vlim = (bytes[5]>>6)&0x03;
-   CCS_Stat = bytes[4]&0x03;
-   CCS_Malf = (bytes[4]>>2)&0x03;
-   CCS_Bmalf = bytes[5]&0x03;
-   CCS_Stop = (bytes[5]>>2)&0x03;
+    CCS_Ilim = (bytes[5]>>4)&0x03;
+    CCS_Vlim = (bytes[5]>>6)&0x03;
+    CCS_Stat = bytes[4]&0x03;
+    CCS_Malf = (bytes[4]>>2)&0x03;
+    CCS_Bmalf = bytes[5]&0x03;
+    CCS_Stop = (bytes[5]>>2)&0x03;
 }
 
 void i3LIMClass::handle2EF(uint32_t data[2])  //Lim data. Min available voltage from the ccs charger.
 
 {
-   uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
-   uint16_t minV_Avail=((bytes[1]<<8)|(bytes[0]));
-   minV_Avail=FP_TOINT(FP_DIV(minV_Avail,10));
-   Param::SetInt(Param::CCS_V_Min,minV_Avail);//minimum available voltage from ccs charger
+    uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
+    uint16_t minV_Avail=((bytes[1]<<8)|(bytes[0]));
+    minV_Avail=FP_TOINT(FP_DIV(minV_Avail,10));
+    Param::SetInt(Param::CCS_V_Min,minV_Avail);//minimum available voltage from ccs charger
 
-   CCS_Plim = (bytes[6]>>4)&0x03;
+    CCS_Plim = (bytes[6]>>4)&0x03;
 
 }
 
 void i3LIMClass::handle272(uint32_t data[2])  //Lim data. CCS contactor state and charge flap open/close status.
 {
-   uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
+    uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
 // Only the top 6-bits indicate the contactor state
-   uint8_t Cont_stat=bytes[2] >> 2;
-   Param::SetInt(Param::CCS_Contactor,Cont_stat);
+    uint8_t Cont_stat=bytes[2] >> 2;
+    Param::SetInt(Param::CCS_Contactor,Cont_stat);
 
-   uint8_t drmodes=bytes[2]&0x03;
-   Param::SetInt(Param::CP_DOOR,drmodes);
+    uint8_t drmodes=bytes[2]&0x03;
+    Param::SetInt(Param::CP_DOOR,drmodes);
 }
 
 
 void i3LIMClass::Task10Ms()
 {
-   uint16_t V_Batt=Param::GetInt(Param::udc)*10;
-   uint8_t V_Batt2=(Param::GetInt(Param::udc))/4;
-   int32_t I_Batt=(Param::GetInt(Param::idc)+819)*10;//(Param::GetInt(Param::idc);FP_FROMINT
-   //I_Batt=0xa0a0;
-   //uint16_t SOC_Local=25*10;//(Param::GetInt(Param::SOC))*10;
-   //uint16_t SOC_Local=(Param::GetInt(Param::SOC))*10;
-   uint16_t SOC_Local=(Param::GetInt(Param::SOCFC))*10;
-   uint8_t bytes[8]; //seems to be from i3 BMS.
-   bytes[0] = I_Batt & 0xFF;  //Battery current LSB. Scale 0.1 offset 819.2. 16 bit unsigned int
-   bytes[1] = I_Batt >> 8;  //Battery current MSB. Scale 0.1 offset 819.2.  16 bit unsigned int
-   bytes[2] = V_Batt & 0xFF;  //Battery voltage LSB. Scale 0.1. 16 bit unsigned int.
-   bytes[3] = V_Batt >> 8;  //Battery voltage MSB. Scale 0.1. 16 bit unsigned int.
-   bytes[4] = SOC_Local & 0xFF;;  //Battery SOC LSB. 12 bit unsigned int. Scale 0.1. 0-100%
-   bytes[5] = SOC_Local >> 8;  //Battery SOC MSB. 12 bit unsigned int. Scale 0.1. 0-100%
-   bytes[6] = 0x65;  //Low nibble battery status. Seem to need to be 0x5.
-   bytes[7] = V_Batt2;  //zwischenkreis. Battery voltage. Scale 4. 8 bit unsigned int.
+    uint16_t V_Batt=Param::GetInt(Param::udc)*10;
+    uint8_t V_Batt2=(Param::GetInt(Param::udc))/4;
+    int32_t I_Batt=(Param::GetInt(Param::idc)+819)*10;//(Param::GetInt(Param::idc);FP_FROMINT
+    //I_Batt=0xa0a0;
+    //uint16_t SOC_Local=25*10;//(Param::GetInt(Param::SOC))*10;
+    //uint16_t SOC_Local=(Param::GetInt(Param::SOC))*10;
+    uint16_t SOC_Local=(Param::GetInt(Param::SOCFC))*10;
+    uint8_t bytes[8]; //seems to be from i3 BMS.
+    bytes[0] = I_Batt & 0xFF;  //Battery current LSB. Scale 0.1 offset 819.2. 16 bit unsigned int
+    bytes[1] = I_Batt >> 8;  //Battery current MSB. Scale 0.1 offset 819.2.  16 bit unsigned int
+    bytes[2] = V_Batt & 0xFF;  //Battery voltage LSB. Scale 0.1. 16 bit unsigned int.
+    bytes[3] = V_Batt >> 8;  //Battery voltage MSB. Scale 0.1. 16 bit unsigned int.
+    bytes[4] = SOC_Local & 0xFF;;  //Battery SOC LSB. 12 bit unsigned int. Scale 0.1. 0-100%
+    bytes[5] = SOC_Local >> 8;  //Battery SOC MSB. 12 bit unsigned int. Scale 0.1. 0-100%
+    bytes[6] = 0x65;  //Low nibble battery status. Seem to need to be 0x5.
+    bytes[7] = V_Batt2;  //zwischenkreis. Battery voltage. Scale 4. 8 bit unsigned int.
 
-   can->Send(0x112, (uint32_t*)bytes,8); //
+    can->Send(0x112, (uint32_t*)bytes,8); //
 
-   ctr_20ms++;
-   if(ctr_20ms==2)
-   {
-      ctr_20ms=0;
+    ctr_20ms++;
+    if(ctr_20ms==2)
+    {
+        ctr_20ms=0;
 
-      //Vehicle speed msg should be 20ms. Lets try 10...
-      bytes[0] = 0x7c;
-      bytes[1] = 0xcb;
-      bytes[2] = 0x00;
-      bytes[3] = 0x00;
-      bytes[4] = 0x8a;
-      can->Send(0x1a1, (uint32_t*)bytes,5); // average 20ms
-   }
+        //Vehicle speed msg should be 20ms. Lets try 10...
+        bytes[0] = 0x7c;
+        bytes[1] = 0xcb;
+        bytes[2] = 0x00;
+        bytes[3] = 0x00;
+        bytes[4] = 0x8a;
+        can->Send(0x1a1, (uint32_t*)bytes,5); // average 20ms
+    }
 
 }
 
@@ -246,180 +261,180 @@ void i3LIMClass::Task10Ms()
 void i3LIMClass::Task200Ms()
 {
 
-   uint8_t bytes[8];
+    uint8_t bytes[8];
 //Lim command 3. Used in DC mode.
-   if(CP_Mode==0x4||CP_Mode==0x5) bytes[0] = 0xFC;
-   else bytes[0] = 0xFD;
+    if(CP_Mode==0x4||CP_Mode==0x5) bytes[0] = 0xFC;
+    else bytes[0] = 0xFD;
 //bytes[0] = 0xFD;// FD at standby, change to FC on 5% pilot. Change back to FD during energy transfer
-   bytes[1] = 0xFF;//these bytes are used as a timer during energy transfer but not at setup
-   bytes[2] = (uint8_t)Chg_Phase<<4;  //upper nibble seems to be a mode command to the ccs station. 0 when off, 9 when in constant current phase of cycle.
-   //more investigation needed here...
-   //Lower nibble seems to be intended for two end charge commands each of 2 bits.
+    bytes[1] = 0xFF;//these bytes are used as a timer during energy transfer but not at setup
+    bytes[2] = (uint8_t)Chg_Phase<<4;  //upper nibble seems to be a mode command to the ccs station. 0 when off, 9 when in constant current phase of cycle.
+    //more investigation needed here...
+    //Lower nibble seems to be intended for two end charge commands each of 2 bits.
 
-   bytes[4] = 0xff;
-   bytes[5] = 0xff;
-   bytes[6] = 0xff;
-   bytes[7] = 0xff;
-   can->Send(0x2fa, (uint32_t*)bytes,8); // this msg varies from 82ms to 1s intervals.
+    bytes[4] = 0xff;
+    bytes[5] = 0xff;
+    bytes[6] = 0xff;
+    bytes[7] = 0xff;
+    can->Send(0x2fa, (uint32_t*)bytes,8); // this msg varies from 82ms to 1s intervals.
 
 
 //////////////////////////////////////////////////////////////////////////////
 //Possibly needed for dc ccs.
 ////////////////////////////////////
 
-   //uint16_t SOC_Local=(Param::GetInt(Param::SOC))*2;
-   uint16_t SOC_Local=(Param::GetInt(Param::SOCFC))*2;
-   bytes[0] = 0x2c;//BMS soc msg. May need to be dynamic
-   bytes[1] = 0xe2;
-   bytes[2] = 0x10;
-   bytes[3] = 0xa3;
+    //uint16_t SOC_Local=(Param::GetInt(Param::SOC))*2;
+    uint16_t SOC_Local=(Param::GetInt(Param::SOCFC))*2;
+    bytes[0] = 0x2c;//BMS soc msg. May need to be dynamic
+    bytes[1] = 0xe2;
+    bytes[2] = 0x10;
+    bytes[3] = 0xa3;
 //bytes[4] = 0x30;    //display soc. scale 0.5.
-   bytes[4] = SOC_Local;    //display soc. scale 0.5.
-   bytes[5] = 0xff;
-   bytes[6] = 0x02;
-   bytes[7] = 0xff;
-   can->Send(0x432, (uint32_t*)bytes,8); // average 190ms
+    bytes[4] = SOC_Local;    //display soc. scale 0.5.
+    bytes[5] = 0xff;
+    bytes[6] = 0x02;
+    bytes[7] = 0xff;
+    can->Send(0x432, (uint32_t*)bytes,8); // average 190ms
 
-   bytes[0] = 0x00;//network management
-   bytes[1] = 0x00;
-   bytes[2] = 0x00;
-   bytes[3] = 0x00;
-   bytes[4] = 0x50;
-   bytes[5] = 0x00;
-   bytes[6] = 0x00;
-   bytes[7] = 0x1a;
-   can->Send(0x51a, (uint32_t*)bytes,8); // average 640ms
+    bytes[0] = 0x00;//network management
+    bytes[1] = 0x00;
+    bytes[2] = 0x00;
+    bytes[3] = 0x00;
+    bytes[4] = 0x50;
+    bytes[5] = 0x00;
+    bytes[6] = 0x00;
+    bytes[7] = 0x1a;
+    can->Send(0x51a, (uint32_t*)bytes,8); // average 640ms
 
-   bytes[0] = 0x00;//network management.May need to be dynamic
-   bytes[1] = 0x00;
-   bytes[2] = 0x00;
-   bytes[3] = 0x00;
-   bytes[4] = 0xfd;
-   bytes[5] = 0x3c;
-   bytes[6] = 0xff;
-   bytes[7] = 0x40;
-   can->Send(0x540, (uint32_t*)bytes,8); // average 640ms
+    bytes[0] = 0x00;//network management.May need to be dynamic
+    bytes[1] = 0x00;
+    bytes[2] = 0x00;
+    bytes[3] = 0x00;
+    bytes[4] = 0xfd;
+    bytes[5] = 0x3c;
+    bytes[6] = 0xff;
+    bytes[7] = 0x40;
+    can->Send(0x540, (uint32_t*)bytes,8); // average 640ms
 
-   bytes[0] = 0x40;//network management zgw
-   bytes[1] = 0x10;
-   bytes[2] = 0x20;
-   bytes[3] = 0x00;
-   bytes[4] = 0x00;
-   bytes[5] = 0x00;
-   bytes[6] = 0x00;
-   bytes[7] = 0x00;
-   can->Send(0x510, (uint32_t*)bytes,8); // average 640ms
+    bytes[0] = 0x40;//network management zgw
+    bytes[1] = 0x10;
+    bytes[2] = 0x20;
+    bytes[3] = 0x00;
+    bytes[4] = 0x00;
+    bytes[5] = 0x00;
+    bytes[6] = 0x00;
+    bytes[7] = 0x00;
+    can->Send(0x510, (uint32_t*)bytes,8); // average 640ms
 
-   ctr_1second++;
-   if(ctr_1second==5)//only send every 1 second.
-   {
-      ctr_1second=0;
-      sec_328++; //increment seconds counter.
-      bytes[0] = sec_328;//rtc msg. needs to be every 1 sec. first 32 bits are 1 second wrap counter
-      bytes[1] = sec_328<<8;
-      bytes[2] = sec_328<<16;
-      bytes[3] = sec_328<<24;
-      bytes[4] = 0x87;    //day counter 16 bit.
-      bytes[5] = 0x1e;
-      can->Send(0x328, (uint32_t*)bytes,6);
+    ctr_1second++;
+    if(ctr_1second==5)//only send every 1 second.
+    {
+        ctr_1second=0;
+        sec_328++; //increment seconds counter.
+        bytes[0] = sec_328;//rtc msg. needs to be every 1 sec. first 32 bits are 1 second wrap counter
+        bytes[1] = sec_328<<8;
+        bytes[2] = sec_328<<16;
+        bytes[3] = sec_328<<24;
+        bytes[4] = 0x87;    //day counter 16 bit.
+        bytes[5] = 0x1e;
+        can->Send(0x328, (uint32_t*)bytes,6);
 
 
 
 //if(Param::GetInt(Param::opmode)==MOD_RUN) bytes[0] = 0xfb;//f1=no obd reset. fb=obd reset.
 //if(Param::GetInt(Param::opmode)!=MOD_RUN) bytes[0] = 0xf1;//f1=no obd reset. fb=obd reset.
-      bytes[0] = 0xf1;
-      bytes[1] = 0xff;
-      can->Send(0x3e8, (uint32_t*)bytes,2);
+        bytes[0] = 0xf1;
+        bytes[1] = 0xff;
+        can->Send(0x3e8, (uint32_t*)bytes,2);
 
-      bytes[0] = 0xc0;//engine info? rex?
-      bytes[1] = 0xf9;
-      bytes[2] = 0x80;
-      bytes[3] = 0xe0;
-      bytes[4] = 0x43;
-      bytes[5] = 0x3c;
-      bytes[6] = 0xc3;//0x3=park
-      bytes[7] = 0xff;
-      can->Send(0x3f9, (uint32_t*)bytes,8); //average 1s
+        bytes[0] = 0xc0;//engine info? rex?
+        bytes[1] = 0xf9;
+        bytes[2] = 0x80;
+        bytes[3] = 0xe0;
+        bytes[4] = 0x43;
+        bytes[5] = 0x3c;
+        bytes[6] = 0xc3;//0x3=park
+        bytes[7] = 0xff;
+        can->Send(0x3f9, (uint32_t*)bytes,8); //average 1s
 
-      ctr_5second++;
-      if(ctr_5second==4)//only send every 4 second.
-      {
-         ctr_5second=0;
+        ctr_5second++;
+        if(ctr_5second==4)//only send every 4 second.
+        {
+            ctr_5second=0;
 
-         //central locking status message.
-         bytes[0] = 0x81;    //81=flap unlock, 80=flap lock.
-         bytes[1] = 0x00;
-         bytes[2] = 0x04;
-         bytes[3] = 0xff;
-         bytes[4] = 0xff;
-         bytes[5] = 0xff;
-         bytes[6] = 0xff;
-         bytes[7] = 0xff;
-         can->Send(0x2fc, (uint32_t*)bytes,8); // average 5s.
+            //central locking status message.
+            bytes[0] = 0x81;    //81=flap unlock, 80=flap lock.
+            bytes[1] = 0x00;
+            bytes[2] = 0x04;
+            bytes[3] = 0xff;
+            bytes[4] = 0xff;
+            bytes[5] = 0xff;
+            bytes[6] = 0xff;
+            bytes[7] = 0xff;
+            can->Send(0x2fc, (uint32_t*)bytes,8); // average 5s.
 
-         bytes[0] = 0x88;//central locking
-         bytes[1] = 0x88;
-         bytes[2] = 0xf8;
-         bytes[3] = 0x0f;
-         bytes[4] = 0xff;
-         bytes[5] = 0xff;
-         bytes[6] = 0xff;
-         bytes[7] = 0xff;
-         can->Send(0x2a0, (uint32_t*)bytes,8); // average 5s.
+            bytes[0] = 0x88;//central locking
+            bytes[1] = 0x88;
+            bytes[2] = 0xf8;
+            bytes[3] = 0x0f;
+            bytes[4] = 0xff;
+            bytes[5] = 0xff;
+            bytes[6] = 0xff;
+            bytes[7] = 0xff;
+            can->Send(0x2a0, (uint32_t*)bytes,8); // average 5s.
 
-         bytes[0] = 0xff;//vehicle condition
-         bytes[1] = 0xff;
-         bytes[2] = 0xc0;
-         bytes[3] = 0xff;
-         bytes[4] = 0xff;
-         bytes[5] = 0xff;
-         bytes[6] = 0xff;
-         bytes[7] = 0xfc;
-         can->Send(0x3a0, (uint32_t*)bytes,8); // average 4s.
-      }
-   }
+            bytes[0] = 0xff;//vehicle condition
+            bytes[1] = 0xff;
+            bytes[2] = 0xc0;
+            bytes[3] = 0xff;
+            bytes[4] = 0xff;
+            bytes[5] = 0xff;
+            bytes[6] = 0xff;
+            bytes[7] = 0xfc;
+            can->Send(0x3a0, (uint32_t*)bytes,8); // average 4s.
+        }
+    }
 
-   /*not needed msgs at least on efacec
-   bytes[0] = 0x00;//network management edme
-   bytes[1] = 0x00;
-   bytes[2] = 0x00;
-   bytes[3] = 0x00;
-   bytes[4] = 0x00;
-   bytes[5] = 0x00;
-   bytes[6] = 0x00;
-   bytes[7] = 0x12;
-   Can::GetInterface(Param::GetInt(Param::lim_can))->Send(0x512, (uint32_t*)bytes,8); // only sent once on 19 log.
+    /*not needed msgs at least on efacec
+    bytes[0] = 0x00;//network management edme
+    bytes[1] = 0x00;
+    bytes[2] = 0x00;
+    bytes[3] = 0x00;
+    bytes[4] = 0x00;
+    bytes[5] = 0x00;
+    bytes[6] = 0x00;
+    bytes[7] = 0x12;
+    Can::GetInterface(Param::GetInt(Param::lim_can))->Send(0x512, (uint32_t*)bytes,8); // only sent once on 19 log.
 
-   bytes[0] = 0x00;//network management kombi
-   bytes[1] = 0x00;
-   bytes[2] = 0x00;
-   bytes[3] = 0x00;
-   bytes[4] = 0xfe;
-   bytes[5] = 0x00;
-   bytes[6] = 0x00;
-   bytes[7] = 0x60;
-   Can::GetInterface(Param::GetInt(Param::lim_can))->Send(0x560, (uint32_t*)bytes,8); // not on is 2019 log
+    bytes[0] = 0x00;//network management kombi
+    bytes[1] = 0x00;
+    bytes[2] = 0x00;
+    bytes[3] = 0x00;
+    bytes[4] = 0xfe;
+    bytes[5] = 0x00;
+    bytes[6] = 0x00;
+    bytes[7] = 0x60;
+    Can::GetInterface(Param::GetInt(Param::lim_can))->Send(0x560, (uint32_t*)bytes,8); // not on is 2019 log
 
-   bytes[0] = 0xa8;//range info, milage display
-   bytes[1] = 0x86;
-   bytes[2] = 0x01;
-   bytes[3] = 0x02;
-   bytes[4] = 0x00;
-   bytes[5] = 0x05;
-   bytes[6] = 0xac;
-   bytes[7] = 0x03;
-   Can::GetInterface(Param::GetInt(Param::lim_can))->Send(0x330, (uint32_t*)bytes,8); // not on is 2019 log
+    bytes[0] = 0xa8;//range info, milage display
+    bytes[1] = 0x86;
+    bytes[2] = 0x01;
+    bytes[3] = 0x02;
+    bytes[4] = 0x00;
+    bytes[5] = 0x05;
+    bytes[6] = 0xac;
+    bytes[7] = 0x03;
+    Can::GetInterface(Param::GetInt(Param::lim_can))->Send(0x330, (uint32_t*)bytes,8); // not on is 2019 log
 
-   bytes[0] = 0x00;//obd msg
-   bytes[1] = 0x2a;
-   bytes[2] = 0x00;
-   bytes[3] = 0x6c;
-   bytes[4] = 0x0f;
-   bytes[5] = 0x55;
-   bytes[6] = 0x00;
-   Can::GetInterface(Param::GetInt(Param::lim_can))->Send(0x397, (uint32_t*)bytes,7); // not on 19 log
+    bytes[0] = 0x00;//obd msg
+    bytes[1] = 0x2a;
+    bytes[2] = 0x00;
+    bytes[3] = 0x6c;
+    bytes[4] = 0x0f;
+    bytes[5] = 0x55;
+    bytes[6] = 0x00;
+    Can::GetInterface(Param::GetInt(Param::lim_can))->Send(0x397, (uint32_t*)bytes,7); // not on 19 log
 
-   */
+    */
 
 }
 ////////////////////////////////////////////////////////////////////////////////
@@ -433,91 +448,91 @@ void i3LIMClass::Task200Ms()
 
 void i3LIMClass::Task100Ms()
 {
-   uint8_t bytes[8];
-   bytes[0] = 0xff;//vehicle status msg
-   bytes[1] = 0x5f;
-   bytes[2] = 0x00;
-   bytes[3] = 0x00;
-   bytes[4] = 0x00;
-   bytes[5] = 0x00;
-   bytes[6] = 0xff;
-   bytes[7] = 0xff;
-   can->Send(0x03c, (uint32_t*)bytes,8); //average 100ms
+    uint8_t bytes[8];
+    bytes[0] = 0xff;//vehicle status msg
+    bytes[1] = 0x5f;
+    bytes[2] = 0x00;
+    bytes[3] = 0x00;
+    bytes[4] = 0x00;
+    bytes[5] = 0x00;
+    bytes[6] = 0xff;
+    bytes[7] = 0xff;
+    can->Send(0x03c, (uint32_t*)bytes,8); //average 100ms
 
-   uint16_t Wh_Local=Param::GetInt(Param::BattCap);
-   CHG_Pwr=(CHG_Pwr & 0xFFF);
-   bytes[0] = Wh_Local & 0xFF;  //Battery Wh lowbyte
-   bytes[1] = Wh_Local >> 8;  //BAttery Wh high byte
-   bytes[2] = (((uint8_t)CHG_Status<<4)|((uint8_t)CHG_Req));  //charge status in bits 4-7.goes to 1 then 2.8 secs later to 2. Plug locking???. Charge request in lower nibble. 1 when charging. 0 when not charging.
-   bytes[3] = (((CHG_Pwr)<<4)|(uint8_t)CHG_Ready);  //charge readiness in bits 0 and 1. 1 = ready to charge.upper nibble is LSB of charge power.Charge power forecast not actual power!
-   bytes[4] = CHG_Pwr>>4;   //MSB of charge power.in this case 0x28 = 40x25 = 1000W. Probably net DC power into the Batt.
-   bytes[5] = FC_Cur & 0xff;   //LSB of the DC ccs current command
-   bytes[6] = ((CONT_Ctrl<<4)|(FC_Cur>>12));   //bits 0 and 1 MSB of the DC ccs current command.Upper nibble is DC ccs contactor control. Observed in DC fc logs only.
-   //transitions from 0 to 2 and start of charge but 2 to 1 to 0 at end. Status and Ready operate the same as in AC logs.
-   bytes[7] = EOC_Time;    // end of charge timer.
-
-
-   can->Send(0x3E9, (uint32_t*)bytes,8); //average 128ms
-
-   //LIM needs to see this but doesnt control anything...
-   bytes[0] = 0xca;
-   bytes[1] = 0xff;
-   bytes[2] = 0x0b;
-   bytes[3] = 0x02;
-   bytes[4] = 0x69;
-   bytes[5] = 0x26;
-   bytes[6] = 0xf3;
-   bytes[7] = 0x4b;
-   can->Send(0x431, (uint32_t*)bytes,8); //.average 197ms but as low as 49ms.
-
-   bytes[0] = 0xf5;//Wake up message.
-   bytes[1] = 0x28;
-   if(Param::GetInt(Param::opmode)==MOD_RUN) bytes[2] = 0x8a;//ignition on
-   if(Param::GetInt(Param::opmode)!=MOD_RUN) bytes[2] = 0x86;//ignition off 86
-   bytes[3] = 0x1d;
-   bytes[4] = 0xf1;
-   bytes[5] = 0x35;
-   bytes[6] = 0x30;
-   bytes[7] = 0x80;
-
-   can->Send(0x12f, (uint32_t*)bytes,8); //. average 100ms
+    uint16_t Wh_Local=Param::GetInt(Param::BattCap);
+    CHG_Pwr=(CHG_Pwr & 0xFFF);
+    bytes[0] = Wh_Local & 0xFF;  //Battery Wh lowbyte
+    bytes[1] = Wh_Local >> 8;  //BAttery Wh high byte
+    bytes[2] = (((uint8_t)CHG_Status<<4)|((uint8_t)CHG_Req));  //charge status in bits 4-7.goes to 1 then 2.8 secs later to 2. Plug locking???. Charge request in lower nibble. 1 when charging. 0 when not charging.
+    bytes[3] = (((CHG_Pwr)<<4)|(uint8_t)CHG_Ready);  //charge readiness in bits 0 and 1. 1 = ready to charge.upper nibble is LSB of charge power.Charge power forecast not actual power!
+    bytes[4] = CHG_Pwr>>4;   //MSB of charge power.in this case 0x28 = 40x25 = 1000W. Probably net DC power into the Batt.
+    bytes[5] = FC_Cur & 0xff;   //LSB of the DC ccs current command
+    bytes[6] = ((CONT_Ctrl<<4)|(FC_Cur>>12));   //bits 0 and 1 MSB of the DC ccs current command.Upper nibble is DC ccs contactor control. Observed in DC fc logs only.
+    //transitions from 0 to 2 and start of charge but 2 to 1 to 0 at end. Status and Ready operate the same as in AC logs.
+    bytes[7] = EOC_Time;    // end of charge timer.
 
 
+    can->Send(0x3E9, (uint32_t*)bytes,8); //average 128ms
 
-   //Lim command 2. Used in DC mode
-   uint16_t V_limit=0;
+    //LIM needs to see this but doesnt control anything...
+    bytes[0] = 0xca;
+    bytes[1] = 0xff;
+    bytes[2] = 0x0b;
+    bytes[3] = 0x02;
+    bytes[4] = 0x69;
+    bytes[5] = 0x26;
+    bytes[6] = 0xf3;
+    bytes[7] = 0x4b;
+    can->Send(0x431, (uint32_t*)bytes,8); //.average 197ms but as low as 49ms.
+
+    bytes[0] = 0xf5;//Wake up message.
+    bytes[1] = 0x28;
+    if(Param::GetInt(Param::opmode)==MOD_RUN) bytes[2] = 0x8a;//ignition on
+    if(Param::GetInt(Param::opmode)!=MOD_RUN) bytes[2] = 0x86;//ignition off 86
+    bytes[3] = 0x1d;
+    bytes[4] = 0xf1;
+    bytes[5] = 0x35;
+    bytes[6] = 0x30;
+    bytes[7] = 0x80;
+
+    can->Send(0x12f, (uint32_t*)bytes,8); //. average 100ms
+
+
+
+    //Lim command 2. Used in DC mode
+    uint16_t V_limit=0;
 //if(lim_state==6) V_limit=401*10;//set to 400v in energy transfer state
 //if(lim_state!=6) V_limit=Param::GetInt(Param::udc)*10;
-   //if(lim_state==4) V_limit=Param::GetInt(Param::udc)*10;// drop vlim only during precharge
-   if(lim_state==4 || lim_state==5) V_limit=Param::GetInt(Param::udc)*10;// drop vlim only during precharge
-   else V_limit=415*10;//set to 415v in all other states
-   uint8_t I_limit=125;//125A limit. may not work
-   bytes[0] = V_limit & 0xFF;  //Charge voltage limit LSB. 14 bit signed int.scale 0.1 0xfa2=4002*.1=400.2Volts
-   bytes[1] = V_limit >> 8;  //Charge voltage limit MSB. 14 bit signed int.scale 0.1
-   bytes[2] = I_limit;  //Fast charge current limit. Not used in logs from 2014-15 vehicle so far. 8 bit unsigned int. scale 1.so max 254amps in theory...
-   bytes[3] = Full_SOCt & 0xFF;  //time remaining in seconds to hit soc target from byte 7 in AC mode. LSB. 16 bit unsigned int. scale 10.Full SOC.
-   bytes[4] = Full_SOCt >> 8;  //time remaining in seconds to hit soc target from byte 7 in AC mode. MSB. 16 bit unsigned int. scale 10.Full SOC.
-   bytes[5] = Bulk_SOCt & 0xFF;  //time remaining in seconds to hit soc target from byte 7 in ccs mode. LSB. 16 bit unsigned int. scale 10.Bulk SOC.
-   bytes[6] = Bulk_SOCt >> 8;  //time remaining in seconds to hit soc target from byte 7 in ccs mode. MSB. 16 bit unsigned int. scale 10.Bulk SOC.
-   bytes[7] = 0xA0;  //Fast charge SOC target. 8 bit unsigned int. scale 0.5. 0xA0=160*0.5=80%
+    //if(lim_state==4) V_limit=Param::GetInt(Param::udc)*10;// drop vlim only during precharge
+    if(lim_state==4 || lim_state==5) V_limit=Param::GetInt(Param::udc)*10;// drop vlim only during precharge
+    else V_limit=415*10;//set to 415v in all other states
+    uint8_t I_limit=125;//125A limit. may not work
+    bytes[0] = V_limit & 0xFF;  //Charge voltage limit LSB. 14 bit signed int.scale 0.1 0xfa2=4002*.1=400.2Volts
+    bytes[1] = V_limit >> 8;  //Charge voltage limit MSB. 14 bit signed int.scale 0.1
+    bytes[2] = I_limit;  //Fast charge current limit. Not used in logs from 2014-15 vehicle so far. 8 bit unsigned int. scale 1.so max 254amps in theory...
+    bytes[3] = Full_SOCt & 0xFF;  //time remaining in seconds to hit soc target from byte 7 in AC mode. LSB. 16 bit unsigned int. scale 10.Full SOC.
+    bytes[4] = Full_SOCt >> 8;  //time remaining in seconds to hit soc target from byte 7 in AC mode. MSB. 16 bit unsigned int. scale 10.Full SOC.
+    bytes[5] = Bulk_SOCt & 0xFF;  //time remaining in seconds to hit soc target from byte 7 in ccs mode. LSB. 16 bit unsigned int. scale 10.Bulk SOC.
+    bytes[6] = Bulk_SOCt >> 8;  //time remaining in seconds to hit soc target from byte 7 in ccs mode. MSB. 16 bit unsigned int. scale 10.Bulk SOC.
+    bytes[7] = 0xA0;  //Fast charge SOC target. 8 bit unsigned int. scale 0.5. 0xA0=160*0.5=80%
 
-   can->Send(0x2f1, (uint32_t*)bytes,8); //. average 100ms
+    can->Send(0x2f1, (uint32_t*)bytes,8); //. average 100ms
 
-   if(Param::GetInt(Param::opmode)!=MOD_RUN) vin_ctr=0;
-   if((Param::GetInt(Param::opmode)==MOD_RUN) && vin_ctr<5)
-   {
-      /*
-      bytes[0] = 0x56;                //vin in ascii from 2017 i3 : VB87926
-      bytes[1] = 0x42;
-      bytes[2] = 0x38;
-      bytes[3] = 0x37;
-      bytes[4] = 0x39;
-      bytes[5] = 0x32;
-      bytes[6] = 0x36;
-      Can::GetInterface(Param::GetInt(Param::lim_can))->Send(0x380, (uint32_t*)bytes,7); //
-      vin_ctr++;
-      */
-   }
+    if(Param::GetInt(Param::opmode)!=MOD_RUN) vin_ctr=0;
+    if((Param::GetInt(Param::opmode)==MOD_RUN) && vin_ctr<5)
+    {
+        /*
+        bytes[0] = 0x56;                //vin in ascii from 2017 i3 : VB87926
+        bytes[1] = 0x42;
+        bytes[2] = 0x38;
+        bytes[3] = 0x37;
+        bytes[4] = 0x39;
+        bytes[5] = 0x32;
+        bytes[6] = 0x36;
+        Can::GetInterface(Param::GetInt(Param::lim_can))->Send(0x380, (uint32_t*)bytes,7); //
+        vin_ctr++;
+        */
+    }
 
 
 
@@ -526,72 +541,72 @@ void i3LIMClass::Task100Ms()
 
 void i3LIMClass::CCS_Pwr_Con()    //here we control ccs charging during state 6.
 {
-   uint16_t Tmp_Vbatt=Param::GetInt(Param::udc);//Actual measured battery voltage by isa shunt
-   uint16_t Tmp_Vbatt_Spnt=Param::GetInt(Param::Voltspnt);
-   uint16_t Tmp_ICCS_Lim=Param::GetInt(Param::CCS_ILim);
-   uint16_t Tmp_ICCS_Avail=Param::GetInt(Param::CCS_I_Avail);
+    uint16_t Tmp_Vbatt=Param::GetInt(Param::udc);//Actual measured battery voltage by isa shunt
+    uint16_t Tmp_Vbatt_Spnt=Param::GetInt(Param::Voltspnt);
+    uint16_t Tmp_ICCS_Lim=Param::GetInt(Param::CCS_ILim);
+    uint16_t Tmp_ICCS_Avail=Param::GetInt(Param::CCS_I_Avail);
 
-   if(CCSI_Spnt>Tmp_ICCS_Lim)CCSI_Spnt=Tmp_ICCS_Lim; //clamp setpoint to current lim paramater.
-   if(CCSI_Spnt>150)CCSI_Spnt=150; //never exceed 150amps for now.
-   if(CCSI_Spnt>=Tmp_ICCS_Avail)CCSI_Spnt=Tmp_ICCS_Avail; //never exceed available current
-   if(CCSI_Spnt>250)CCSI_Spnt=0; //crude way to prevent rollover
-   if((Tmp_Vbatt<Tmp_Vbatt_Spnt)&&(CCS_Ilim==0x0)&&(CCS_Plim==0x0))CCSI_Spnt++;//increment if voltage lower than setpoint and power and current limts not set from charger.
-   if(Tmp_Vbatt>Tmp_Vbatt_Spnt)CCSI_Spnt--;//decrement if voltage equal to or greater than setpoint.
-   if(CCS_Ilim==0x1)CCSI_Spnt--;//decrement if current limit flag is set
-   if(CCS_Plim==0x1)CCSI_Spnt--;//decrement if Power limit flag is set
-   //BMS charge current limit for CCS
-   //Note: No need to worry about bms type as if none selected sets to 999.
-   CCSI_Spnt = MIN(Param::GetInt(Param::BMS_ChargeLim), CCSI_Spnt);
+    if(CCSI_Spnt>Tmp_ICCS_Lim)CCSI_Spnt=Tmp_ICCS_Lim; //clamp setpoint to current lim paramater.
+    if(CCSI_Spnt>150)CCSI_Spnt=150; //never exceed 150amps for now.
+    if(CCSI_Spnt>=Tmp_ICCS_Avail)CCSI_Spnt=Tmp_ICCS_Avail; //never exceed available current
+    if(CCSI_Spnt>250)CCSI_Spnt=0; //crude way to prevent rollover
+    if((Tmp_Vbatt<Tmp_Vbatt_Spnt)&&(CCS_Ilim==0x0)&&(CCS_Plim==0x0))CCSI_Spnt++;//increment if voltage lower than setpoint and power and current limts not set from charger.
+    if(Tmp_Vbatt>Tmp_Vbatt_Spnt)CCSI_Spnt--;//decrement if voltage equal to or greater than setpoint.
+    if(CCS_Ilim==0x1)CCSI_Spnt--;//decrement if current limit flag is set
+    if(CCS_Plim==0x1)CCSI_Spnt--;//decrement if Power limit flag is set
+    //BMS charge current limit for CCS
+    //Note: No need to worry about bms type as if none selected sets to 999.
+    CCSI_Spnt = MIN(Param::GetInt(Param::BMS_ChargeLim), CCSI_Spnt);
 
-   Param::SetInt(Param::CCS_Ireq,CCSI_Spnt);
+    Param::SetInt(Param::CCS_Ireq,CCSI_Spnt);
 }
 
 void i3LIMClass::Chg_Timers()
 {
-   Timer_1Sec--;   //decrement the loop counter
+    Timer_1Sec--;   //decrement the loop counter
 
-   if(Timer_1Sec==0)   //1 second has elapsed
-   {
-      Timer_1Sec=5;
-      Bulk_SOCt--;    //Decrement timers. Just on time for now will be current based in final version
-      Full_SOCt--;
-      Timer_60Sec--;  //decrement the 1 minute counter
-      if(Timer_60Sec==0)
-      {
-         Timer_60Sec=60;
-         EOC_Time--;    //decrement end of charge minutes timer
-      }
+    if(Timer_1Sec==0)   //1 second has elapsed
+    {
+        Timer_1Sec=5;
+        Bulk_SOCt--;    //Decrement timers. Just on time for now will be current based in final version
+        Full_SOCt--;
+        Timer_60Sec--;  //decrement the 1 minute counter
+        if(Timer_60Sec==0)
+        {
+            Timer_60Sec=60;
+            EOC_Time--;    //decrement end of charge minutes timer
+        }
 
-   }
+    }
 }
 
 bool i3LIMClass::DCFCRequest(bool RunCh)
 {
 
-      if (Param::GetBool(Param::PlugDet)&&(CP_Mode==0x4||CP_Mode==0x5))  //if we have an enable and a plug in and a 5% pilot lets go DC charge mode.
-      {
-      //removed static pilot option as was causing false entry to dc mode when ac evse used.
-      //will see how this manifests...
+    if (Param::GetBool(Param::PlugDet)&&(CP_Mode==0x4||CP_Mode==0x5))  //if we have an enable and a plug in and a 5% pilot lets go DC charge mode.
+    {
+        //removed static pilot option as was causing false entry to dc mode when ac evse used.
+        //will see how this manifests...
 
-          if(lim_state>19)lim_state=0;//clear from  ac test mode
-         /*
+        if(lim_state>19)lim_state=0;//clear from  ac test mode
+        /*
 
-         0=no pilot
-         1=10-96%PWM not charge ready
-         2=10-96%PWM charge ready
-         3=error
-         4=5% not charge ready
-         5=5% charge ready
-         6=pilot static
+        0=no pilot
+        1=10-96%PWM not charge ready
+        2=10-96%PWM charge ready
+        3=error
+        4=5% not charge ready
+        5=5% charge ready
+        6=pilot static
 
-         */
+        */
 
-         Param::SetInt(Param::CCS_State,lim_state);//update state machine level on webui
-         switch(lim_state)
-         {
+        Param::SetInt(Param::CCS_State,lim_state);//update state machine level on webui
+        switch(lim_state)
+        {
 
-         case 0:
-         {
+        case 0:
+        {
             Chg_Phase=ChargePhase::Standby;
             CONT_Ctrl=0x0; //dc contactor mode control required in DC
             FC_Cur=0;//ccs current request from web ui for now.
@@ -605,15 +620,15 @@ bool i3LIMClass::DCFCRequest(bool RunCh)
             lim_stateCnt++; //increment state timer counter
             if(lim_stateCnt>20)//2 second delay
             {
-               lim_state++; //next state after 2 secs
-               lim_stateCnt=0;
+                lim_state++; //next state after 2 secs
+                lim_stateCnt=0;
             }
 
-         }
-         break;
+        }
+        break;
 
-         case 1:
-         {
+        case 1:
+        {
             //uint16_t I_avail_tmp=Param::GetInt(Param::CCS_I_Avail);
             Chg_Phase=ChargePhase::Initialisation;
             CONT_Ctrl=0x0; //dc contactor mode control required in DC
@@ -630,15 +645,15 @@ bool i3LIMClass::DCFCRequest(bool RunCh)
             if(ChargeType==0x04 || ChargeType==0x28|| ChargeType==0x09) lim_stateCnt++;
             if(lim_stateCnt>25)//2 secs efacec critical! 20 works. 50 does not.
             {
-               lim_state++; //next state after 4 secs
-               lim_stateCnt=0;
+                lim_state++; //next state after 4 secs
+                lim_stateCnt=0;
             }
 
-         }
-         break;
+        }
+        break;
 
-         case 2:
-         {
+        case 2:
+        {
             //
             Chg_Phase=ChargePhase::CableTest;
             CONT_Ctrl=0x0; //dc contactor mode control required in DC
@@ -655,11 +670,11 @@ bool i3LIMClass::DCFCRequest(bool RunCh)
             CCSI_Spnt=0;//No current
             if(Cont_Volts>0)lim_state++; //we wait for the contactor voltage to rise before hitting next state.
 
-         }
-         break;
+        }
+        break;
 
-         case 3:
-         {
+        case 3:
+        {
             //I don't like this state CableTest here. Should it remain in Initialisation ....
             Chg_Phase=ChargePhase::CableTest;
             CONT_Ctrl=0x0; //dc contactor mode control required in DC
@@ -673,15 +688,15 @@ bool i3LIMClass::DCFCRequest(bool RunCh)
             if(Cont_Volts<=50)lim_stateCnt++; //we wait for the contactor voltage to drop under 50v to indicate end of cable test
             if(lim_stateCnt>20)
             {
-               if(CCS_Iso==0x1) lim_state++; //next state after 2 secs if we have valid iso test
-               lim_stateCnt=0;
+                if(CCS_Iso==0x1) lim_state++; //next state after 2 secs if we have valid iso test
+                lim_stateCnt=0;
             }
 
-         }
-         break;
+        }
+        break;
 
-         case 4:
-         {
+        case 4:
+        {
             Chg_Phase = ChargePhase::Subpoena; //precharge phase in this state
             CONT_Ctrl = 0x0;                   //dc contactor mode control required in DC
             FC_Cur = 0;                        //ccs current request from web ui for now.
@@ -694,24 +709,24 @@ bool i3LIMClass::DCFCRequest(bool RunCh)
 
             if ((Param::GetInt(Param::udc) - Cont_Volts) < 20)
             {
-               lim_stateCnt++; //we wait for the contactor voltage to be 20v or less diff to main batt v
+                lim_stateCnt++; //we wait for the contactor voltage to be 20v or less diff to main batt v
             }
             else
             {
-               // If the contactor voltage wanders out of range start again
-               lim_stateCnt = 0;
+                // If the contactor voltage wanders out of range start again
+                lim_stateCnt = 0;
             }
 
             // Wait for contactor voltage to be stable for 2 seconds
             if (lim_stateCnt > 20)
             {
-               lim_state++; //next state after 2 secs
-               lim_stateCnt = 0;
+                lim_state++; //next state after 2 secs
+                lim_stateCnt = 0;
             }
-         }
-         break;
-         case 5:
-         {
+        }
+        break;
+        case 5:
+        {
             //precharge phase in this state but voltage close enough to close contactors
             Chg_Phase = ChargePhase::Subpoena;
             CONT_Ctrl = 0x2;                   //dc contactor closed
@@ -726,13 +741,13 @@ bool i3LIMClass::DCFCRequest(bool RunCh)
             // Once the contactors report as closed we're OK to proceed to energy transfer
             if (Param::GetBool(Param::CCS_Contactor))
             {
-               lim_state++;
+                lim_state++;
             }
-         }
-         break;
+        }
+        break;
 
-         case 6:
-         {
+        case 6:
+        {
             Chg_Phase=ChargePhase::EnergyTransfer;
             CONT_Ctrl=0x2; //dc contactor to close mode
             //FC_Cur=Param::GetInt(Param::CCS_ICmd);//ccs manual control
@@ -748,15 +763,15 @@ bool i3LIMClass::DCFCRequest(bool RunCh)
 
             if((!RunCh)||CCS_IntStat==0x02)//if we have a request to terminate from the web ui or the evse then move to next state.
             {
-               FC_Cur=0;//set current to 0
-               lim_state++; //move to state 7 (shutdown)
+                FC_Cur=0;//set current to 0
+                lim_state++; //move to state 7 (shutdown)
             }
 
-         }
-         break;
+        }
+        break;
 
-         case 7:    //shutdown state
-         {
+        case 7:    //shutdown state
+        {
             Chg_Phase=ChargePhase::Shutdown;
             CONT_Ctrl=0x2; //dc contactor to close mode
             FC_Cur=0;//current command to 0
@@ -768,16 +783,16 @@ bool i3LIMClass::DCFCRequest(bool RunCh)
             lim_stateCnt++;
             if(lim_stateCnt>10) //wait 2 seconds
             {
-               lim_state++; //next state after 2 secs
-               lim_stateCnt=0;
+                lim_state++; //next state after 2 secs
+                lim_stateCnt=0;
             }
 
 
-         }
-         break;
+        }
+        break;
 
-         case 8:    //shutdown state
-         {
+        case 8:    //shutdown state
+        {
             Chg_Phase=ChargePhase::Shutdown;
             CONT_Ctrl=0x1; //dc contactor to open with diag mode
             FC_Cur=0;//current command to 0
@@ -790,15 +805,15 @@ bool i3LIMClass::DCFCRequest(bool RunCh)
             if(Cont_Volts==0)lim_stateCnt++; //we wait for the contactor voltage to return to 0 to indicate contactors open
             if(lim_stateCnt>10)
             {
-               lim_state++; //next state after 2 secs
-               lim_stateCnt=0;
+                lim_state++; //next state after 2 secs
+                lim_stateCnt=0;
             }
 
-         }
-         break;
+        }
+        break;
 
-         case 9:    //shutdown state
-         {
+        case 9:    //shutdown state
+        {
             Chg_Phase=ChargePhase::Standby;
             CONT_Ctrl=0x0; //dc contactor to open mode
             FC_Cur=0;//current command to 0
@@ -809,70 +824,70 @@ bool i3LIMClass::DCFCRequest(bool RunCh)
             CHG_Pwr=0;//0 power
             return false;
 
-         }
-         break;
+        }
+        break;
 
 
-         }
+        }
 
-         if(RunCh)return true;//set dc charge mode if we are enabled on webui
-         if((!RunCh)&&lim_state==9)return false;//set no charge mode if we are disabled on webui and in state 9 of dc machine
+        if(RunCh)return true;//set dc charge mode if we are enabled on webui
+        if((!RunCh)&&lim_state==9)return false;//set no charge mode if we are disabled on webui and in state 9 of dc machine
 
-      }
-/*
-        if (!Param::GetBool(Param::PlugDet))  //if we  plug remove shut down
-        {
-         lim_state=0;//return to state 0
-         Param::SetInt(Param::CCS_State,lim_state);
-         Chg_Phase=ChargePhase::Standby;
-         CONT_Ctrl=0x0; //dc contactor mode 0 in off
-         FC_Cur=0;//ccs current request zero
-         EOC_Time=0x00;
-         CHG_Status=ChargeStatus::NotRdy;
-         CHG_Req=ChargeRequest::EndCharge;
-         CHG_Ready=ChargeReady::NotRdy;
-         CHG_Pwr=0;
-         return false;
-         }
-*/
+    }
+    /*
+            if (!Param::GetBool(Param::PlugDet))  //if we  plug remove shut down
+            {
+             lim_state=0;//return to state 0
+             Param::SetInt(Param::CCS_State,lim_state);
+             Chg_Phase=ChargePhase::Standby;
+             CONT_Ctrl=0x0; //dc contactor mode 0 in off
+             FC_Cur=0;//ccs current request zero
+             EOC_Time=0x00;
+             CHG_Status=ChargeStatus::NotRdy;
+             CHG_Req=ChargeRequest::EndCharge;
+             CHG_Ready=ChargeReady::NotRdy;
+             CHG_Pwr=0;
+             return false;
+             }
+    */
 
-return false;
+    return false;
 }
 
 bool i3LIMClass::ACRequest(bool RunCh)
 {
 
-        if (Param::GetBool(Param::PlugDet)&&(CP_Mode==0x1||CP_Mode==0x2)&&RunCh)  //if we have an enable and a plug in and a std ac pilot lets go AC charge mode.
+    if (Param::GetBool(Param::PlugDet)&&(CP_Mode==0x1||CP_Mode==0x2)&&RunCh)  //if we have an enable and a plug in and a std ac pilot lets go AC charge mode.
 
-        {
-         lim_state=20;//return to state 0
-         Param::SetInt(Param::CCS_State,lim_state);
-         Chg_Phase=ChargePhase::Standby;
-         CONT_Ctrl=0x0; //dc contactor mode 0 in AC
-         FC_Cur=0;//ccs current request zero
-         EOC_Time=0xFE;
-         CHG_Status=ChargeStatus::Rdy;
-         CHG_Req=ChargeRequest::Charge;
-         CHG_Ready=ChargeReady::Rdy;
-         CHG_Pwr=6500/25;//approx 6.5kw ac
-         return true;
-        }
-        else
-        {
+    {
+        lim_state=20;//return to state 0
+        Param::SetInt(Param::CCS_State,lim_state);
+        Chg_Phase=ChargePhase::Standby;
+        CONT_Ctrl=0x0; //dc contactor mode 0 in AC
+        FC_Cur=0;//ccs current request zero
+        EOC_Time=0xFE;
+        CHG_Status=ChargeStatus::Rdy;
+        CHG_Req=ChargeRequest::Charge;
+        CHG_Ready=ChargeReady::Rdy;
+        CHG_Pwr=6500/25;//approx 6.5kw ac
+        return true;
+    }
+    else
+    {
         lim_state=30;//return to state 0
         Param::SetInt(Param::CCS_State,lim_state);
         Chg_Phase=ChargePhase::Standby;
-            CONT_Ctrl=0x0; //dc contactor mode 0 in off
-            FC_Cur=0;//ccs current request zero
-            EOC_Time=0x00;
-            CHG_Status=ChargeStatus::NotRdy;
-            CHG_Req=ChargeRequest::EndCharge;
-            CHG_Ready=ChargeReady::NotRdy;
-            CHG_Pwr=0;
+        CONT_Ctrl=0x0; //dc contactor mode 0 in off
+        FC_Cur=0;//ccs current request zero
+        EOC_Time=0x00;
+        CHG_Status=ChargeStatus::NotRdy;
+        CHG_Req=ChargeRequest::EndCharge;
+        CHG_Ready=ChargeReady::NotRdy;
+        CHG_Pwr=0;
 
-            return false;
+        return false;
 
-        }
+    }
 
 }
 

--- a/src/stm32_vcu.cpp
+++ b/src/stm32_vcu.cpp
@@ -21,7 +21,10 @@
  */
 #include "stm32_vcu.h"
 
-extern "C" void __cxa_pure_virtual() { while (1); }
+extern "C" void __cxa_pure_virtual()
+{
+    while (1);
+}
 
 static Stm32Scheduler* scheduler;
 static bool chargeMode = false;
@@ -89,615 +92,633 @@ static BMS* selectedBMS = &BMSnone;
 static DCDC* selectedDCDC = &DCDCnone;
 static Can_OBD2 canOBD2;
 static Shifter shifterNone;
+static RearOutlanderInverter rearoutlanderInv;
 
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 static void Ms200Task(void)
 {
-   int opmode = Param::GetInt(Param::opmode);
+    int opmode = Param::GetInt(Param::opmode);
 
-   selectedVehicle->Task200Ms();
-   if(opmode==MOD_CHARGE) selectedCharger->Task200Ms();
+    selectedVehicle->Task200Ms();
+    if(opmode==MOD_CHARGE) selectedCharger->Task200Ms();
 
-   Param::SetInt(Param::Day,days);
-   Param::SetInt(Param::Hour,hours);
-   Param::SetInt(Param::Min,minutes);
-   Param::SetInt(Param::Sec,seconds);
-   Param::SetInt(Param::ChgT,ChgDur_tmp);
-   if(ChgSet==2 && !ChgLck)  //if in timer mode and not locked out from a previous full charge.
-   {
-      if(opmode!=MOD_CHARGE)
-      {
-         if((ChgHrs_tmp==hours)&&(ChgMins_tmp==minutes)&&(ChgDur_tmp!=0))RunChg=true;//if we arrive at set charge time and duration is non zero then initiate charge
-         else RunChg=false;
-      }
+    Param::SetInt(Param::Day,days);
+    Param::SetInt(Param::Hour,hours);
+    Param::SetInt(Param::Min,minutes);
+    Param::SetInt(Param::Sec,seconds);
+    Param::SetInt(Param::ChgT,ChgDur_tmp);
+    if(ChgSet==2 && !ChgLck)  //if in timer mode and not locked out from a previous full charge.
+    {
+        if(opmode!=MOD_CHARGE)
+        {
+            if((ChgHrs_tmp==hours)&&(ChgMins_tmp==minutes)&&(ChgDur_tmp!=0))RunChg=true;//if we arrive at set charge time and duration is non zero then initiate charge
+            else RunChg=false;
+        }
 
-      if(opmode==MOD_CHARGE)
-      {
-         if(ChgTicks!=0)
-         {
-            ChgTicks--; //decrement charge timer ticks
-            ChgTicks_1Min++;
-         }
+        if(opmode==MOD_CHARGE)
+        {
+            if(ChgTicks!=0)
+            {
+                ChgTicks--; //decrement charge timer ticks
+                ChgTicks_1Min++;
+            }
 
-         if(ChgTicks==0)
-         {
-            RunChg=false; //end charge if still charging once timer expires.
-            ChgTicks = (GetInt(Param::Chg_Dur)*300);//recharge the tick timer
-         }
+            if(ChgTicks==0)
+            {
+                RunChg=false; //end charge if still charging once timer expires.
+                ChgTicks = (GetInt(Param::Chg_Dur)*300);//recharge the tick timer
+            }
 
-         if (ChgTicks_1Min==300)
-         {
-            ChgTicks_1Min=0;
-            ChgDur_tmp--; //countdown minutes of charge time remaining.
-         }
-      }
+            if (ChgTicks_1Min==300)
+            {
+                ChgTicks_1Min=0;
+                ChgDur_tmp--; //countdown minutes of charge time remaining.
+            }
+        }
 
-   }
-   if(ChgSet==0 && !ChgLck) RunChg=true;//enable from webui if we are not locked out from an auto termination
-   if(ChgSet==1) RunChg=false;//disable from webui
+    }
+    if(ChgSet==0 && !ChgLck) RunChg=true;//enable from webui if we are not locked out from an auto termination
+    if(ChgSet==1) RunChg=false;//disable from webui
 
-  //Handle PP on the Charging port
-   if(Param::GetInt(Param::GPA1Func) == IOMatrix::PILOT_PROX || Param::GetInt(Param::GPA2Func) == IOMatrix::PILOT_PROX ) {
-      int ppThresh = Param::GetInt(Param::ppthresh);
+    //Handle PP on the Charging port
+    if(Param::GetInt(Param::GPA1Func) == IOMatrix::PILOT_PROX || Param::GetInt(Param::GPA2Func) == IOMatrix::PILOT_PROX )
+    {
+        int ppThresh = Param::GetInt(Param::ppthresh);
 
-      int ppValue = IOMatrix::GetAnaloguePin(IOMatrix::PILOT_PROX)->Get();
-      Param::SetInt(Param::PPVal, ppValue);
+        int ppValue = IOMatrix::GetAnaloguePin(IOMatrix::PILOT_PROX)->Get();
+        Param::SetInt(Param::PPVal, ppValue);
 
 
-      //if PP is less than threshold and currently disabled and not already finished
-      if (ppValue < ppThresh && ChgSet==1 && !ChgLck) {
-         RunChg=true;
-      } else if (ppValue > ppThresh) {
-         //even if timer was enabled, change to disabled, we've unplugged
-         RunChg=false;
-      }
-   }
+        //if PP is less than threshold and currently disabled and not already finished
+        if (ppValue < ppThresh && ChgSet==1 && !ChgLck)
+        {
+            RunChg=true;
+        }
+        else if (ppValue > ppThresh)
+        {
+            //even if timer was enabled, change to disabled, we've unplugged
+            RunChg=false;
+        }
+    }
 
-   if(selectedCharger->ControlCharge(RunChg, ACrequest) && (opmode != MOD_RUN))
-   {
+    if(selectedCharger->ControlCharge(RunChg, ACrequest) && (opmode != MOD_RUN))
+    {
         chargeMode = true;   //AC charge mode
         Param::SetInt(Param::chgtyp,AC);
-   }
-   else if(!chargeModeDC)
-   {
+    }
+    else if(!chargeModeDC)
+    {
         Param::SetInt(Param::chgtyp,OFF);
         chargeMode = false;  //no charge mode
-   }
+    }
 
-   //in chademo , we do not want to run the 200ms task unless in dc charge mode
-   if(targetChgint == ChargeInterfaces::Chademo && chargeModeDC) selectedChargeInt->Task200Ms();
-   //In case of the LIM we want to send it all the time if lim in use
-   if((targetChgint == ChargeInterfaces::i3LIM) || (targetChgint == ChargeInterfaces::Unused) || (targetChgint == ChargeInterfaces::CPC)) selectedChargeInt->Task200Ms();
-   //and just to be thorough ...
-   if(targetChgint == ChargeInterfaces::Unused) selectedChargeInt->Task200Ms();
-
-
-
-   ///////////////////////////////////////
-   //Charge term logic for AC charge
-   ///////////////////////////////////////
-   /*
-   if we are in charge mode and battV >= setpoint and power is <= termination setpoint
-       Then we end charge.
-   */
-   if(opmode==MOD_CHARGE && !chargeModeDC)
-   {
-      if(Param::GetInt(Param::udc)>=Param::GetInt(Param::Voltspnt) && Param::GetInt(Param::idc)<=Param::GetInt(Param::IdcTerm))
-      {
-         RunChg=false;//end charge
-         ChgLck=true;//set charge lockout flag
-      }
-
-      if(selectedBMS->MaxChargeCurrent()==0)//BMS can command an AC charge shutdown if its current limit is 0
-      {
-         RunChg=false;//end charge
-         ChgLck=true;//set charge lockout flag
-      }
+    //in chademo , we do not want to run the 200ms task unless in dc charge mode
+    if(targetChgint == ChargeInterfaces::Chademo && chargeModeDC) selectedChargeInt->Task200Ms();
+    //In case of the LIM we want to send it all the time if lim in use
+    if((targetChgint == ChargeInterfaces::i3LIM) || (targetChgint == ChargeInterfaces::Unused) || (targetChgint == ChargeInterfaces::CPC)) selectedChargeInt->Task200Ms();
+    //and just to be thorough ...
+    if(targetChgint == ChargeInterfaces::Unused) selectedChargeInt->Task200Ms();
 
 
-   }
-   if(opmode==MOD_RUN) {
-      ChgLck=false;//reset charge lockout flag when we drive off
 
-      //Brake Vac Sensor
-      if(Param::GetInt(Param::GPA1Func) == IOMatrix::VAC_SENSOR || Param::GetInt(Param::GPA2Func) == IOMatrix::VAC_SENSOR ) {
-         int brkVacThresh = Param::GetInt(Param::BrkVacThresh);
-         int BrkVacHyst = Param::GetInt(Param::BrkVacHyst);
+    ///////////////////////////////////////
+    //Charge term logic for AC charge
+    ///////////////////////////////////////
+    /*
+    if we are in charge mode and battV >= setpoint and power is <= termination setpoint
+        Then we end charge.
+    */
+    if(opmode==MOD_CHARGE && !chargeModeDC)
+    {
+        if(Param::GetInt(Param::udc)>=Param::GetInt(Param::Voltspnt) && Param::GetInt(Param::idc)<=Param::GetInt(Param::IdcTerm))
+        {
+            RunChg=false;//end charge
+            ChgLck=true;//set charge lockout flag
+        }
 
-         int brkVacVal = IOMatrix::GetAnaloguePin(IOMatrix::VAC_SENSOR)->Get();
-         Param::SetInt(Param::BrkVacVal, brkVacVal);
+        if(selectedBMS->MaxChargeCurrent()==0)//BMS can command an AC charge shutdown if its current limit is 0
+        {
+            RunChg=false;//end charge
+            ChgLck=true;//set charge lockout flag
+        }
 
-         //enable pump
-         if (brkVacVal > brkVacThresh) {
-            IOMatrix::GetPin(IOMatrix::BRAKEVACPUMP)->Clear();
-         } else if (brkVacVal < BrkVacHyst) {
-            IOMatrix::GetPin(IOMatrix::BRAKEVACPUMP)->Set();
-         }
-      }
-   }
+
+    }
+    if(opmode==MOD_RUN)
+    {
+        ChgLck=false;//reset charge lockout flag when we drive off
+
+        //Brake Vac Sensor
+        if(Param::GetInt(Param::GPA1Func) == IOMatrix::VAC_SENSOR || Param::GetInt(Param::GPA2Func) == IOMatrix::VAC_SENSOR )
+        {
+            int brkVacThresh = Param::GetInt(Param::BrkVacThresh);
+            int BrkVacHyst = Param::GetInt(Param::BrkVacHyst);
+
+            int brkVacVal = IOMatrix::GetAnaloguePin(IOMatrix::VAC_SENSOR)->Get();
+            Param::SetInt(Param::BrkVacVal, brkVacVal);
+
+            //enable pump
+            if (brkVacVal > brkVacThresh)
+            {
+                IOMatrix::GetPin(IOMatrix::BRAKEVACPUMP)->Clear();
+            }
+            else if (brkVacVal < BrkVacHyst)
+            {
+                IOMatrix::GetPin(IOMatrix::BRAKEVACPUMP)->Set();
+            }
+        }
+    }
 
 }
 
 static void Ms100Task(void)
 {
-   DigIo::led_out.Toggle();
-   iwdg_reset();
-   float cpuLoad = scheduler->GetCpuLoad() / 10.0f;
-   Param::SetFloat(Param::cpuload, cpuLoad);
-   Param::SetInt(Param::lasterr, ErrorMessage::GetLastError());
-   int opmode = Param::GetInt(Param::opmode);
-   utils::SelectDirection(selectedVehicle , selectedShifter);
-   utils::CalcSOC();
+    DigIo::led_out.Toggle();
+    iwdg_reset();
+    float cpuLoad = scheduler->GetCpuLoad() / 10.0f;
+    Param::SetFloat(Param::cpuload, cpuLoad);
+    Param::SetInt(Param::lasterr, ErrorMessage::GetLastError());
+    int opmode = Param::GetInt(Param::opmode);
+    utils::SelectDirection(selectedVehicle, selectedShifter);
+    utils::CalcSOC();
 
-   Param::SetInt(Param::cruisestt, selectedVehicle->GetCruiseState());
-   Param::SetFloat(Param::FrontRearBal, selectedVehicle->GetFrontRearBalance());
+    Param::SetInt(Param::cruisestt, selectedVehicle->GetCruiseState());
+    Param::SetFloat(Param::FrontRearBal, selectedVehicle->GetFrontRearBalance());
 
-   utils::ProcessCruiseControlButtons();
+    utils::ProcessCruiseControlButtons();
 
-   selectedInverter->Task100Ms();
-   selectedVehicle->Task100Ms();
-   selectedCharger->Task100Ms();
-   selectedBMS->Task100Ms();
-   selectedDCDC->Task100Ms();
-   selectedShifter->Task100Ms();
-   canMap->SendAll();
-
-
-   if (Param::GetInt(Param::dir) < 0)
-   {
-      IOMatrix::GetPin(IOMatrix::REVERSELIGHT)->Set();
-   }
-   else
-   {
-      IOMatrix::GetPin(IOMatrix::REVERSELIGHT)->Clear();
-   }
-
-   if(opmode==MOD_RUN)
-   {
-      IOMatrix::GetPin(IOMatrix::RUNINDICATION)->Set();
-   }
-   else
-   {
-      IOMatrix::GetPin(IOMatrix::RUNINDICATION)->Clear();
-   }
+    selectedInverter->Task100Ms();
+    selectedVehicle->Task100Ms();
+    selectedCharger->Task100Ms();
+    selectedBMS->Task100Ms();
+    selectedDCDC->Task100Ms();
+    selectedShifter->Task100Ms();
+    canMap->SendAll();
 
 
-   Param::SetFloat(Param::tmphs, selectedInverter->GetInverterTemperature()); //send inverter temp to web interface
-   Param::SetFloat(Param::tmpm, selectedInverter->GetMotorTemperature()); //send motor temp to web interface
-   Param::SetFloat(Param::InvStat, selectedInverter->GetInverterState()); //update inverter status on web interface
-   Param::SetFloat(Param::INVudc, selectedInverter->GetInverterVoltage()); //display inverter derived dc link voltage on web interface
+    if (Param::GetInt(Param::dir) < 0)
+    {
+        IOMatrix::GetPin(IOMatrix::REVERSELIGHT)->Set();
+    }
+    else
+    {
+        IOMatrix::GetPin(IOMatrix::REVERSELIGHT)->Clear();
+    }
 
-   Param::SetInt(Param::T15Stat, selectedVehicle->Ready());
+    if(opmode==MOD_RUN)
+    {
+        IOMatrix::GetPin(IOMatrix::RUNINDICATION)->Set();
+    }
+    else
+    {
+        IOMatrix::GetPin(IOMatrix::RUNINDICATION)->Clear();
+    }
 
-   int32_t IsaTemp=ISA::Temperature;
-   Param::SetInt(Param::tmpaux,IsaTemp);
 
-   if(targetChgint == ChargeInterfaces::i3LIM || chargeModeDC) selectedChargeInt->Task100Ms();// send the 100ms task request for the lim all the time and for others if in DC charge mode
+    Param::SetFloat(Param::tmphs, selectedInverter->GetInverterTemperature()); //send inverter temp to web interface
+    Param::SetFloat(Param::tmpm, selectedInverter->GetMotorTemperature()); //send motor temp to web interface
+    Param::SetFloat(Param::InvStat, selectedInverter->GetInverterState()); //update inverter status on web interface
+    Param::SetFloat(Param::INVudc, selectedInverter->GetInverterVoltage()); //display inverter derived dc link voltage on web interface
 
-   if(selectedChargeInt->DCFCRequest(RunChg))//Request to run dc fast charge
-   {
-   //Here we receive a valid DCFC startup request.
-      if(opmode != MOD_RUN) chargeMode = true;// set charge mode to true to bring up hv
-      chargeModeDC = true;   //DC charge mode on
-   }
-   else if(chargeModeDC)
-   {
-      Param::SetInt(Param::chgtyp,OFF);
-      chargeMode = false;  //no charge mode
-      chargeModeDC = false;   //DC charge mode off
-   }
+    Param::SetInt(Param::T15Stat, selectedVehicle->Ready());
 
-   if(!chargeModeDC)//Request to run ac charge from the interface (e.g. LIM) if we are NOT in DC charge mode.
-   {
-      ACrequest=selectedChargeInt->ACRequest(RunChg);
-   }
+    int32_t IsaTemp=ISA::Temperature;
+    Param::SetInt(Param::tmpaux,IsaTemp);
 
-   Param::SetInt(Param::HeatReq,IOMatrix::GetPin(IOMatrix::HEATREQ)->Get());
+    if(targetChgint == ChargeInterfaces::i3LIM || chargeModeDC) selectedChargeInt->Task100Ms();// send the 100ms task request for the lim all the time and for others if in DC charge mode
+
+    if(selectedChargeInt->DCFCRequest(RunChg))//Request to run dc fast charge
+    {
+        //Here we receive a valid DCFC startup request.
+        if(opmode != MOD_RUN) chargeMode = true;// set charge mode to true to bring up hv
+        chargeModeDC = true;   //DC charge mode on
+    }
+    else if(chargeModeDC)
+    {
+        Param::SetInt(Param::chgtyp,OFF);
+        chargeMode = false;  //no charge mode
+        chargeModeDC = false;   //DC charge mode off
+    }
+
+    if(!chargeModeDC)//Request to run ac charge from the interface (e.g. LIM) if we are NOT in DC charge mode.
+    {
+        ACrequest=selectedChargeInt->ACRequest(RunChg);
+    }
+
+    Param::SetInt(Param::HeatReq,IOMatrix::GetPin(IOMatrix::HEATREQ)->Get());
 }
 
 static void ControlCabHeater(int opmode)
 {
-   //Only run heater in run mode
-   //What about charge mode and timer mode?
-   if (opmode == MOD_RUN && Param::GetInt(Param::Control) == 1)
-   {
-      IOMatrix::GetPin(IOMatrix::HEATERENABLE)->Set();//Heater enable and coolant pump on
-      selectedHeater->SetTargetTemperature(50); //TODO: Currently does nothing
-      selectedHeater->SetPower(Param::GetInt(Param::HeatPwr),Param::GetBool(Param::HeatReq));
-   }
-   else
-   {
-      IOMatrix::GetPin(IOMatrix::HEATERENABLE)->Clear(); //Disable heater and coolant pump
-      selectedHeater->SetPower(0,0);
-   }
+    //Only run heater in run mode
+    //What about charge mode and timer mode?
+    if (opmode == MOD_RUN && Param::GetInt(Param::Control) == 1)
+    {
+        IOMatrix::GetPin(IOMatrix::HEATERENABLE)->Set();//Heater enable and coolant pump on
+        selectedHeater->SetTargetTemperature(50); //TODO: Currently does nothing
+        selectedHeater->SetPower(Param::GetInt(Param::HeatPwr),Param::GetBool(Param::HeatReq));
+    }
+    else
+    {
+        IOMatrix::GetPin(IOMatrix::HEATERENABLE)->Clear(); //Disable heater and coolant pump
+        selectedHeater->SetPower(0,0);
+    }
 }
 
 static void Ms10Task(void)
 {
-   static uint32_t vehicleStartTime = 0;
+    static uint32_t vehicleStartTime = 0;
 
-   int16_t previousSpeed=Param::GetInt(Param::speed);
-   int16_t speed = 0;
-   float torquePercent;
-   int opmode = Param::GetInt(Param::opmode);
-   int stt = STAT_NONE;
-   int requestedDirection = Param::GetInt(Param::dir);
+    int16_t previousSpeed=Param::GetInt(Param::speed);
+    int16_t speed = 0;
+    float torquePercent;
+    int opmode = Param::GetInt(Param::opmode);
+    int stt = STAT_NONE;
+    int requestedDirection = Param::GetInt(Param::dir);
 
-   ErrorMessage::SetTime(rtc_get_counter_val());
+    ErrorMessage::SetTime(rtc_get_counter_val());
 
-   selectedChargeInt->Task10Ms();
+    selectedChargeInt->Task10Ms();
 
-   if (Param::GetInt(Param::opmode) == MOD_RUN)
-   {
-      torquePercent = utils::ProcessThrottle(previousSpeed);
+    if (Param::GetInt(Param::opmode) == MOD_RUN)
+    {
+        torquePercent = utils::ProcessThrottle(previousSpeed); //run the throttle reading and checks and then generate Potnom
 
-      //When requesting regen we need to be careful. If the car is not rolling
-      //in the same direction as the selected gear, we will actually accelerate!
-      //Exclude openinverter here because that has its own regen logic
-      if (torquePercent < 0 && Param::GetInt(Param::Inverter) != InvModes::OpenI)
-      {
-         int rollingDirection = previousSpeed >= 0 ? 1 : -1;
+        //! logic below is superseded by regen tapering
+        //When requesting regen we need to be careful. If the car is not rolling
+        //in the same direction as the selected gear, we will actually accelerate!
+        //Exclude openinverter here because that has its own regen logic
+        /*
+        if (torquePercent < 0 && Param::GetInt(Param::Inverter) != InvModes::OpenI)
+        {
+            int rollingDirection = previousSpeed >= 0 ? 1 : -1;
 
-         //When rolling backward while in forward gear, apply POSITIVE torque to slow down backward motion
-         //Vice versa when in reverse gear and rolling forward.
-         if (rollingDirection != requestedDirection)
-         {
-            torquePercent = -torquePercent;
-         }
-      }
-      else if (torquePercent >= 0)
-      {
-         torquePercent *= requestedDirection;
-      }
+            //When rolling backward while in forward gear, apply POSITIVE torque to slow down backward motion
+            //Vice versa when in reverse gear and rolling forward.
+            if (rollingDirection != requestedDirection)
+            {
+                torquePercent = -torquePercent;
+            }
+        }
+        else if (torquePercent >= 0)
+        {
+            torquePercent *= requestedDirection;
+        }
+        */
 
-      selectedInverter->Task10Ms();
-   }
-   else
-   {
-      torquePercent = 0;
-      utils::displayThrottle();//just displays pot and pot2 when not in run mode to allow throttle cal
-   }
+        torquePercent *= requestedDirection; //torque requests invert when reverse direction is selected
+
+        selectedInverter->Task10Ms();
+    }
+    else
+    {
+        torquePercent = 0;
+        utils::displayThrottle();//just displays pot and pot2 when not in run mode to allow throttle cal
+    }
 
 
-   selectedInverter->SetTorque(torquePercent);
-   speed = ABS(selectedInverter->GetMotorSpeed());//set motor rpm on interface
+    selectedInverter->SetTorque(torquePercent);
+    speed = ABS(selectedInverter->GetMotorSpeed());//set motor rpm on interface
 
-   Param::SetInt(Param::speed, speed);
-   utils::GetDigInputs(canInterface[Param::GetInt(Param::InverterCan)]);
+    Param::SetInt(Param::speed, speed);
+    utils::GetDigInputs(canInterface[Param::GetInt(Param::InverterCan)]);
 
-   selectedVehicle->SetRevCounter(ABS(Param::GetInt(Param::speed)));
-   selectedVehicle->SetTemperatureGauge(Param::GetFloat(Param::tmphs));
-   selectedVehicle->Task10Ms();
-   selectedDCDC->Task10Ms();
-   selectedShifter->Task10Ms();
-   if(opmode==MOD_CHARGE) selectedCharger->Task10Ms();
-   if(opmode==MOD_RUN) Param::SetInt(Param::canctr, (Param::GetInt(Param::canctr) + 1) & 0xF);//Update the OI can counter in RUN mode only
+    selectedVehicle->SetRevCounter(ABS(Param::GetInt(Param::speed)));
+    selectedVehicle->SetTemperatureGauge(Param::GetFloat(Param::tmphs));
+    selectedVehicle->Task10Ms();
+    selectedDCDC->Task10Ms();
+    selectedShifter->Task10Ms();
+    if(opmode==MOD_CHARGE) selectedCharger->Task10Ms();
+    if(opmode==MOD_RUN) Param::SetInt(Param::canctr, (Param::GetInt(Param::canctr) + 1) & 0xF);//Update the OI can counter in RUN mode only
 
-   //////////////////////////////////////////////////
-   //            MODE CONTROL SECTION              //
-   //////////////////////////////////////////////////
-   float udc = utils::ProcessUdc(GetInt(Param::speed));
-   stt |= Param::GetInt(Param::pot) <= Param::GetInt(Param::potmin) ? STAT_NONE : STAT_POTPRESSED;
-   stt |= udc >= Param::GetFloat(Param::udcsw) ? STAT_NONE : STAT_UDCBELOWUDCSW;
-   stt |= udc < Param::GetFloat(Param::udclim) ? STAT_NONE : STAT_UDCLIM;
-   Param::SetInt(Param::status, stt);
+    //////////////////////////////////////////////////
+    //            MODE CONTROL SECTION              //
+    //////////////////////////////////////////////////
+    float udc = utils::ProcessUdc(GetInt(Param::speed));
+    stt |= Param::GetInt(Param::pot) <= Param::GetInt(Param::potmin) ? STAT_NONE : STAT_POTPRESSED;
+    stt |= udc >= Param::GetFloat(Param::udcsw) ? STAT_NONE : STAT_UDCBELOWUDCSW;
+    stt |= udc < Param::GetFloat(Param::udclim) ? STAT_NONE : STAT_UDCLIM;
+    Param::SetInt(Param::status, stt);
 
-switch (opmode)
-   {
-   case MOD_OFF:
-      initbyStart=false;
-      initbyCharge=false;
-      DigIo::inv_out.Clear();//inverter power off
-      DigIo::dcsw_out.Clear();
-      IOMatrix::GetPin(IOMatrix::NEGCONTACTOR)->Clear();//Negative contactors off if used
-      IOMatrix::GetPin(IOMatrix::COOLANTPUMP)->Clear();//Coolant pump off if used
-      DigIo::prec_out.Clear();
-      Param::SetInt(Param::dir, 0); // shift to park/neutral on shutdown regardless of shifter pos
-      selectedVehicle->DashOff();
-      StartSig=false;//reset for next time
-      if(Param::GetInt(Param::pot) < Param::GetInt(Param::potmin))
-      {
-      if ((selectedVehicle->Start() && selectedVehicle->Ready()))
-         {
-            StartSig=true;
-            opmode = MOD_PRECHARGE;//proceed to precharge if 1)throttle not pressed , 2)ign on , 3)start signal rx
+    switch (opmode)
+    {
+    case MOD_OFF:
+        initbyStart=false;
+        initbyCharge=false;
+        DigIo::inv_out.Clear();//inverter power off
+        DigIo::dcsw_out.Clear();
+        IOMatrix::GetPin(IOMatrix::NEGCONTACTOR)->Clear();//Negative contactors off if used
+        IOMatrix::GetPin(IOMatrix::COOLANTPUMP)->Clear();//Coolant pump off if used
+        DigIo::prec_out.Clear();
+        Param::SetInt(Param::dir, 0); // shift to park/neutral on shutdown regardless of shifter pos
+        selectedVehicle->DashOff();
+        StartSig=false;//reset for next time
+        if(Param::GetInt(Param::pot) < Param::GetInt(Param::potmin))
+        {
+            if ((selectedVehicle->Start() && selectedVehicle->Ready()))
+            {
+                StartSig=true;
+                opmode = MOD_PRECHARGE;//proceed to precharge if 1)throttle not pressed , 2)ign on , 3)start signal rx
+                vehicleStartTime = rtc_get_counter_val();
+                initbyStart=true;
+            }
+        }
+        if(chargeMode)
+        {
+            opmode = MOD_PRECHARGE;//proceed to precharge if charge requested.
             vehicleStartTime = rtc_get_counter_val();
-            initbyStart=true;
-         }
-      }
-      if(chargeMode)
-      {
-       opmode = MOD_PRECHARGE;//proceed to precharge if charge requested.
-       vehicleStartTime = rtc_get_counter_val();
-       initbyCharge=true;
-      }
-      Param::SetInt(Param::opmode, opmode);
-   break;
+            initbyCharge=true;
+        }
+        Param::SetInt(Param::opmode, opmode);
+        break;
 
-   case MOD_PRECHARGE:
-      if (!chargeMode)
-      {
-         DigIo::inv_out.Set();//inverter power on but not if we are in charge mode!
-      }
-      IOMatrix::GetPin(IOMatrix::NEGCONTACTOR)->Set();
-      IOMatrix::GetPin(IOMatrix::COOLANTPUMP)->Set();
-      DigIo::prec_out.Set();//commence precharge
-      if ((stt & (STAT_POTPRESSED | STAT_UDCBELOWUDCSW | STAT_UDCLIM)) == STAT_NONE)
-      {
-         if(StartSig)
-         {
-         opmode = MOD_RUN;
-         StartSig=false;//reset for next time
-         }
-         else if(chargeMode) opmode = MOD_CHARGE;
-      }
-      if(initbyCharge && !chargeMode) opmode = MOD_OFF;// These two statements catch a precharge hang from either start mode or run mode.
-      if(initbyStart && !selectedVehicle->Ready()) opmode = MOD_OFF;
-      if (udc < (Param::GetInt(Param::udcsw)) && rtc_get_counter_val() > (vehicleStartTime + PRECHARGE_TIMEOUT))
-      {
-         DigIo::prec_out.Clear();
-         ErrorMessage::Post(ERR_PRECHARGE);
-         opmode = MOD_PCHFAIL;
-      }
-      Param::SetInt(Param::opmode, opmode);
-   break;
+    case MOD_PRECHARGE:
+        if (!chargeMode)
+        {
+            DigIo::inv_out.Set();//inverter power on but not if we are in charge mode!
+        }
+        IOMatrix::GetPin(IOMatrix::NEGCONTACTOR)->Set();
+        IOMatrix::GetPin(IOMatrix::COOLANTPUMP)->Set();
+        DigIo::prec_out.Set();//commence precharge
+        if ((stt & (STAT_POTPRESSED | STAT_UDCBELOWUDCSW | STAT_UDCLIM)) == STAT_NONE)
+        {
+            if(StartSig)
+            {
+                opmode = MOD_RUN;
+                StartSig=false;//reset for next time
+            }
+            else if(chargeMode) opmode = MOD_CHARGE;
+        }
+        if(initbyCharge && !chargeMode) opmode = MOD_OFF;// These two statements catch a precharge hang from either start mode or run mode.
+        if(initbyStart && !selectedVehicle->Ready()) opmode = MOD_OFF;
+        if (udc < (Param::GetInt(Param::udcsw)) && rtc_get_counter_val() > (vehicleStartTime + PRECHARGE_TIMEOUT))
+        {
+            DigIo::prec_out.Clear();
+            ErrorMessage::Post(ERR_PRECHARGE);
+            opmode = MOD_PCHFAIL;
+        }
+        Param::SetInt(Param::opmode, opmode);
+        break;
 
-   case MOD_PCHFAIL:
-      StartSig=false;
-      DigIo::prec_out.Clear();//explicitly turn off precharge relay in a fail condition
-      if(initbyCharge && !chargeMode) opmode = MOD_OFF;//only go to off if the signal from charge or vehicle start is removed
-      if(initbyStart && !selectedVehicle->Ready()) opmode = MOD_OFF;//this avoids oscillation in the event of a precharge system failure
-      Param::SetInt(Param::opmode, opmode);
-   break;
+    case MOD_PCHFAIL:
+        StartSig=false;
+        DigIo::prec_out.Clear();//explicitly turn off precharge relay in a fail condition
+        if(initbyCharge && !chargeMode) opmode = MOD_OFF;//only go to off if the signal from charge or vehicle start is removed
+        if(initbyStart && !selectedVehicle->Ready()) opmode = MOD_OFF;//this avoids oscillation in the event of a precharge system failure
+        Param::SetInt(Param::opmode, opmode);
+        break;
 
-   case MOD_CHARGE:
-      DigIo::dcsw_out.Set();
-      ErrorMessage::UnpostAll();
-      if(!chargeMode) opmode = MOD_OFF;
-      Param::SetInt(Param::opmode, opmode);
-   break;
+    case MOD_CHARGE:
+        DigIo::dcsw_out.Set();
+        ErrorMessage::UnpostAll();
+        if(!chargeMode) opmode = MOD_OFF;
+        Param::SetInt(Param::opmode, opmode);
+        break;
 
-   case MOD_RUN:
-      DigIo::dcsw_out.Set();
-      Param::SetInt(Param::opmode, MOD_RUN);
-      ErrorMessage::UnpostAll();
-      if(!selectedVehicle->Ready()) opmode = MOD_OFF;
-      Param::SetInt(Param::opmode, opmode);
-   break;
+    case MOD_RUN:
+        DigIo::dcsw_out.Set();
+        Param::SetInt(Param::opmode, MOD_RUN);
+        ErrorMessage::UnpostAll();
+        if(!selectedVehicle->Ready()) opmode = MOD_OFF;
+        Param::SetInt(Param::opmode, opmode);
+        break;
 
 
-   }
+    }
 
-   ControlCabHeater(opmode);
-   if (Param::GetInt(Param::Type) == 1)  SBOX::ControlContactors(opmode,canInterface[Param::GetInt(Param::ShuntCan)]);//BMW contactor box
-   if (Param::GetInt(Param::Type) == 2)  VWBOX::ControlContactors(opmode,canInterface[Param::GetInt(Param::ShuntCan)]);//VW contactor box
+    ControlCabHeater(opmode);
+    if (Param::GetInt(Param::Type) == 1)  SBOX::ControlContactors(opmode,canInterface[Param::GetInt(Param::ShuntCan)]);//BMW contactor box
+    if (Param::GetInt(Param::Type) == 2)  VWBOX::ControlContactors(opmode,canInterface[Param::GetInt(Param::ShuntCan)]);//VW contactor box
 
 }
 
 static void Ms1Task(void)
 {
-   selectedInverter->Task1Ms();
-   selectedVehicle->Task1Ms();
-   selectedCharger->Task1Ms();
-   selectedChargeInt->Task1Ms();
-   selectedShifter->Task1Ms();
-   selectedDCDC->Task1Ms();
+    selectedInverter->Task1Ms();
+    selectedVehicle->Task1Ms();
+    selectedCharger->Task1Ms();
+    selectedChargeInt->Task1Ms();
+    selectedShifter->Task1Ms();
+    selectedDCDC->Task1Ms();
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 static void UpdateInv()
 {
-   selectedInverter->DeInit();
-   switch (Param::GetInt(Param::Inverter))
-   {
-      case InvModes::NoInv:
-         selectedInverter = &NoInverter;
-         break;
-      case InvModes::Leaf_Gen1:
-         selectedInverter = &leafInv;
-         break;
-      case InvModes::GS450H:
-         selectedInverter = &gs450Inverter;
-         gs450Inverter.SetGS450H();
-         break;
-     case InvModes::GS300H:
-         selectedInverter = &gs450Inverter;
-         gs450Inverter.SetGS300H();
-         break;
-      case InvModes::Prius_Gen3:
-         selectedInverter = &gs450Inverter;
-         gs450Inverter.SetPrius();
-         break;
-      case InvModes::Outlander:
-         selectedInverter = &outlanderInv;
-         break;
-      case InvModes::OpenI:
-         selectedInverter = &openInv;
-         break;
-   }
-   //This will call SetCanFilters() via the Clear Callback
-   canInterface[0]->ClearUserMessages();
-   canInterface[1]->ClearUserMessages();
+    selectedInverter->DeInit();
+    switch (Param::GetInt(Param::Inverter))
+    {
+    case InvModes::NoInv:
+        selectedInverter = &NoInverter;
+        break;
+    case InvModes::Leaf_Gen1:
+        selectedInverter = &leafInv;
+        break;
+    case InvModes::GS450H:
+        selectedInverter = &gs450Inverter;
+        gs450Inverter.SetGS450H();
+        break;
+    case InvModes::GS300H:
+        selectedInverter = &gs450Inverter;
+        gs450Inverter.SetGS300H();
+        break;
+    case InvModes::Prius_Gen3:
+        selectedInverter = &gs450Inverter;
+        gs450Inverter.SetPrius();
+        break;
+    case InvModes::Outlander:
+        selectedInverter = &outlanderInv;
+        break;
+    case InvModes::OpenI:
+        selectedInverter = &openInv;
+        break;
+    case InvModes::RearOutlander:
+        selectedInverter = &rearoutlanderInv;
+        break;
+    }
+    //This will call SetCanFilters() via the Clear Callback
+    canInterface[0]->ClearUserMessages();
+    canInterface[1]->ClearUserMessages();
 }
 
 static void UpdateVehicle()
 {
-   switch (Param::GetInt(Param::Vehicle))
-   {
-      case BMW_E39:
-         selectedVehicle = &e39Vehicle;
-         e39Vehicle.SetE46(false);
-         break;
-      case BMW_E46:
-         selectedVehicle = &e39Vehicle;
-         e39Vehicle.SetE46(true);
-         break;
-      case BMW_E65:
-         selectedVehicle = &e65Vehicle;
-         break;
-      case VAG:
-         selectedVehicle = &vagVehicle;
-         break;
-      case SUBARU:
-         selectedVehicle = &subaruVehicle;
-         break;
-     case BMW_E31:
-         selectedVehicle = &e31Vehicle;
-         break;
+    switch (Param::GetInt(Param::Vehicle))
+    {
+    case BMW_E39:
+        selectedVehicle = &e39Vehicle;
+        e39Vehicle.SetE46(false);
+        break;
+    case BMW_E46:
+        selectedVehicle = &e39Vehicle;
+        e39Vehicle.SetE46(true);
+        break;
+    case BMW_E65:
+        selectedVehicle = &e65Vehicle;
+        break;
+    case VAG:
+        selectedVehicle = &vagVehicle;
+        break;
+    case SUBARU:
+        selectedVehicle = &subaruVehicle;
+        break;
+    case BMW_E31:
+        selectedVehicle = &e31Vehicle;
+        break;
 
-   }
-   //This will call SetCanFilters() via the Clear Callback
-   canInterface[0]->ClearUserMessages();
-   canInterface[1]->ClearUserMessages();
+    }
+    //This will call SetCanFilters() via the Clear Callback
+    canInterface[0]->ClearUserMessages();
+    canInterface[1]->ClearUserMessages();
 
 }
 
 static void UpdateCharger()
 {
-   selectedCharger->DeInit();
-   switch (Param::GetInt(Param::chargemodes))
-   {
-      case ChargeModes::Off:
-      chargeMode = false;
-      selectedCharger = &nochg;
-         break;
-      case ChargeModes::EXT_DIGI:
-      selectedCharger = &chgdigi;
-         break;
-      case ChargeModes::Volt_Ampera:
-      selectedCharger = &ampChg;
-         break;
-      case ChargeModes::Leaf_PDM:
-      selectedCharger = &chargerPDM;
-         break;
-      case ChargeModes::TeslaOI:
-      selectedCharger = &ChargerTesla;
-         break;
-      case ChargeModes::Out_lander:
-      selectedCharger = &outChg;
-         break;
+    selectedCharger->DeInit();
+    switch (Param::GetInt(Param::chargemodes))
+    {
+    case ChargeModes::Off:
+        chargeMode = false;
+        selectedCharger = &nochg;
+        break;
+    case ChargeModes::EXT_DIGI:
+        selectedCharger = &chgdigi;
+        break;
+    case ChargeModes::Volt_Ampera:
+        selectedCharger = &ampChg;
+        break;
+    case ChargeModes::Leaf_PDM:
+        selectedCharger = &chargerPDM;
+        break;
+    case ChargeModes::TeslaOI:
+        selectedCharger = &ChargerTesla;
+        break;
+    case ChargeModes::Out_lander:
+        selectedCharger = &outChg;
+        break;
 
-               case ChargeModes::Elcon:
-      selectedCharger = &ChargerElcon;
-         break;
+    case ChargeModes::Elcon:
+        selectedCharger = &ChargerElcon;
+        break;
 
-   }
-   //This will call SetCanFilters() via the Clear Callback
-   canInterface[0]->ClearUserMessages();
-   canInterface[1]->ClearUserMessages();
+    }
+    //This will call SetCanFilters() via the Clear Callback
+    canInterface[0]->ClearUserMessages();
+    canInterface[1]->ClearUserMessages();
 }
 
 static void UpdateChargeInt()
 {
-   selectedChargeInt->DeInit();
-   switch (Param::GetInt(Param::interface))
-   {
-      case ChargeInterfaces::Unused:
-      selectedChargeInt = &UnUsed;
-         break;
-      case ChargeInterfaces::Chademo:
-      selectedChargeInt = &chademoFC;
-         break;
-      case ChargeInterfaces::i3LIM:
-      selectedChargeInt = &LIMFC;
-         break;
-               case ChargeInterfaces::CPC:
-      selectedChargeInt = &CPCcan;
-         break;
-   }
-   //This will call SetCanFilters() via the Clear Callback
-   canInterface[0]->ClearUserMessages();
-   canInterface[1]->ClearUserMessages();
+    selectedChargeInt->DeInit();
+    switch (Param::GetInt(Param::interface))
+    {
+    case ChargeInterfaces::Unused:
+        selectedChargeInt = &UnUsed;
+        break;
+    case ChargeInterfaces::Chademo:
+        selectedChargeInt = &chademoFC;
+        break;
+    case ChargeInterfaces::i3LIM:
+        selectedChargeInt = &LIMFC;
+        break;
+    case ChargeInterfaces::CPC:
+        selectedChargeInt = &CPCcan;
+        break;
+    }
+    //This will call SetCanFilters() via the Clear Callback
+    canInterface[0]->ClearUserMessages();
+    canInterface[1]->ClearUserMessages();
 }
 
 static void UpdateHeater()
 {
-   selectedHeater->DeInit();
-   switch (Param::GetInt(Param::Heater))
-   {
-      case HeatType::Noheater:
-      selectedHeater = &Heaternone;
-         break;
-      case HeatType::AmpHeater:
-      selectedHeater = &amperaHeater;
-         break;
-      case HeatType::VW:
-         break;
-   }
-   //This will call SetCanFilters() via the Clear Callback
-   canInterface[0]->ClearUserMessages();
-   canInterface[1]->ClearUserMessages();
+    selectedHeater->DeInit();
+    switch (Param::GetInt(Param::Heater))
+    {
+    case HeatType::Noheater:
+        selectedHeater = &Heaternone;
+        break;
+    case HeatType::AmpHeater:
+        selectedHeater = &amperaHeater;
+        break;
+    case HeatType::VW:
+        break;
+    }
+    //This will call SetCanFilters() via the Clear Callback
+    canInterface[0]->ClearUserMessages();
+    canInterface[1]->ClearUserMessages();
 }
 
 static void UpdateBMS()
 {
-      selectedBMS->DeInit();
-      switch (Param::GetInt(Param::BMS_Mode))
-      {
-         case BMSModes::BMSModeSimpBMS:
-            selectedBMS = &BMSsimp;
-            break;
-         case BMSModes::BMSModeDaisychainSingleBMS:
-         case BMSModes::BMSModeDaisychainDualBMS:
-            selectedBMS = &BMSdaisychain;
-            break;
-         default:
-            // Default to no BMS
-            selectedBMS = &BMSnone;
-            break;
-      }
-   //This will call SetCanFilters() via the Clear Callback
-   canInterface[0]->ClearUserMessages();
-   canInterface[1]->ClearUserMessages();
+    selectedBMS->DeInit();
+    switch (Param::GetInt(Param::BMS_Mode))
+    {
+    case BMSModes::BMSModeSimpBMS:
+        selectedBMS = &BMSsimp;
+        break;
+    case BMSModes::BMSModeDaisychainSingleBMS:
+    case BMSModes::BMSModeDaisychainDualBMS:
+        selectedBMS = &BMSdaisychain;
+        break;
+    default:
+        // Default to no BMS
+        selectedBMS = &BMSnone;
+        break;
+    }
+    //This will call SetCanFilters() via the Clear Callback
+    canInterface[0]->ClearUserMessages();
+    canInterface[1]->ClearUserMessages();
 }
 
 static void UpdateDCDC()
 {
-      selectedBMS->DeInit();
-      switch (Param::GetInt(Param::DCdc_Type))
-      {
-         case DCDCModes::NoDCDC:
-            selectedDCDC = &DCDCnone;
-            break;
+    selectedBMS->DeInit();
+    switch (Param::GetInt(Param::DCdc_Type))
+    {
+    case DCDCModes::NoDCDC:
+        selectedDCDC = &DCDCnone;
+        break;
 
-        case DCDCModes::TeslaG2:
-            selectedDCDC = &DCDCTesla;
-            break;
+    case DCDCModes::TeslaG2:
+        selectedDCDC = &DCDCTesla;
+        break;
 
-         default:
-            // Default to no DCDC
-            selectedDCDC = &DCDCnone;
-            break;
-      }
-   //This will call SetCanFilters() via the Clear Callback
-   canInterface[0]->ClearUserMessages();
-   canInterface[1]->ClearUserMessages();
+    default:
+        // Default to no DCDC
+        selectedDCDC = &DCDCnone;
+        break;
+    }
+    //This will call SetCanFilters() via the Clear Callback
+    canInterface[0]->ClearUserMessages();
+    canInterface[1]->ClearUserMessages();
 }
 
 
 static void UpdateShifter()
 {
 
-      switch (Param::GetInt(Param::GearLvr))
-      {
-         case ShifterModes::NoShifter:
-            selectedShifter = &shifterNone;
-            break;
+    switch (Param::GetInt(Param::GearLvr))
+    {
+    case ShifterModes::NoShifter:
+        selectedShifter = &shifterNone;
+        break;
 
-        case ShifterModes::BMWF30:
-            selectedShifter = &F30GearLever;
-            break;
+    case ShifterModes::BMWF30:
+        selectedShifter = &F30GearLever;
+        break;
 
-         default:
-            // Default to no shifter
-            selectedShifter = &shifterNone;
-            break;
-      }
-   //This will call SetCanFilters() via the Clear Callback
-   canInterface[0]->ClearUserMessages();
-   canInterface[1]->ClearUserMessages();
+    default:
+        // Default to no shifter
+        selectedShifter = &shifterNone;
+        break;
+    }
+    //This will call SetCanFilters() via the Clear Callback
+    canInterface[0]->ClearUserMessages();
+    canInterface[1]->ClearUserMessages();
 }
 
 
@@ -705,277 +726,287 @@ static void UpdateShifter()
 //CAN interface of a device, this will be called by the CanHardware module
 static void SetCanFilters()
 {
-   CanHardware* inverter_can = canInterface[Param::GetInt(Param::InverterCan)];
-   CanHardware* vehicle_can = canInterface[Param::GetInt(Param::VehicleCan)];
-   CanHardware* shunt_can = canInterface[Param::GetInt(Param::ShuntCan)];
-   CanHardware* lim_can = canInterface[Param::GetInt(Param::LimCan)];
-   CanHardware* charger_can = canInterface[Param::GetInt(Param::ChargerCan)];
-   CanHardware* bms_can = canInterface[Param::GetInt(Param::BMSCan)];
-   CanHardware* obd2_can = canInterface[Param::GetInt(Param::OBD2Can)];
-   CanHardware* dcdc_can = canInterface[Param::GetInt(Param::DCDCCan)];
+    CanHardware* inverter_can = canInterface[Param::GetInt(Param::InverterCan)];
+    CanHardware* vehicle_can = canInterface[Param::GetInt(Param::VehicleCan)];
+    CanHardware* shunt_can = canInterface[Param::GetInt(Param::ShuntCan)];
+    CanHardware* lim_can = canInterface[Param::GetInt(Param::LimCan)];
+    CanHardware* charger_can = canInterface[Param::GetInt(Param::ChargerCan)];
+    CanHardware* bms_can = canInterface[Param::GetInt(Param::BMSCan)];
+    CanHardware* obd2_can = canInterface[Param::GetInt(Param::OBD2Can)];
+    CanHardware* dcdc_can = canInterface[Param::GetInt(Param::DCDCCan)];
 
-   selectedInverter->SetCanInterface(inverter_can);
-   selectedVehicle->SetCanInterface(vehicle_can);
-   selectedCharger->SetCanInterface(charger_can);
-   selectedChargeInt->SetCanInterface(lim_can);
-   selectedBMS->SetCanInterface(bms_can);
-   selectedDCDC->SetCanInterface(dcdc_can);
-   selectedShifter->SetCanInterface(vehicle_can);
-   canOBD2.SetCanInterface(obd2_can);
+    selectedInverter->SetCanInterface(inverter_can);
+    selectedVehicle->SetCanInterface(vehicle_can);
+    selectedCharger->SetCanInterface(charger_can);
+    selectedChargeInt->SetCanInterface(lim_can);
+    selectedBMS->SetCanInterface(bms_can);
+    selectedDCDC->SetCanInterface(dcdc_can);
+    selectedShifter->SetCanInterface(vehicle_can);
+    canOBD2.SetCanInterface(obd2_can);
 
-   if (Param::GetInt(Param::Type) == 0)  ISA::RegisterCanMessages(shunt_can);//select isa shunt
-   if (Param::GetInt(Param::Type) == 1)  SBOX::RegisterCanMessages(shunt_can);//select bmw sbox
-   if (Param::GetInt(Param::Type) == 2)  VWBOX::RegisterCanMessages(shunt_can);//select vw sbox
+    if (Param::GetInt(Param::Type) == 0)  ISA::RegisterCanMessages(shunt_can);//select isa shunt
+    if (Param::GetInt(Param::Type) == 1)  SBOX::RegisterCanMessages(shunt_can);//select bmw sbox
+    if (Param::GetInt(Param::Type) == 2)  VWBOX::RegisterCanMessages(shunt_can);//select vw sbox
+
+    canInterface[1]->RegisterUserMessage(0x601); //CanSDO
+    canInterface[0]->RegisterUserMessage(0x601); //CanSDO
 
 }
 
 void Param::Change(Param::PARAM_NUM paramNum)
 {
-   // This function is called when the user changes a parameter
-   switch (paramNum)
-   {
-   case Param::Inverter:
-      UpdateInv();
-      break;
-   case Param::Vehicle:
-      UpdateVehicle();
-      break;
-   case Param::chargemodes:
-      UpdateCharger();
-      break;
-   case Param::interface:
-      UpdateChargeInt();
-      break;
-   case Param::Heater:
-      UpdateHeater();
-      break;
-   case Param::BMS_Mode:
-      UpdateBMS();
-      break;
-   case Param::DCdc_Type:
-      UpdateDCDC();
-      break;
-   case Param::GearLvr:
-      UpdateShifter();
-      break;
-   case Param::InverterCan:
-   case Param::VehicleCan:
-   case Param::ShuntCan:
-   case Param::LimCan:
-   case Param::ChargerCan:
-      canInterface[0]->ClearUserMessages();
-      canInterface[1]->ClearUserMessages();
-      break;
-   case Param::CAN3Speed:
-      CANSPI_Initialize();// init the MCP25625 on CAN3
-      CANSPI_ENRx_IRQ();  //init CAN3 Rx IRQ
-      break;
-   case Param::Tim3_Presc:
-   case Param::Tim3_Period:
-   case Param::Tim3_1_OC:
-   case Param::Tim3_2_OC:
-   case Param::Tim3_3_OC:
-   case Param::PWM1Func:
-   case Param::PWM2Func:
-   case Param::PWM3Func:
-      tim3_setup();
-      break;
-   default:
-      break;
-   }
+    // This function is called when the user changes a parameter
+    switch (paramNum)
+    {
+    case Param::Inverter:
+        UpdateInv();
+        break;
+    case Param::Vehicle:
+        UpdateVehicle();
+        break;
+    case Param::chargemodes:
+        UpdateCharger();
+        break;
+    case Param::interface:
+        UpdateChargeInt();
+        break;
+    case Param::Heater:
+        UpdateHeater();
+        break;
+    case Param::BMS_Mode:
+        UpdateBMS();
+        break;
+    case Param::DCdc_Type:
+        UpdateDCDC();
+        break;
+    case Param::GearLvr:
+        UpdateShifter();
+        break;
+    case Param::InverterCan:
+    case Param::VehicleCan:
+    case Param::ShuntCan:
+    case Param::LimCan:
+    case Param::ChargerCan:
+        canInterface[0]->ClearUserMessages();
+        canInterface[1]->ClearUserMessages();
+        break;
+    case Param::CAN3Speed:
+        CANSPI_Initialize();// init the MCP25625 on CAN3
+        CANSPI_ENRx_IRQ();  //init CAN3 Rx IRQ
+        break;
+    case Param::Tim3_Presc:
+    case Param::Tim3_Period:
+    case Param::Tim3_1_OC:
+    case Param::Tim3_2_OC:
+    case Param::Tim3_3_OC:
+    case Param::PWM1Func:
+    case Param::PWM2Func:
+    case Param::PWM3Func:
+        tim3_setup();
+        break;
+    default:
+        break;
+    }
 
-   Throttle::potmin[0] = Param::GetInt(Param::potmin);
-   Throttle::potmax[0] = Param::GetInt(Param::potmax);
-   Throttle::potmin[1] = Param::GetInt(Param::pot2min);
-   Throttle::potmax[1] = Param::GetInt(Param::pot2max);
-   Throttle::regenTravel = Param::GetFloat(Param::regentravel);
-   Throttle::regenmax = Param::GetFloat(Param::regenmax);
-   Throttle::throtmax = Param::GetFloat(Param::throtmax);
-   Throttle::throtmin = Param::GetFloat(Param::throtmin);
-   Throttle::throtdead = Param::GetFloat(Param::throtdead);
-   Throttle::idcmin = Param::GetFloat(Param::idcmin);
-   Throttle::idcmax = Param::GetFloat(Param::idcmax);
-   Throttle::udcmin = Param::GetFloat(Param::udcmin);
-   Throttle::speedLimit = Param::GetInt(Param::revlim);
-   Throttle::regenRamp = Param::GetFloat(Param::regenramp);
-   targetCharger=static_cast<ChargeModes>(Param::GetInt(Param::chargemodes));//get charger setting from menu
-   targetChgint=static_cast<ChargeInterfaces>(Param::GetInt(Param::interface));//get interface setting from menu
-   if(ChgSet==1)
-   {
-      seconds=Param::GetInt(Param::Set_Sec);//only update these params if charge command is set to disable
-      minutes=Param::GetInt(Param::Set_Min);
-      hours=Param::GetInt(Param::Set_Hour);
-      days=Param::GetInt(Param::Set_Day);
-      ChgHrs_tmp=GetInt(Param::Chg_Hrs);
-      ChgMins_tmp=GetInt(Param::Chg_Min);
-      ChgDur_tmp=GetInt(Param::Chg_Dur);
-   }
-   ChgSet = Param::GetInt(Param::Chgctrl);//0=enable,1=disable,2=timer.
-   ChgTicks = (GetInt(Param::Chg_Dur)*300);//number of 200ms ticks that equates to charge timer in minutes
-   IOMatrix::AssignFromParams();
-   IOMatrix::AssignFromParamsAnalogue();
+    Throttle::potmin[0] = Param::GetInt(Param::potmin);
+    Throttle::potmax[0] = Param::GetInt(Param::potmax);
+    Throttle::potmin[1] = Param::GetInt(Param::pot2min);
+    Throttle::potmax[1] = Param::GetInt(Param::pot2max);
+    Throttle::regenRpm = Param::GetFloat(Param::regenrpm);
+    Throttle::regenmax = Param::GetFloat(Param::regenmax);
+    Throttle::throtmax = Param::GetFloat(Param::throtmax);
+    Throttle::throtmin = Param::GetFloat(Param::throtmin);
+    Throttle::throtdead = Param::GetFloat(Param::throtdead);
+    Throttle::idcmin = Param::GetFloat(Param::idcmin);
+    Throttle::idcmax = Param::GetFloat(Param::idcmax);
+    Throttle::udcmin = Param::GetFloat(Param::udcmin);
+    Throttle::udcmax = Param::GetFloat(Param::udclim);
+    Throttle::speedLimit = Param::GetInt(Param::revlim);
+    Throttle::regenRamp = Param::GetFloat(Param::regenramp);
+    Throttle::throtmaxRev = Param::GetFloat(throtmaxRev);
+    Throttle::regenBrake = Param::GetFloat(Param::regenBrake);
+
+    targetCharger=static_cast<ChargeModes>(Param::GetInt(Param::chargemodes));//get charger setting from menu
+    targetChgint=static_cast<ChargeInterfaces>(Param::GetInt(Param::interface));//get interface setting from menu
+    if(ChgSet==1)
+    {
+        seconds=Param::GetInt(Param::Set_Sec);//only update these params if charge command is set to disable
+        minutes=Param::GetInt(Param::Set_Min);
+        hours=Param::GetInt(Param::Set_Hour);
+        days=Param::GetInt(Param::Set_Day);
+        ChgHrs_tmp=GetInt(Param::Chg_Hrs);
+        ChgMins_tmp=GetInt(Param::Chg_Min);
+        ChgDur_tmp=GetInt(Param::Chg_Dur);
+    }
+    ChgSet = Param::GetInt(Param::Chgctrl);//0=enable,1=disable,2=timer.
+    ChgTicks = (GetInt(Param::Chg_Dur)*300);//number of 200ms ticks that equates to charge timer in minutes
+    IOMatrix::AssignFromParams();
+    IOMatrix::AssignFromParamsAnalogue();
 }
 
 
 static bool CanCallback(uint32_t id, uint32_t data[2], uint8_t dlc) //This is where we go when a defined CAN message is received.
 {
-   dlc = dlc;
-   switch (id)
-   {
-      case 0x7DF:
+    dlc = dlc;
+    switch (id)
+    {
+    case 0x7DF:
         canOBD2.DecodeCAN(id,data);
         break;
 
-   default:
-   if (Param::GetInt(Param::Type) == 0)  ISA::DecodeCAN(id, data);
-   if (Param::GetInt(Param::Type) == 1)  SBOX::DecodeCAN(id, data);
-   if (Param::GetInt(Param::Type) == 2)  VWBOX::DecodeCAN(id, data);
-      selectedInverter->DecodeCAN(id, data);
-      selectedVehicle->DecodeCAN(id, data);
-      selectedCharger->DecodeCAN(id, data);
-      selectedChargeInt->DecodeCAN(id, data);
-      selectedBMS->DecodeCAN(id, (uint8_t*)data);
-      selectedDCDC->DecodeCAN(id, (uint8_t*)data);
-      selectedShifter->DecodeCAN(id,data);
-      break;
-   }
-   return false;
+    default:
+        if (Param::GetInt(Param::Type) == 0)  ISA::DecodeCAN(id, data);
+        if (Param::GetInt(Param::Type) == 1)  SBOX::DecodeCAN(id, data);
+        if (Param::GetInt(Param::Type) == 2)  VWBOX::DecodeCAN(id, data);
+        selectedInverter->DecodeCAN(id, data);
+        selectedVehicle->DecodeCAN(id, data);
+        selectedCharger->DecodeCAN(id, data);
+        selectedChargeInt->DecodeCAN(id, data);
+        selectedBMS->DecodeCAN(id, (uint8_t*)data);
+        selectedDCDC->DecodeCAN(id, (uint8_t*)data);
+        selectedShifter->DecodeCAN(id,data);
+        break;
+    }
+    return false;
 }
 
 
 static void ConfigureVariantIO()
 {
-   ANA_IN_CONFIGURE(ANA_IN_LIST);
-   DIG_IO_CONFIGURE(DIG_IO_LIST);
+    ANA_IN_CONFIGURE(ANA_IN_LIST);
+    DIG_IO_CONFIGURE(DIG_IO_LIST);
 
-   AnaIn::Start();
+    AnaIn::Start();
 }
 
 
 extern "C" void tim4_isr(void)
 {
-   scheduler->Run();
+    scheduler->Run();
 }
 
 
 extern "C" void exti15_10_isr(void)    //CAN3 MCP25625 interruppt
 {
-   uCAN_MSG rxMessage;
-   uint32_t canData[2];
-   if(CANSPI_receive(&rxMessage))
-   {
-      canData[0]=(rxMessage.frame.data0 | rxMessage.frame.data1<<8 | rxMessage.frame.data2<<16 | rxMessage.frame.data3<<24);
-      canData[1]=(rxMessage.frame.data4 | rxMessage.frame.data5<<8 | rxMessage.frame.data6<<16 | rxMessage.frame.data7<<24);
-   }
-   //can cast this to uint32_t[2]. dont be an idiot! * pointer
-   CANSPI_CLR_IRQ();   //Clear Rx irqs in mcp25625
-   exti_reset_request(EXTI15); // clear irq
-   if((rxMessage.frame.id==0x108)||(rxMessage.frame.id==0x109)) selectedChargeInt->DecodeCAN(rxMessage.frame.id, canData);
+    uCAN_MSG rxMessage;
+    uint32_t canData[2];
+    if(CANSPI_receive(&rxMessage))
+    {
+        canData[0]=(rxMessage.frame.data0 | rxMessage.frame.data1<<8 | rxMessage.frame.data2<<16 | rxMessage.frame.data3<<24);
+        canData[1]=(rxMessage.frame.data4 | rxMessage.frame.data5<<8 | rxMessage.frame.data6<<16 | rxMessage.frame.data7<<24);
+    }
+    //can cast this to uint32_t[2]. dont be an idiot! * pointer
+    CANSPI_CLR_IRQ();   //Clear Rx irqs in mcp25625
+    exti_reset_request(EXTI15); // clear irq
+    if((rxMessage.frame.id==0x108)||(rxMessage.frame.id==0x109)) selectedChargeInt->DecodeCAN(rxMessage.frame.id, canData);
 
 }
 
 extern "C" void rtc_isr(void)
 {
-   /* The interrupt flag isn't cleared by hardware, we have to do it. */
-   rtc_clear_flag(RTC_SEC);
+    /* The interrupt flag isn't cleared by hardware, we have to do it. */
+    rtc_clear_flag(RTC_SEC);
 
-   if ( ++seconds >= 60 )
-   {
-      ++minutes;
-      seconds -= 60;
-   }
-   if ( minutes >= 60 )
-   {
-      ++hours;
-      minutes -= 60;
-   }
-   if ( hours >= 24 )
-   {
-      ++days;
-      hours -= 24;
-   }
+    if ( ++seconds >= 60 )
+    {
+        ++minutes;
+        seconds -= 60;
+    }
+    if ( minutes >= 60 )
+    {
+        ++hours;
+        minutes -= 60;
+    }
+    if ( hours >= 24 )
+    {
+        ++days;
+        hours -= 24;
+    }
 }
 
 extern "C" int main(void)
 {
-   extern const TERM_CMD TermCmds[];
+    extern const TERM_CMD TermCmds[];
 
-   clock_setup();
-   rtc_setup();
-   ConfigureVariantIO();
-   gpio_primary_remap(AFIO_MAPR_SWJ_CFG_JTAG_OFF_SW_ON, AFIO_MAPR_CAN2_REMAP | AFIO_MAPR_TIM1_REMAP_FULL_REMAP);//32f107
-   usart2_setup();//TOYOTA HYBRID INVERTER INTERFACE
-   nvic_setup();
-   parm_load();
-   spi2_setup();
-   spi3_setup();
-   tim3_setup(); //For general purpose PWM output
-   Param::Change(Param::PARAM_LAST);
-   DigIo::inv_out.Clear();//inverter power off during bootup
-   DigIo::mcp_sby.Clear();//enable can3
+    clock_setup();
+    rtc_setup();
+    ConfigureVariantIO();
+    gpio_primary_remap(AFIO_MAPR_SWJ_CFG_JTAG_OFF_SW_ON, AFIO_MAPR_CAN2_REMAP | AFIO_MAPR_TIM1_REMAP_FULL_REMAP);//32f107
+    usart2_setup();//TOYOTA HYBRID INVERTER INTERFACE
+    nvic_setup();
+    parm_load();
+    spi2_setup();
+    spi3_setup();
+    tim3_setup(); //For general purpose PWM output
+    Param::Change(Param::PARAM_LAST);
+    DigIo::inv_out.Clear();//inverter power off during bootup
+    DigIo::mcp_sby.Clear();//enable can3
 
-   Terminal t(USART3, TermCmds);
+    Terminal t(USART3, TermCmds);
 //   FunctionPointerCallback canCb(CanCallback, SetCanFilters);
-   Stm32Can c(CAN1, CanHardware::Baud500);
-   Stm32Can c2(CAN2, CanHardware::Baud500, true);
-   FunctionPointerCallback cb(CanCallback, SetCanFilters);
-   Stm32Can *CanMapDev = &c;
-   if (Param::GetInt(Param::CanMapCan) == 0) {
-      CanMapDev = &c;
-   } else {
-      CanMapDev = &c2;
-   }
-   CanMap cm(CanMapDev);
-   CanSdo sdo(&c, &cm);
-   sdo.SetNodeId(3);//id 3 for vcu?
-   // Set up CAN 1 callback and messages to listen for
- //  c.AddReceiveCallback(&canCb);
- //  c2.AddReceiveCallback(&canCb);
-   canInterface[0] = &c;
-   canInterface[1] = &c2;
-   c.AddCallback(&cb);
-   c2.AddCallback(&cb);
-   TerminalCommands::SetCanMap(&cm);
-   canMap = &cm;
+    Stm32Can c(CAN1, CanHardware::Baud500);
+    Stm32Can c2(CAN2, CanHardware::Baud500, true);
+    FunctionPointerCallback cb(CanCallback, SetCanFilters);
+    Stm32Can *CanMapDev = &c;
+    if (Param::GetInt(Param::CanMapCan) == 0)
+    {
+        CanMapDev = &c;
+    }
+    else
+    {
+        CanMapDev = &c2;
+    }
+    CanMap cm(CanMapDev);
+    CanSdo sdo(&c, &cm);
+    sdo.SetNodeId(3);//id 3 for vcu?
+    // Set up CAN 1 callback and messages to listen for
+//  c.AddReceiveCallback(&canCb);
+//  c2.AddReceiveCallback(&canCb);
+    canInterface[0] = &c;
+    canInterface[1] = &c2;
+    c.AddCallback(&cb);
+    c2.AddCallback(&cb);
+    TerminalCommands::SetCanMap(&cm);
+    canMap = &cm;
 
-   CanHardware* shunt_can = canInterface[Param::GetInt(Param::ShuntCan)];
+    CanHardware* shunt_can = canInterface[Param::GetInt(Param::ShuntCan)];
 
-   canOBD2.SetCanInterface(canInterface[Param::GetInt(Param::OBD2Can)]);
+    canOBD2.SetCanInterface(canInterface[Param::GetInt(Param::OBD2Can)]);
 
-   CANSPI_Initialize();// init the MCP25625 on CAN3
-   CANSPI_ENRx_IRQ();  //init CAN3 Rx IRQ
+    CANSPI_Initialize();// init the MCP25625 on CAN3
+    CANSPI_ENRx_IRQ();  //init CAN3 Rx IRQ
 
-   UpdateInv();
-   UpdateVehicle();
-   UpdateCharger();
-   UpdateChargeInt();
-   UpdateBMS();
-   UpdateHeater();
-   UpdateDCDC();
-   UpdateShifter();
+    UpdateInv();
+    UpdateVehicle();
+    UpdateCharger();
+    UpdateChargeInt();
+    UpdateBMS();
+    UpdateHeater();
+    UpdateDCDC();
+    UpdateShifter();
 
-   Stm32Scheduler s(TIM4); //We never exit main so it's ok to put it on stack
-   scheduler = &s;
+    Stm32Scheduler s(TIM4); //We never exit main so it's ok to put it on stack
+    scheduler = &s;
 
-   s.AddTask(Ms1Task, 1);
-   s.AddTask(Ms10Task, 10);
-   s.AddTask(Ms100Task, 100);
-   s.AddTask(Ms200Task, 200);
+    s.AddTask(Ms1Task, 1);
+    s.AddTask(Ms10Task, 10);
+    s.AddTask(Ms100Task, 100);
+    s.AddTask(Ms200Task, 200);
 
-   if(Param::GetInt(Param::IsaInit)==1) ISA::initialize(shunt_can);//only call this once if a new sensor is fitted.
+    if(Param::GetInt(Param::IsaInit)==1) ISA::initialize(shunt_can);//only call this once if a new sensor is fitted.
 
-   Param::SetInt(Param::version, 4); //backward compatibility
-   Param::SetInt(Param::opmode, MOD_OFF);//always off at startup
+    Param::SetInt(Param::version, 4); //backward compatibility
+    Param::SetInt(Param::opmode, MOD_OFF);//always off at startup
 
-   while(1)
-   {
-      char c = 0;
-      t.Run();
-      if (sdo.GetPrintRequest() == PRINT_JSON)
-      {
-         TerminalCommands::PrintParamsJson(&sdo, &c);
-      }
-   }
+    while(1)
+    {
+        char c = 0;
+        t.Run();
+        if (sdo.GetPrintRequest() == PRINT_JSON)
+        {
+            TerminalCommands::PrintParamsJson(&sdo, &c);
+        }
+    }
 
-   return 0;
+    return 0;
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -368,10 +368,9 @@ float ProcessThrottle(int speed)
 
    finalSpnt = Throttle::RampThrottle(finalSpnt);
 
-   Throttle::UdcLimitCommand(finalSpnt, Param::Get(Param::udc));
+   Throttle::UdcLimitCommand(finalSpnt,Param::GetFloat(Param::udc));
    Throttle::IdcLimitCommand(finalSpnt, ABS(Param::GetFloat(Param::idc)));
    Throttle::SpeedLimitCommand(finalSpnt, ABS(speed));
-
 
    if (Throttle::TemperatureDerate(Param::Get(Param::tmphs), Param::Get(Param::tmphsmax), finalSpnt))
    {

--- a/stm32-vcu.cbp
+++ b/stm32-vcu.cbp
@@ -52,16 +52,18 @@
 		<Unit filename="include/BMW_E31.h" />
 		<Unit filename="include/BMW_E65.h" />
 		<Unit filename="include/CANSPI.h" />
+		<Unit filename="include/CPC.h" />
 		<Unit filename="include/Can_E39.h" />
 		<Unit filename="include/Can_OBD2.h" />
 		<Unit filename="include/Can_OI.h" />
 		<Unit filename="include/Can_VAG.h" />
+		<Unit filename="include/ElconCharger.h" />
 		<Unit filename="include/F30_Lever.h" />
 		<Unit filename="include/GS450H.h" />
 		<Unit filename="include/MCP2515.h" />
 		<Unit filename="include/NissanPDM.h" />
+		<Unit filename="include/NoInverter.h" />
 		<Unit filename="include/TeslaDCDC.h" />
-		<Unit filename="include/VWheater.h" />
 		<Unit filename="include/amperaheater.h" />
 		<Unit filename="include/anain_prj.h" />
 		<Unit filename="include/bms.h" />
@@ -104,7 +106,6 @@
 		<Unit filename="libopeninv/include/canmap.h" />
 		<Unit filename="libopeninv/include/digio.h" />
 		<Unit filename="libopeninv/include/errormessage.h" />
-		<Unit filename="libopeninv/include/linbus.h" />
 		<Unit filename="libopeninv/include/my_fp.h" />
 		<Unit filename="libopeninv/include/my_math.h" />
 		<Unit filename="libopeninv/include/my_string.h" />
@@ -120,7 +121,6 @@
 		<Unit filename="libopeninv/src/canmap.cpp" />
 		<Unit filename="libopeninv/src/digio.cpp" />
 		<Unit filename="libopeninv/src/errormessage.cpp" />
-		<Unit filename="libopeninv/src/linbus.cpp" />
 		<Unit filename="libopeninv/src/my_fp.c">
 			<Option compilerVar="CC" />
 		</Unit>
@@ -137,16 +137,17 @@
 		<Unit filename="src/BMW_E31.cpp" />
 		<Unit filename="src/BMW_E65.cpp" />
 		<Unit filename="src/CANSPI.cpp" />
+		<Unit filename="src/CPC.cpp" />
 		<Unit filename="src/Can_E39.cpp" />
 		<Unit filename="src/Can_OBD2.cpp" />
 		<Unit filename="src/Can_OI.cpp" />
 		<Unit filename="src/Can_VAG.cpp" />
+		<Unit filename="src/ElconCharger.cpp" />
 		<Unit filename="src/F30_Lever.cpp" />
 		<Unit filename="src/GS450H.cpp" />
 		<Unit filename="src/MCP2515.cpp" />
 		<Unit filename="src/NissanPDM.cpp" />
 		<Unit filename="src/TeslaDCDC.cpp" />
-		<Unit filename="src/VWheater.cpp" />
 		<Unit filename="src/amperacharger.cpp" />
 		<Unit filename="src/amperaheater.cpp" />
 		<Unit filename="src/bmw_sbox.cpp" />


### PR DESCRIPTION
This adds:
1. Rear outlander inverter control as per: https://github.com/damienmaguire/Stm32-vcu/pull/75 
2. Regen - Tested on BenB Mgf with Outlander Rear inverter.
3. Ability to have no inverter selected
4. Improved E90 support, allowing BMW CAN to sleep - Jamie Jones validated on his BMW
5. EVS-CPC support as a charing interface - Validated functionality on Mr600v datsun
6. Elcon charge CAN control - Validated functionality on Mr600v datsun