### PR TITLE
Regen improvements v2

### DIFF
--- a/include/GS450H.h
+++ b/include/GS450H.h
@@ -51,6 +51,7 @@ private:
    uint8_t VerifyMTHChecksum(uint16_t );
    void CalcHTMChecksum(uint16_t);
    void setTimerState(bool);
+   void GS450Hgear();
 };
 
 #endif /* GS450H_h */

--- a/include/leafinv.h
+++ b/include/leafinv.h
@@ -36,7 +36,7 @@ public:
    float GetMotorTemperature() { return motor_temp; }
    float GetInverterTemperature() { return inv_temp; }
    float GetInverterVoltage() { return voltage / 2; }
-   float GetMotorSpeed() { return speed / 2; }
+   float GetMotorSpeed() { return speed; }
    int GetInverterState() { return error; }
    void SetCanInterface(CanHardware* c);
 

--- a/include/param_prj.h
+++ b/include/param_prj.h
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#define VER 2.06.A
+#define VER 2.09.XX
 
 
 /* Entries must be ordered as follows:
@@ -25,7 +25,7 @@
    2. Temporary parameters (id = 0)
    3. Display values
  */
-//Next param id (increase when adding new parameter!): 125
+//Next param id (increase when adding new parameter!): 128
 /*              category     name         unit       min     max     default id */
 #define PARAM_LIST \
     PARAM_ENTRY(CAT_SETUP,     Inverter,     INVMODES, 0,      8,      0,      5  ) \
@@ -48,11 +48,13 @@
     PARAM_ENTRY(CAT_THROTTLE,  pot2min,     "dig",     0,      4095,   4095,   9  ) \
     PARAM_ENTRY(CAT_THROTTLE,  pot2max,     "dig",     0,      4095,   4095,   10 ) \
     PARAM_ENTRY(CAT_THROTTLE,  regenrpm,    "rpm",       0,      10000,    1500,     60 ) \
+    PARAM_ENTRY(CAT_THROTTLE,  regenendrpm,"rpm",     0,      10000,  100,  126 ) \
     PARAM_ENTRY(CAT_THROTTLE,  regenmax,     "%",       -100,   0,     -10,     61 ) \
     PARAM_ENTRY(CAT_THROTTLE,  regenBrake,    "%",       -100,   0,     -10,     122 ) \
     PARAM_ENTRY(CAT_THROTTLE,  regenramp,   "%/10ms",  0.1,    100,    100,    68 ) \
     PARAM_ENTRY(CAT_THROTTLE,  potmode,     POTMODES,  0,      1,      0,      11 ) \
     PARAM_ENTRY(CAT_THROTTLE,  dirmode,     DIRMODES,  0,      4,      1,      12 ) \
+    PARAM_ENTRY(CAT_THROTTLE,  reversemotor,  ONOFF,  0,      1,      0,      127 ) \
     PARAM_ENTRY(CAT_THROTTLE,  throtramp,   "%/10ms",  0.1,    100,    100,    13 ) \
     PARAM_ENTRY(CAT_THROTTLE,  throtramprpm,"rpm",     0,      20000,  20000,  14 ) \
     PARAM_ENTRY(CAT_THROTTLE,  revlim,      "rpm",     0,      20000,  6000,   15 ) \
@@ -76,7 +78,7 @@
     PARAM_ENTRY(CAT_CONTACT,   udcsw,       "V",       0,      1000,   330,    32 ) \
     PARAM_ENTRY(CAT_CONTACT,   cruiselight, ONOFF,     0,      1,      0,      33 ) \
     PARAM_ENTRY(CAT_CONTACT,   errlights,   ERRLIGHTS, 0,      255,    0,      34 ) \
-    PARAM_ENTRY(CAT_COMM,      CAN3Speed,   CAN3Spd,   0,      1,      0,      77 ) \
+    PARAM_ENTRY(CAT_COMM,      CAN3Speed,   CAN3Spd,   0,      2,      0,      77 ) \
     PARAM_ENTRY(CAT_CHARGER,   BattCap,     "kWh",     0.1,    250,    22,     38 ) \
     PARAM_ENTRY(CAT_CHARGER,   Voltspnt,    "V",       0,      1000,   395,    40 ) \
     PARAM_ENTRY(CAT_CHARGER,   Pwrspnt,     "W",       0,      12000,  1500,   41 ) \
@@ -258,7 +260,7 @@
 #define CHGMODS      "0=Off, 1=EXT_DIGI, 2=Volt_Ampera, 3=Leaf_PDM, 4=TeslaOI, 5=Out_lander 6=Elcon"
 #define CHGCTRL      "0=Enable, 1=Disable, 2=Timer"
 #define CHGINT       "0=Unused, 1=i3LIM, 2=Chademo, 3=CPC"
-#define CAN3Spd      "0=k33.3, 1=k500"
+#define CAN3Spd      "0=k33.3, 1=k500. 2=k100"
 #define TRNMODES     "0=Manual, 1=Auto"
 #define CAN_DEV      "0=CAN1, 1=CAN2"
 #define CAT_THROTTLE "Throttle"

--- a/include/throttle.h
+++ b/include/throttle.h
@@ -65,6 +65,7 @@ public:
     static float idcmin;
     static float idcmax;
     static int speedLimit;
+    static float regenendRpm;
 
 private:
     static int speedFiltered;

--- a/src/CANSPI.cpp
+++ b/src/CANSPI.cpp
@@ -148,6 +148,13 @@ if(Param::GetInt(Param::CAN3Speed)==1)
       MCP2515_Write_Byte(MCP2515_CNF3, 0x83);
 }
 
+if(Param::GetInt(Param::CAN3Speed)==2)
+{
+   MCP2515_Write_Byte(MCP2515_CNF1, 0x03);//100kbps at 16HMz xtal.
+   MCP2515_Write_Byte(MCP2515_CNF2, 0xFA);
+   MCP2515_Write_Byte(MCP2515_CNF3, 0x87);
+}
+
 if(Param::GetInt(Param::CAN3Speed)==0)
 {
    MCP2515_Write_Byte(MCP2515_CNF1, 0x4E);//33kbps at 16HMz xtal.

--- a/src/GS450H.cpp
+++ b/src/GS450H.cpp
@@ -10,11 +10,16 @@
 #define  HIGH_Gear  1
 #define  AUTO_Gear  2
 
+#define GS450H 1
+#define PRIUS 2
+#define IS300H 3
+
+static uint8_t DriveType = 0;
 volatile int received = 0;
 static uint8_t htm_state = 0;
 static uint8_t inv_status = 1;//must be 1 for gs450h and gs300h
 uint16_t counter;
-static uint16_t htm_checksum;
+//static uint16_t htm_checksum; //superseded by Checksum function
 static uint8_t frame_count;
 static uint8_t GearSW;
 static int16_t mg1_torque, mg2_torque, speedSum;
@@ -30,8 +35,8 @@ static void dma_write(uint8_t *data, int size);
 static uint8_t mth_data[140];
 static uint8_t htm_data_setup[100]= {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,25,0,0,0,0,0,0,0,128,0,0,0,128,0,0,0,37,1};
 static uint8_t htm_data[105]= {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,255,0,0,0,0,0,0,0,0,0};
-static uint8_t htm_data_GS300H[105]={0,14,0,2,0,0,0,0,0,0,0,0,0,23,0,97,0,0,0,0,0,0,0,248,254,8,1,0,0,0,0,0,0,22,0,0,0,0,0,23,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,23,0,75,22,47,250,137,14,0,0,23,0,0,0,0,201,0,218,0,16,0,0,0,29,0,0,0,0,0,0
-};
+static uint8_t htm_data_GS300H[105]= {0,14,0,2,0,0,0,0,0,0,0,0,0,23,0,97,0,0,0,0,0,0,0,248,254,8,1,0,0,0,0,0,0,22,0,0,0,0,0,23,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,23,0,75,22,47,250,137,14,0,0,23,0,0,0,0,201,0,218,0,16,0,0,0,29,0,0,0,0,0,0
+                                     };
 #if 0
 // Not currently used
 static uint8_t htm_data_setup_auris[100]= {0x00, 0x0E, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x19, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x88, 0x00, 0x00, 0x00, 0xA0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x5F, 0x01};
@@ -39,100 +44,142 @@ static uint8_t htm_data_setup_auris[100]= {0x00, 0x0E, 0x00, 0x00, 0x00, 0x00, 0
 
 uint8_t htm_data_init[7][100]=
 {
-   {0,14,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,4,0,25,0,0,0,0,0,0,0,0,0,0,136,0,0,0,160,0,0,0,0,0,0,0,95,1},
-   {0,14,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,4,0,25,0,0,0,0,0,0,0,0,0,0,136,0,0,0,160,0,0,0,0,0,0,0,95,1},
-   {0,30,0,0,0,0,0,18,0,154,250,0,0,0,0,97,4,0,0,0,0,0,173,255,82,0,0,0,0,0,0,0,16,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,4,75,25,60,246,52,8,0,0,0,0,0,0,138,0,0,0,168,0,0,0,1,0,0,0,72,7},
-   {0,30,0,0,0,0,0,18,0,154,250,0,0,0,0,97,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,16,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,4,75,25,60,246,52,8,0,0,0,0,0,0,138,0,0,0,168,0,0,0,2,0,0,0,75,5},
-   {0,30,0,0,0,0,0,18,0,154,250,0,0,0,0,97,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,16,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,4,75,25,60,246,52,8,0,0,0,0,0,0,138,0,0,0,168,0,0,0,2,0,0,0,75,5},
-   {0,30,0,0,0,0,0,18,0,154,250,0,0,255,0,97,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,16,0,0,0,0,0,255,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,255,4,73,25,60,246,52,8,0,0,255,0,0,0,138,0,0,0,168,0,0,0,3,0,0,0,70,9},
-   {0,30,0,2,0,0,0,18,0,154,250,0,0,16,0,97,0,0,0,0,0,0,200,249,56,6,165,0,136,0,63,0,16,0,0,0,63,0,16,0,3,128,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,16,0,75,12,45,248,21,6,0,0,16,0,0,0,202,0,211,0,16,0,0,0,134,16,0,0,130,10}
+    {0,14,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,4,0,25,0,0,0,0,0,0,0,0,0,0,136,0,0,0,160,0,0,0,0,0,0,0,95,1},
+    {0,14,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,4,0,25,0,0,0,0,0,0,0,0,0,0,136,0,0,0,160,0,0,0,0,0,0,0,95,1},
+    {0,30,0,0,0,0,0,18,0,154,250,0,0,0,0,97,4,0,0,0,0,0,173,255,82,0,0,0,0,0,0,0,16,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,4,75,25,60,246,52,8,0,0,0,0,0,0,138,0,0,0,168,0,0,0,1,0,0,0,72,7},
+    {0,30,0,0,0,0,0,18,0,154,250,0,0,0,0,97,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,16,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,4,75,25,60,246,52,8,0,0,0,0,0,0,138,0,0,0,168,0,0,0,2,0,0,0,75,5},
+    {0,30,0,0,0,0,0,18,0,154,250,0,0,0,0,97,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,16,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,4,75,25,60,246,52,8,0,0,0,0,0,0,138,0,0,0,168,0,0,0,2,0,0,0,75,5},
+    {0,30,0,0,0,0,0,18,0,154,250,0,0,255,0,97,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,16,0,0,0,0,0,255,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,255,4,73,25,60,246,52,8,0,0,255,0,0,0,138,0,0,0,168,0,0,0,3,0,0,0,70,9},
+    {0,30,0,2,0,0,0,18,0,154,250,0,0,16,0,97,0,0,0,0,0,0,200,249,56,6,165,0,136,0,63,0,16,0,0,0,63,0,16,0,3,128,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,16,0,75,12,45,248,21,6,0,0,16,0,0,0,202,0,211,0,16,0,0,0,134,16,0,0,130,10}
 };
 
 uint8_t  htm_data_Init_GS300H[6][105]=
 {
-     {0,14,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,4,0,25,0,0,0,0,0,0,0,0,0,0,0,136,0,0,0,160,0,0,0,0,0,0,0,0,95,1},
-     {0,14,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,4,0,25,0,0,0,0,0,0,0,0,0,0,0,136,0,0,0,160,0,0,0,0,0,0,0,0,95,1},
-     {0,14,0,0,0,0,0,0,0,0,0,0,0,0,0,97,4,0,0,0,0,0,0,173,255,82,0,0,0,0,0,0,0,22,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,4,75,25,212,254,210,15,0,0,0,0,0,0,0,137,0,0,0,168,0,0,0,1,0,0,0,0,220,6},
-     {0,14,0,0,0,0,0,0,0,0,0,0,0,0,0,97,4,0,0,0,0,0,0,173,255,82,0,0,0,0,0,0,0,22,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,4,75,25,212,254,210,15,0,0,0,0,0,0,0,137,0,0,0,168,0,0,0,1,0,0,0,0,220,6},
-     {0,14,0,0,0,0,0,0,0,0,0,0,0,0,0,97,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,22,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,4,75,25,212,254,190,15,0,0,0,0,0,0,0,137,0,0,0,168,0,0,0,2,0,0,0,0,203,4},
-     {0,14,0,0,0,0,0,0,0,0,0,0,0,0,0,97,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,22,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,4,75,25,212,254,190,15,0,0,0,0,0,0,0,137,0,0,0,168,0,0,0,2,0,0,0,0,203,4}
+    {0,14,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,4,0,25,0,0,0,0,0,0,0,0,0,0,0,136,0,0,0,160,0,0,0,0,0,0,0,0,95,1},
+    {0,14,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,4,0,25,0,0,0,0,0,0,0,0,0,0,0,136,0,0,0,160,0,0,0,0,0,0,0,0,95,1},
+    {0,14,0,0,0,0,0,0,0,0,0,0,0,0,0,97,4,0,0,0,0,0,0,173,255,82,0,0,0,0,0,0,0,22,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,4,75,25,212,254,210,15,0,0,0,0,0,0,0,137,0,0,0,168,0,0,0,1,0,0,0,0,220,6},
+    {0,14,0,0,0,0,0,0,0,0,0,0,0,0,0,97,4,0,0,0,0,0,0,173,255,82,0,0,0,0,0,0,0,22,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,4,75,25,212,254,210,15,0,0,0,0,0,0,0,137,0,0,0,168,0,0,0,1,0,0,0,0,220,6},
+    {0,14,0,0,0,0,0,0,0,0,0,0,0,0,0,97,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,22,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,4,75,25,212,254,190,15,0,0,0,0,0,0,0,137,0,0,0,168,0,0,0,2,0,0,0,0,203,4},
+    {0,14,0,0,0,0,0,0,0,0,0,0,0,0,0,97,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,22,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,4,75,25,212,254,190,15,0,0,0,0,0,0,0,137,0,0,0,168,0,0,0,2,0,0,0,0,203,4}
 };
 
 void GS450HClass::SetTorque(float torquePercent)
 {
-   if(!TorqueCut)
-   {
-   scaledTorqueTarget = (torquePercent * 3500) / 100.0f;
-   mg2_torque = this->scaledTorqueTarget;
+    if(DriveType == GS450H)
+    {
+        if(!TorqueCut)
+        {
+            scaledTorqueTarget = (torquePercent * 3500) / 100.0f;
+            mg2_torque = this->scaledTorqueTarget;
 
-   if (scaledTorqueTarget < 0) mg1_torque = 0;
-   else mg1_torque=((mg2_torque*5)/4);
-   }
-   else
-   {
-       mg2_torque =0;
-       mg1_torque=0;
-   }
+            if (scaledTorqueTarget < 0) mg1_torque = 0;
+            else mg1_torque=((mg2_torque*5)/4);
+        }
+        else
+        {
+            mg2_torque =0;
+            mg1_torque=0;
+        }
+    }
+    else if(DriveType == PRIUS)
+    {
+        if(!TorqueCut)
+        {
+            scaledTorqueTarget = (torquePercent * 3500) / 100.0f;
+            mg2_torque = this->scaledTorqueTarget;
 
+            if (scaledTorqueTarget < 0) mg1_torque = 0;
+            else mg1_torque=((mg2_torque*5)/4);
+        }
+        else
+        {
+            mg2_torque =0;
+            mg1_torque=0;
+        }
+    }
+    else if(DriveType == IS300H)
+    {
+        if(!TorqueCut)
+        {
+            scaledTorqueTarget = (torquePercent * 3500) / 100.0f;
+            mg2_torque = this->scaledTorqueTarget;
+
+            if (scaledTorqueTarget < 0) mg1_torque = 0;
+            else mg1_torque=((mg2_torque*5)/4);
+        }
+        else
+        {
+            mg2_torque =0;
+            mg1_torque=0;
+        }
+    }
 }
 
 float GS450HClass::GetMotorTemperature()
 {
-   int tmpmg1 = AnaIn::MG1_Temp.Get();//in the gs450h case we must read the analog temp values from sensors in the gearbox
-   int tmpmg2 = AnaIn::MG2_Temp.Get();
+    int tmpmg1 = AnaIn::MG1_Temp.Get();//in the gs450h case we must read the analog temp values from sensors in the gearbox
+    int tmpmg2 = AnaIn::MG2_Temp.Get();
 
-   float t1 = (tmpmg1*(-0.02058758))+56.56512898;//Trying a best fit line approach.
-   float t2 = (tmpmg2*(-0.02058758))+56.56512898;;
-   float tmpm = MAX(t1, t2);//which ever is the hottest gets displayed
+    float t1 = (tmpmg1*(-0.02058758))+56.56512898;//Trying a best fit line approach.
+    float t2 = (tmpmg2*(-0.02058758))+56.56512898;;
+    float tmpm = MAX(t1, t2);//which ever is the hottest gets displayed
 
-   return float(tmpm);
+    return float(tmpm);
 
 }
 
 // 100 ms code
 void GS450HClass::Task100Ms()
 {
-   //Param::SetInt(Param::InvStat, GS450HClass::statusFB()); //update inverter status on web interface
-   gear=(Param::GetInt(Param::Gear));
+    if(DriveType == GS450H)
+    {
+        GS450Hgear();
+    }
+}
 
-   if (gear == 1)
-   {
-      DigIo::SP_out.Clear();
-      DigIo::SL1_out.Clear();
-      DigIo::SL2_out.Clear();
+void GS450HClass::GS450Hgear()
+{
+    //Param::SetInt(Param::InvStat, GS450HClass::statusFB()); //update inverter status on web interface
+    gear=(Param::GetInt(Param::Gear));
+
+    if (gear == 1)
+    {
+        DigIo::SP_out.Clear();
+        DigIo::SL1_out.Clear();
+        DigIo::SL2_out.Clear();
 
 
-   }
+    }
 
-   if (gear == 0)
-   {
-      DigIo::SP_out.Clear();
-      DigIo::SL1_out.Set();
-      DigIo::SL2_out.Set();
+    if (gear == 0)
+    {
+        DigIo::SP_out.Clear();
+        DigIo::SL1_out.Set();
+        DigIo::SL2_out.Set();
 
 
-   }
+    }
 
-   if (Param::GetInt(Param::opmode) == MOD_OFF)
-   {
-       //setTimerState(false);
-       Lexus_Oil2 =0;
-   }
-   else
-   {
-       //setTimerState(true);
-   }
+    if (Param::GetInt(Param::opmode) == MOD_OFF)
+    {
+        //setTimerState(false);
         Lexus_Oil2 =0;
-   if (Param::GetInt(Param::opmode) == MOD_RUN) Lexus_Oil2 = Param::GetInt(Param::OilPump);
-   Lexus_Oil2 = utils::change(Lexus_Oil2, 10, 80, 1875, 425); //map oil pump pwm to timer
-   timer_set_oc_value(TIM1, TIM_OC1, Lexus_Oil2);//duty. 1000 = 52% , 500 = 76% , 1500=28%
+    }
+    else
+    {
+        //setTimerState(true);
+    }
+    Lexus_Oil2 =0;
+    if (Param::GetInt(Param::opmode) == MOD_RUN) Lexus_Oil2 = Param::GetInt(Param::OilPump);
+    Lexus_Oil2 = utils::change(Lexus_Oil2, 10, 80, 1875, 425); //map oil pump pwm to timer
+    timer_set_oc_value(TIM1, TIM_OC1, Lexus_Oil2);//duty. 1000 = 52% , 500 = 76% , 1500=28%
 
-   Param::SetInt(Param::Gear1,!DigIo::gear1_in.Get());//update web interface with status of gearbox PB feedbacks for diag purposes.
-   Param::SetInt(Param::Gear2,!DigIo::gear2_in.Get());
-   Param::SetInt(Param::Gear3,!DigIo::gear3_in.Get());
-   GearSW=((!DigIo::gear3_in.Get()<<2)|(!DigIo::gear2_in.Get()<<1)|(!DigIo::gear1_in.Get()));
-   if(GearSW==6) Param::SetInt(Param::GearFB,LOW_Gear);// set low gear
-   if(GearSW==5) Param::SetInt(Param::GearFB,HIGH_Gear);// set high gear
+    Param::SetInt(Param::Gear1,!DigIo::gear1_in.Get());//update web interface with status of gearbox PB feedbacks for diag purposes.
+    Param::SetInt(Param::Gear2,!DigIo::gear2_in.Get());
+    Param::SetInt(Param::Gear3,!DigIo::gear3_in.Get());
+    GearSW=((!DigIo::gear3_in.Get()<<2)|(!DigIo::gear2_in.Get()<<1)|(!DigIo::gear1_in.Get()));
+    if(GearSW==6) Param::SetInt(Param::GearFB,LOW_Gear);// set low gear
+    if(GearSW==5) Param::SetInt(Param::GearFB,HIGH_Gear);// set high gear
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -142,433 +189,437 @@ void GS450HClass::Task100Ms()
 void GS450HClass::SetPrius()
 {
     setTimerState(true);//start toyota timers
-   if (htm_state<5)
-   {
-      htm_state = 5;
-      inv_status = 0;//must be 0 for prius
-   }
+    if (htm_state<5)
+    {
+        htm_state = 5;
+        inv_status = 0;//must be 0 for prius
+    }
+    DriveType = PRIUS;
 }
 
 void GS450HClass::SetGS450H()
 {
     setTimerState(true);//start toyota timers
-   if (htm_state>4)
-   {
-      htm_state = 0;
-      inv_status = 1;//must be 1 for gs450h
-   }
+    if (htm_state>4)
+    {
+        htm_state = 0;
+        inv_status = 1;//must be 1 for gs450h
+    }
+    DriveType = GS450H;
 }
 
 void GS450HClass::SetGS300H()
 {
     setTimerState(true);//start toyota timers
-   if (htm_state<10)
-   {
-      htm_state = 10;
+    if (htm_state<10)
+    {
+        htm_state = 10;
 
-   }
+    }
     inv_status = 0;//must be 0 for gs300h
-   for(int i=0; i<105; i++)htm_data[i] = htm_data_GS300H[i];
+    for(int i=0; i<105; i++)htm_data[i] = htm_data_GS300H[i];
+    DriveType = IS300H;
 }
 
 uint8_t GS450HClass::VerifyMTHChecksum(uint16_t len)
 {
 
-   uint16_t mth_checksum=0;
+    uint16_t mth_checksum=0;
 
-   for(int i=0; i<(len-2); i++)
-      mth_checksum+=mth_data[i];
+    for(int i=0; i<(len-2); i++)
+        mth_checksum+=mth_data[i];
 
 
-   if(mth_checksum==(mth_data[len-2]|(mth_data[len-1]<<8))) return 1;
-   else return 0;
+    if(mth_checksum==(mth_data[len-2]|(mth_data[len-1]<<8))) return 1;
+    else return 0;
 
 }
 
 void GS450HClass::CalcHTMChecksum(uint16_t len)
 {
+    uint16_t htm_checksum=0;
 
-   uint16_t htm_checksum=0;
-
-   for(int i=0; i<(len-2); i++)htm_checksum+=htm_data[i];
-   htm_data[len-2]=htm_checksum&0xFF;
-   htm_data[len-1]=htm_checksum>>8;
-
+    for(int i=0; i<(len-2); i++)htm_checksum+=htm_data[i];
+    htm_data[len-2]=htm_checksum&0xFF;
+    htm_data[len-1]=htm_checksum>>8;
 }
 
 
 void GS450HClass::Task1Ms()
 {
 
-   switch(htm_state)
-   {
-   case 0:
-      dma_read(mth_data,100);//read in mth data via dma. Probably need some kind of check dma complete flag here
-      DigIo::req_out.Clear(); //HAL_GPIO_WritePin(HTM_SYNC_GPIO_Port, HTM_SYNC_Pin, 0);
-      htm_state++;
-      break;
-   case 1:
-      DigIo::req_out.Set();  //HAL_GPIO_WritePin(HTM_SYNC_GPIO_Port, HTM_SYNC_Pin, 1);
+    switch(htm_state)
+    {
+    case 0:
+        dma_read(mth_data,100);//read in mth data via dma. Probably need some kind of check dma complete flag here
+        DigIo::req_out.Clear(); //HAL_GPIO_WritePin(HTM_SYNC_GPIO_Port, HTM_SYNC_Pin, 0);
+        htm_state++;
+        break;
+    case 1:
+        DigIo::req_out.Set();  //HAL_GPIO_WritePin(HTM_SYNC_GPIO_Port, HTM_SYNC_Pin, 1);
 
-      if(inv_status==0)
-      {
-         if (dma_get_interrupt_flag(DMA1, DMA_CHANNEL7, DMA_TCIF))// if the transfer complete flag is set then send another packet
-         {
-            dma_clear_interrupt_flags(DMA1, DMA_CHANNEL7, DMA_TCIF);//clear the flag.
-            dma_write(htm_data,80); //HAL_UART_Transmit_IT(&huart2, htm_data, 80);
-         }
+        if(inv_status==0)
+        {
+            if (dma_get_interrupt_flag(DMA1, DMA_CHANNEL7, DMA_TCIF))// if the transfer complete flag is set then send another packet
+            {
+                dma_clear_interrupt_flags(DMA1, DMA_CHANNEL7, DMA_TCIF);//clear the flag.
+                dma_write(htm_data,80); //HAL_UART_Transmit_IT(&huart2, htm_data, 80);
+            }
 
-      }
-      else
-      {
-         dma_write(htm_data_setup,80);   //HAL_UART_Transmit_IT(&huart2, htm_data_setup, 80);
-         if(mth_data[1]!=0) inv_status--;
-         if(mth_data[1]==0) inv_status=1;
-      }
-      htm_state++;
-      break;
-   case 2:
-      htm_state++;
-      break;
-   case 3:
-      if(VerifyMTHChecksum(100)==0 || dma_get_interrupt_flag(DMA1, DMA_CHANNEL6, DMA_TCIF)==0)
-      {
-         statusInv=0;
-      }
-      else
-      {
-         //exchange data and prepare next HTM frame
-         dma_clear_interrupt_flags(DMA1, DMA_CHANNEL6, DMA_TCIF);
-         statusInv=1;
-         dc_bus_voltage=(((mth_data[82]|mth_data[83]<<8)-5)/2);
-         temp_inv_water=(mth_data[42]|mth_data[43]<<8);
-         temp_inv_inductor=(mth_data[86]|mth_data[87]<<8);
-         mg1_speed=mth_data[6]|mth_data[7]<<8;
-         mg2_speed=mth_data[31]|mth_data[32]<<8;
-      }
+        }
+        else
+        {
+            dma_write(htm_data_setup,80);   //HAL_UART_Transmit_IT(&huart2, htm_data_setup, 80);
+            if(mth_data[1]!=0) inv_status--;
+            if(mth_data[1]==0) inv_status=1;
+        }
+        htm_state++;
+        break;
+    case 2:
+        htm_state++;
+        break;
+    case 3:
+        if(VerifyMTHChecksum(100)==0 || dma_get_interrupt_flag(DMA1, DMA_CHANNEL6, DMA_TCIF)==0)
+        {
+            statusInv=0;
+        }
+        else
+        {
+            //exchange data and prepare next HTM frame
+            dma_clear_interrupt_flags(DMA1, DMA_CHANNEL6, DMA_TCIF);
+            statusInv=1;
+            dc_bus_voltage=(((mth_data[82]|mth_data[83]<<8)-5)/2);
+            temp_inv_water=(mth_data[42]|mth_data[43]<<8);
+            temp_inv_inductor=(mth_data[86]|mth_data[87]<<8);
+            mg1_speed=mth_data[6]|mth_data[7]<<8;
+            mg2_speed=mth_data[31]|mth_data[32]<<8;
+        }
 
-      mth_data[98]=0;
-      mth_data[99]=0;
+        mth_data[98]=0;
+        mth_data[99]=0;
 
-      htm_state++;
-      break;
-   case 4:
-      // -3500 (reverse) to 3500 (forward)
-      Param::SetInt(Param::torque,mg2_torque);//post processed final torue value sent to inv to web interface
+        htm_state++;
+        break;
+    case 4:
+        // -3500 (reverse) to 3500 (forward)
+        Param::SetInt(Param::torque,mg2_torque);//post processed final torue value sent to inv to web interface
 
-      //speed feedback
-      speedSum=mg2_speed+mg1_speed;
-      speedSum/=113;
-      speedSum2=speedSum;
-      htm_data[0]=speedSum2;
-      htm_data[75]=(mg1_torque*4) & 0xFF;
-      htm_data[76]=((mg1_torque*4)>>8) & 0xFF;
+        //speed feedback
+        speedSum=mg2_speed+mg1_speed;
+        speedSum/=113;
+        speedSum2=speedSum;
+        htm_data[0]=speedSum2;
+        htm_data[75]=(mg1_torque*4) & 0xFF;
+        htm_data[76]=((mg1_torque*4)>>8) & 0xFF;
 
-      //mg1
-      htm_data[5]=(-mg1_torque) & 0xFF;  //negative is forward
-      htm_data[6]=((-mg1_torque) >> 8);
-      htm_data[11]=htm_data[5];
-      htm_data[12]=htm_data[6];
+        //mg1
+        htm_data[5]=(-mg1_torque) & 0xFF;  //negative is forward
+        htm_data[6]=((-mg1_torque) >> 8);
+        htm_data[11]=htm_data[5];
+        htm_data[12]=htm_data[6];
 
-      //mg2
-      htm_data[26]=(mg2_torque) & 0xFF; //positive is forward
-      htm_data[27]=((mg2_torque)>>8) & 0xFF;
-      htm_data[32]=htm_data[26];
-      htm_data[33]=htm_data[27];
+        //mg2
+        htm_data[26]=(mg2_torque) & 0xFF; //positive is forward
+        htm_data[27]=((mg2_torque)>>8) & 0xFF;
+        htm_data[32]=htm_data[26];
+        htm_data[33]=htm_data[27];
 
-      htm_data[63]=(-5000)&0xFF;  // regen ability of battery
-      htm_data[64]=((-5000)>>8);
+        htm_data[63]=(-5000)&0xFF;  // regen ability of battery
+        htm_data[64]=((-5000)>>8);
 
-      htm_data[65]=(27500)&0xFF;  // discharge ability of battery
-      htm_data[66]=((27500)>>8);
+        htm_data[65]=(27500)&0xFF;  // discharge ability of battery
+        htm_data[66]=((27500)>>8);
 
-      //checksum
-      htm_checksum=0;
+        //!!moved to checksum function.
+        /*
+        htm_checksum=0;
 
-      for (int i = 0; i < 78; i++)
-         htm_checksum += htm_data[i];
+        for (int i = 0; i < 78; i++)
+            htm_checksum += htm_data[i];
 
-      htm_data[78]=htm_checksum&0xFF;
-      htm_data[79]=htm_checksum>>8;
+        htm_data[78]=htm_checksum&0xFF;
+        htm_data[79]=htm_checksum>>8;
+        */
+        CalcHTMChecksum(80);
 
-      if(counter>100)
-      {
+        if(counter>100)
+        {
 //HAL_GPIO_TogglePin(LED1_GPIO_Port, LED1_Pin );
-         counter = 0;
-      }
-      else
-      {
-         counter++;
-      }
+            counter = 0;
+        }
+        else
+        {
+            counter++;
+        }
 
-      htm_state=0;
-      break;
+        htm_state=0;
+        break;
 
-   /***** Demo code for Gen3 Prius/Auris direct communications! */
-   case 5:
-      dma_read(mth_data,120);//read in mth data via dma. Probably need some kind of check dma complete flag here
-      DigIo::req_out.Clear(); //HAL_GPIO_WritePin(HTM_SYNC_GPIO_Port, HTM_SYNC_Pin, 0);
-      htm_state++;
-      break;
-   case 6:
-      DigIo::req_out.Set();  //HAL_GPIO_WritePin(HTM_SYNC_GPIO_Port, HTM_SYNC_Pin, 1);
+    /***** Demo code for Gen3 Prius/Auris direct communications! */
+    case 5:
+        dma_read(mth_data,120);//read in mth data via dma. Probably need some kind of check dma complete flag here
+        DigIo::req_out.Clear(); //HAL_GPIO_WritePin(HTM_SYNC_GPIO_Port, HTM_SYNC_Pin, 0);
+        htm_state++;
+        break;
+    case 6:
+        DigIo::req_out.Set();  //HAL_GPIO_WritePin(HTM_SYNC_GPIO_Port, HTM_SYNC_Pin, 1);
 
-      if(inv_status>5)
-      {
-         if (dma_get_interrupt_flag(DMA1, DMA_CHANNEL7, DMA_TCIF))// if the transfer complete flag is set then send another packet
-         {
-            dma_clear_interrupt_flags(DMA1, DMA_CHANNEL7, DMA_TCIF);//clear the flag.
-            dma_write(htm_data,100); //HAL_UART_Transmit_IT(&huart2, htm_data, 80);
-         }
-      }
-      else
-      {
-         dma_write(&htm_data_init[ inv_status ][0],100); //HAL_UART_Transmit_IT(&huart2, htm_data_setup, 80);
+        if(inv_status>5)
+        {
+            if (dma_get_interrupt_flag(DMA1, DMA_CHANNEL7, DMA_TCIF))// if the transfer complete flag is set then send another packet
+            {
+                dma_clear_interrupt_flags(DMA1, DMA_CHANNEL7, DMA_TCIF);//clear the flag.
+                dma_write(htm_data,100); //HAL_UART_Transmit_IT(&huart2, htm_data, 80);
+            }
+        }
+        else
+        {
+            dma_write(&htm_data_init[ inv_status ][0],100); //HAL_UART_Transmit_IT(&huart2, htm_data_setup, 80);
 
-         inv_status++;
-         if(inv_status==6)
-         {
-            //memcpy(htm_data, &htm_data_init[ inv_status ][0], 100);
-         }
-      }
-      htm_state++;
-      break;
-   case 7:
-      htm_state++;
-      break;
-   case 8:
-      if(VerifyMTHChecksum(120)==0 || dma_get_interrupt_flag(DMA1, DMA_CHANNEL6, DMA_TCIF)==0)
-      {
+            inv_status++;
+            if(inv_status==6)
+            {
+                //memcpy(htm_data, &htm_data_init[ inv_status ][0], 100);
+            }
+        }
+        htm_state++;
+        break;
+    case 7:
+        htm_state++;
+        break;
+    case 8:
+        if(VerifyMTHChecksum(120)==0 || dma_get_interrupt_flag(DMA1, DMA_CHANNEL6, DMA_TCIF)==0)
+        {
 
-         statusInv=0;
-      }
-      else
-      {
+            statusInv=0;
+        }
+        else
+        {
 
-         //exchange data and prepare next HTM frame
-         dma_clear_interrupt_flags(DMA1, DMA_CHANNEL6, DMA_TCIF);
-         statusInv=1;
-         dc_bus_voltage=(((mth_data[100]|mth_data[101]<<8)-5)/2);
-         temp_inv_water=(mth_data[42]|mth_data[43]<<8);
-         temp_inv_inductor=(mth_data[86]|mth_data[87]<<8);
-         mg1_speed=mth_data[6]|mth_data[7]<<8;
-         mg2_speed=mth_data[38]|mth_data[39]<<8;
-      }
+            //exchange data and prepare next HTM frame
+            dma_clear_interrupt_flags(DMA1, DMA_CHANNEL6, DMA_TCIF);
+            statusInv=1;
+            dc_bus_voltage=(((mth_data[100]|mth_data[101]<<8)-5)/2);
+            temp_inv_water=(mth_data[42]|mth_data[43]<<8);
+            temp_inv_inductor=(mth_data[86]|mth_data[87]<<8);
+            mg1_speed=mth_data[6]|mth_data[7]<<8;
+            mg2_speed=mth_data[38]|mth_data[39]<<8;
+        }
 
-      mth_data[98]=0;
-      mth_data[99]=0;
+        mth_data[98]=0;
+        mth_data[99]=0;
 
-      htm_state++;
-      break;
-   case 9:
-      Param::SetInt(Param::torque,mg2_torque);//post processed final torue value sent to inv to web interface
+        htm_state++;
+        break;
+    case 9:
+        Param::SetInt(Param::torque,mg2_torque);//post processed final torue value sent to inv to web interface
 
-      //speed feedback
-      speedSum=mg2_speed+mg1_speed;
-      speedSum/=113;
-      //Possibly not needed
-      //uint8_t speedSum2=speedSum;
-      //htm_data[0]=speedSum2;
+        //speed feedback
+        speedSum=mg2_speed+mg1_speed;
+        speedSum/=113;
+        //Possibly not needed
+        //uint8_t speedSum2=speedSum;
+        //htm_data[0]=speedSum2;
 
-      //these bytes are used, and seem to be MG1 for startup, but can't work out the relatino to the
-      //bytes earlier in the stream, possibly the byte order has been flipped on these 2 bytes
-      //could be a software bug ?
-      htm_data[76]=(mg1_torque*4) & 0xFF;
-      htm_data[75]=((mg1_torque*4)>>8) & 0xFF;
+        //these bytes are used, and seem to be MG1 for startup, but can't work out the relatino to the
+        //bytes earlier in the stream, possibly the byte order has been flipped on these 2 bytes
+        //could be a software bug ?
+        htm_data[76]=(mg1_torque*4) & 0xFF;
+        htm_data[75]=((mg1_torque*4)>>8) & 0xFF;
 
-      //mg1
-      htm_data[5]=(mg1_torque)&0xFF;  //negative is forward
-      htm_data[6]=((mg1_torque)>>8);
-      htm_data[11]=htm_data[5];
-      htm_data[12]=htm_data[6];
+        //mg1
+        htm_data[5]=(mg1_torque)&0xFF;  //negative is forward
+        htm_data[6]=((mg1_torque)>>8);
+        htm_data[11]=htm_data[5];
+        htm_data[12]=htm_data[6];
 
-      //mg2 the MG2 values are now beside each other!
-      htm_data[30]=(mg2_torque) & 0xFF; //positive is forward
-      htm_data[31]=((mg2_torque)>>8) & 0xFF;
+        //mg2 the MG2 values are now beside each other!
+        htm_data[30]=(mg2_torque) & 0xFF; //positive is forward
+        htm_data[31]=((mg2_torque)>>8) & 0xFF;
 
-      if(scaledTorqueTarget > 0)
-      {
-         //forward direction these bytes should match
-         htm_data[26]=htm_data[30];
-         htm_data[27]=htm_data[31];
-         htm_data[28]=(mg2_torque/2) & 0xFF; //positive is forward
-         htm_data[29]=((mg2_torque/2)>>8) & 0xFF;
-      }
+        if(scaledTorqueTarget > 0)
+        {
+            //forward direction these bytes should match
+            htm_data[26]=htm_data[30];
+            htm_data[27]=htm_data[31];
+            htm_data[28]=(mg2_torque/2) & 0xFF; //positive is forward
+            htm_data[29]=((mg2_torque/2)>>8) & 0xFF;
+        }
 
-      if(scaledTorqueTarget < 0)
-      {
-         //reverse direction these bytes should match
-         htm_data[28]=htm_data[30];
-         htm_data[29]=htm_data[31];
-         htm_data[26]=(mg2_torque/2) & 0xFF; //positive is forward
-         htm_data[27]=((mg2_torque/2)>>8) & 0xFF;
-      }
+        if(scaledTorqueTarget < 0)
+        {
+            //reverse direction these bytes should match
+            htm_data[28]=htm_data[30];
+            htm_data[29]=htm_data[31];
+            htm_data[26]=(mg2_torque/2) & 0xFF; //positive is forward
+            htm_data[27]=((mg2_torque/2)>>8) & 0xFF;
+        }
 
-      //This data has moved!
+        //This data has moved!
 
-      htm_data[85]=(-5000)&0xFF;  // regen ability of battery
-      htm_data[86]=((-5000)>>8);
+        htm_data[85]=(-5000)&0xFF;  // regen ability of battery
+        htm_data[86]=((-5000)>>8);
 
-      htm_data[87]=(-10000)&0xFF;  // discharge ability of battery
-      htm_data[88]=((-10000)>>8);
+        htm_data[87]=(-10000)&0xFF;  // discharge ability of battery
+        htm_data[88]=((-10000)>>8);
 
-      //checksum
-      if(++frame_count & 0x01)
-      {
-         htm_data[94]++;
-      }
+        //checksum
+        if(++frame_count & 0x01)
+        {
+            htm_data[94]++;
+        }
 
-      CalcHTMChecksum(100);
+        CalcHTMChecksum(100);
 
-      htm_state=5;
-      break;
+        htm_state=5;
+        break;
 
 
-         /***** Code for Lexus GS300H */
-   case 10:
-      if (Param::GetInt(Param::opmode) != MOD_RUN) inv_status = 0;
-      dma_read(mth_data,140);//read in mth data via dma.
-      DigIo::req_out.Clear(); //HAL_GPIO_WritePin(HTM_SYNC_GPIO_Port, HTM_SYNC_Pin, 0);
-      htm_state++;
-      break;
-   case 11:
-      DigIo::req_out.Set();  //HAL_GPIO_WritePin(HTM_SYNC_GPIO_Port, HTM_SYNC_Pin, 1);
-      if(inv_status>6)
-      {
-         if (dma_get_interrupt_flag(DMA1, DMA_CHANNEL7, DMA_TCIF))// if the transfer complete flag is set then send another packet
-         {
-            dma_clear_interrupt_flags(DMA1, DMA_CHANNEL7, DMA_TCIF);//clear the flag.
-            dma_write(htm_data,105); //HAL_UART_Transmit_IT(&huart2, htm_data, 80);
-         }
-      }
-      else
-      {
-         dma_write(&htm_data_Init_GS300H[ inv_status ][0],105); //HAL_UART_Transmit_IT(&huart2, htm_data_setup, 80);
+    /***** Code for Lexus GS300H */
+    case 10:
+        if (Param::GetInt(Param::opmode) != MOD_RUN) inv_status = 0;
+        dma_read(mth_data,140);//read in mth data via dma.
+        DigIo::req_out.Clear(); //HAL_GPIO_WritePin(HTM_SYNC_GPIO_Port, HTM_SYNC_Pin, 0);
+        htm_state++;
+        break;
+    case 11:
+        DigIo::req_out.Set();  //HAL_GPIO_WritePin(HTM_SYNC_GPIO_Port, HTM_SYNC_Pin, 1);
+        if(inv_status>6)
+        {
+            if (dma_get_interrupt_flag(DMA1, DMA_CHANNEL7, DMA_TCIF))// if the transfer complete flag is set then send another packet
+            {
+                dma_clear_interrupt_flags(DMA1, DMA_CHANNEL7, DMA_TCIF);//clear the flag.
+                dma_write(htm_data,105); //HAL_UART_Transmit_IT(&huart2, htm_data, 80);
+            }
+        }
+        else
+        {
+            dma_write(&htm_data_Init_GS300H[ inv_status ][0],105); //HAL_UART_Transmit_IT(&huart2, htm_data_setup, 80);
 
-         inv_status++;
+            inv_status++;
 
-      }
-      htm_state++;
-      break;
-   case 12:
-      htm_state++;
-      break;
-   case 13:
-      if(VerifyMTHChecksum(140)==0 || dma_get_interrupt_flag(DMA1, DMA_CHANNEL6, DMA_TCIF)==0)
-      {
+        }
+        htm_state++;
+        break;
+    case 12:
+        htm_state++;
+        break;
+    case 13:
+        if(VerifyMTHChecksum(140)==0 || dma_get_interrupt_flag(DMA1, DMA_CHANNEL6, DMA_TCIF)==0)
+        {
 
-         statusInv=0;
-         inv_status=0;
-      }
-      else
-      {
+            statusInv=0;
+            inv_status=0;
+        }
+        else
+        {
 
-         //exchange data and prepare next HTM frame
-         dma_clear_interrupt_flags(DMA1, DMA_CHANNEL6, DMA_TCIF);
-         statusInv=1;
-         dc_bus_voltage=(((mth_data[117]|mth_data[118]<<8))/2);
-         temp_inv_water=int8_t(mth_data[20]);
-         temp_inv_inductor=(mth_data[25]|mth_data[26]<<8);
-         mg1_speed=mth_data[10]|mth_data[11]<<8;
-         mg2_speed=mth_data[43]|mth_data[44]<<8;
-      }
+            //exchange data and prepare next HTM frame
+            dma_clear_interrupt_flags(DMA1, DMA_CHANNEL6, DMA_TCIF);
+            statusInv=1;
+            dc_bus_voltage=(((mth_data[117]|mth_data[118]<<8))/2);
+            temp_inv_water=int8_t(mth_data[20]);
+            temp_inv_inductor=(mth_data[25]|mth_data[26]<<8);
+            mg1_speed=mth_data[10]|mth_data[11]<<8;
+            mg2_speed=mth_data[43]|mth_data[44]<<8;
+        }
 
-     // mth_data[98]=0;
-     // mth_data[99]=0;
+        // mth_data[98]=0;
+        // mth_data[99]=0;
 
-      htm_state++;
-      break;
-   case 14:
-      Param::SetInt(Param::torque,mg2_torque);//post processed final torue value sent to inv to web interface
+        htm_state++;
+        break;
+    case 14:
+        Param::SetInt(Param::torque,mg2_torque);//post processed final torue value sent to inv to web interface
 
-      //speed feedback
-      speedSum=mg2_speed+mg1_speed;
-      speedSum/=113;
-      //Possibly not needed
-      //uint8_t speedSum2=speedSum;
-      //htm_data[0]=speedSum2;
+        //speed feedback
+        speedSum=mg2_speed+mg1_speed;
+        speedSum/=113;
+        //Possibly not needed
+        //uint8_t speedSum2=speedSum;
+        //htm_data[0]=speedSum2;
 
-      //these bytes are used, and seem to be MG1 for startup, but can't work out the relatino to the
-      //bytes earlier in the stream, possibly the byte order has been flipped on these 2 bytes
-      //could be a software bug ?
-     // htm_data[76]=(mg1_torque*4) & 0xFF;
-     // htm_data[75]=((mg1_torque*4)>>8) & 0xFF;
+        //these bytes are used, and seem to be MG1 for startup, but can't work out the relatino to the
+        //bytes earlier in the stream, possibly the byte order has been flipped on these 2 bytes
+        //could be a software bug ?
+        // htm_data[76]=(mg1_torque*4) & 0xFF;
+        // htm_data[75]=((mg1_torque*4)>>8) & 0xFF;
 
-    //mg1
-    htm_data[5]=(mg1_torque*-1)&0xFF;  //negative is forward
-    htm_data[6]=((mg1_torque*-1)>>8);
-    htm_data[11]=htm_data[5];
-    htm_data[12]=htm_data[6];
+        //mg1
+        htm_data[5]=(mg1_torque*-1)&0xFF;  //negative is forward
+        htm_data[6]=((mg1_torque*-1)>>8);
+        htm_data[11]=htm_data[5];
+        htm_data[12]=htm_data[6];
 
-    //mg2
-    htm_data[31]=(mg2_torque)&0xFF; //positive is forward
-    htm_data[32]=((mg2_torque)>>8);
-    htm_data[37]=htm_data[26];
-    htm_data[38]=htm_data[27];
-/*
-      if(scaledTorqueTarget > 0)
-      {
-         //forward direction these bytes should match
-         htm_data[26]=htm_data[30];
-         htm_data[27]=htm_data[31];
-         htm_data[28]=(mg2_torque/2) & 0xFF; //positive is forward
-         htm_data[29]=((mg2_torque/2)>>8) & 0xFF;
-      }
+        //mg2
+        htm_data[31]=(mg2_torque)&0xFF; //positive is forward
+        htm_data[32]=((mg2_torque)>>8);
+        htm_data[37]=htm_data[26];
+        htm_data[38]=htm_data[27];
+        /*
+              if(scaledTorqueTarget > 0)
+              {
+                 //forward direction these bytes should match
+                 htm_data[26]=htm_data[30];
+                 htm_data[27]=htm_data[31];
+                 htm_data[28]=(mg2_torque/2) & 0xFF; //positive is forward
+                 htm_data[29]=((mg2_torque/2)>>8) & 0xFF;
+              }
 
-      if(scaledTorqueTarget < 0)
-      {
-         //reverse direction these bytes should match
-         htm_data[28]=htm_data[30];
-         htm_data[29]=htm_data[31];
-         htm_data[26]=(mg2_torque/2) & 0xFF; //positive is forward
-         htm_data[27]=((mg2_torque/2)>>8) & 0xFF;
-      }
+              if(scaledTorqueTarget < 0)
+              {
+                 //reverse direction these bytes should match
+                 htm_data[28]=htm_data[30];
+                 htm_data[29]=htm_data[31];
+                 htm_data[26]=(mg2_torque/2) & 0xFF; //positive is forward
+                 htm_data[27]=((mg2_torque/2)>>8) & 0xFF;
+              }
 
-*/
-      //This data has moved!
+        */
+        //This data has moved!
 
-      htm_data[79]=(-5000)&0xFF;  // regen ability of battery
-      htm_data[80]=((-5000)>>8);
+        htm_data[79]=(-5000)&0xFF;  // regen ability of battery
+        htm_data[80]=((-5000)>>8);
 
-      htm_data[81]=(10000)&0xFF;  // discharge ability of battery
-      htm_data[82]=((10000)>>8);
-/*
-      //checksum
-     if(++frame_count & 0x01)
-      {
-         htm_data[94]++;
-      }
-*/
-      CalcHTMChecksum(105);
+        htm_data[81]=(10000)&0xFF;  // discharge ability of battery
+        htm_data[82]=((10000)>>8);
+        /*
+              //checksum
+             if(++frame_count & 0x01)
+              {
+                 htm_data[94]++;
+              }
+        */
+        CalcHTMChecksum(105);
 
-      htm_state=10;
-      break;
-   }
+        htm_state=10;
+        break;
+    }
 }
 
 void GS450HClass::setTimerState(bool desiredTimerState)
 {
-   if (desiredTimerState != this->timerIsRunning)
-   {
-      if (desiredTimerState)
-      {
-         tim_setup(); //toyota hybrid oil pump pwm timer
-         tim2_setup(); //TOYOTA HYBRID INVERTER INTERFACE CLOCK
-         this->timerIsRunning=true; //timers are now running
-      }
-      else
-      {
-         // These are only used with the Totoa hybrid option.
-         timer_disable_counter(TIM2); //TOYOTA HYBRID INVERTER INTERFACE CLOCK
-         timer_disable_counter(TIM1); //toyota hybrid oil pump pwm timer
-         this->timerIsRunning=false; //timers are now stopped
-      }
-   }
+    if (desiredTimerState != this->timerIsRunning)
+    {
+        if (desiredTimerState)
+        {
+            tim_setup(); //toyota hybrid oil pump pwm timer
+            tim2_setup(); //TOYOTA HYBRID INVERTER INTERFACE CLOCK
+            this->timerIsRunning=true; //timers are now running
+        }
+        else
+        {
+            // These are only used with the Totoa hybrid option.
+            timer_disable_counter(TIM2); //TOYOTA HYBRID INVERTER INTERFACE CLOCK
+            timer_disable_counter(TIM1); //toyota hybrid oil pump pwm timer
+            this->timerIsRunning=false; //timers are now stopped
+        }
+    }
 }
 
 int GS450HClass::GetInverterState()
 {
-   return statusInv;
+    return statusInv;
 }
 //////////////////////////////////////////////////////////////
 
@@ -579,47 +630,47 @@ int GS450HClass::GetInverterState()
 
 static void dma_write(uint8_t *data, int size)
 {
-   /*
-    * Using channel 7 for USART2_TX
-    */
+    /*
+     * Using channel 7 for USART2_TX
+     */
 
-   /* Reset DMA channel*/
-   dma_channel_reset(DMA1, DMA_CHANNEL7);
+    /* Reset DMA channel*/
+    dma_channel_reset(DMA1, DMA_CHANNEL7);
 
-   dma_set_peripheral_address(DMA1, DMA_CHANNEL7, (uint32_t)&USART2_DR);
-   dma_set_memory_address(DMA1, DMA_CHANNEL7, (uint32_t)data);
-   dma_set_number_of_data(DMA1, DMA_CHANNEL7, size);
-   dma_set_read_from_memory(DMA1, DMA_CHANNEL7);
-   dma_enable_memory_increment_mode(DMA1, DMA_CHANNEL7);
-   dma_set_peripheral_size(DMA1, DMA_CHANNEL7, DMA_CCR_PSIZE_8BIT);
-   dma_set_memory_size(DMA1, DMA_CHANNEL7, DMA_CCR_MSIZE_8BIT);
-   dma_set_priority(DMA1, DMA_CHANNEL7, DMA_CCR_PL_MEDIUM);
+    dma_set_peripheral_address(DMA1, DMA_CHANNEL7, (uint32_t)&USART2_DR);
+    dma_set_memory_address(DMA1, DMA_CHANNEL7, (uint32_t)data);
+    dma_set_number_of_data(DMA1, DMA_CHANNEL7, size);
+    dma_set_read_from_memory(DMA1, DMA_CHANNEL7);
+    dma_enable_memory_increment_mode(DMA1, DMA_CHANNEL7);
+    dma_set_peripheral_size(DMA1, DMA_CHANNEL7, DMA_CCR_PSIZE_8BIT);
+    dma_set_memory_size(DMA1, DMA_CHANNEL7, DMA_CCR_MSIZE_8BIT);
+    dma_set_priority(DMA1, DMA_CHANNEL7, DMA_CCR_PL_MEDIUM);
 
-   dma_enable_channel(DMA1, DMA_CHANNEL7);
+    dma_enable_channel(DMA1, DMA_CHANNEL7);
 
-   usart_enable_tx_dma(USART2);
+    usart_enable_tx_dma(USART2);
 }
 
 static void dma_read(uint8_t *data, int size)
 {
-   /*
-    * Using channel 6 for USART2_RX
-    */
+    /*
+     * Using channel 6 for USART2_RX
+     */
 
-   /* Reset DMA channel*/
-   dma_channel_reset(DMA1, DMA_CHANNEL6);
+    /* Reset DMA channel*/
+    dma_channel_reset(DMA1, DMA_CHANNEL6);
 
-   dma_set_peripheral_address(DMA1, DMA_CHANNEL6, (uint32_t)&USART2_DR);
-   dma_set_memory_address(DMA1, DMA_CHANNEL6, (uint32_t)data);
-   dma_set_number_of_data(DMA1, DMA_CHANNEL6, size);
-   dma_set_read_from_peripheral(DMA1, DMA_CHANNEL6);
-   dma_enable_memory_increment_mode(DMA1, DMA_CHANNEL6);
-   dma_set_peripheral_size(DMA1, DMA_CHANNEL6, DMA_CCR_PSIZE_8BIT);
-   dma_set_memory_size(DMA1, DMA_CHANNEL6, DMA_CCR_MSIZE_8BIT);
-   dma_set_priority(DMA1, DMA_CHANNEL6, DMA_CCR_PL_LOW);
+    dma_set_peripheral_address(DMA1, DMA_CHANNEL6, (uint32_t)&USART2_DR);
+    dma_set_memory_address(DMA1, DMA_CHANNEL6, (uint32_t)data);
+    dma_set_number_of_data(DMA1, DMA_CHANNEL6, size);
+    dma_set_read_from_peripheral(DMA1, DMA_CHANNEL6);
+    dma_enable_memory_increment_mode(DMA1, DMA_CHANNEL6);
+    dma_set_peripheral_size(DMA1, DMA_CHANNEL6, DMA_CCR_PSIZE_8BIT);
+    dma_set_memory_size(DMA1, DMA_CHANNEL6, DMA_CCR_MSIZE_8BIT);
+    dma_set_priority(DMA1, DMA_CHANNEL6, DMA_CCR_PL_LOW);
 
-   dma_enable_channel(DMA1, DMA_CHANNEL6);
+    dma_enable_channel(DMA1, DMA_CHANNEL6);
 
-   usart_enable_rx_dma(USART2);
+    usart_enable_rx_dma(USART2);
 }
 

--- a/src/RearOutlanderinverter.cpp
+++ b/src/RearOutlanderinverter.cpp
@@ -23,89 +23,93 @@
 
 RearOutlanderInverter::RearOutlanderInverter()
 {
-   //ctor
+    //ctor
 }
 
 void RearOutlanderInverter::SetCanInterface(CanHardware* c)
 {
-   can = c;
+    can = c;
 
-   can->RegisterUserMessage(0x289);//Outlander Inv Msg
-   can->RegisterUserMessage(0x299);//Outlander Inv Msg
-   can->RegisterUserMessage(0x733);//Outlander Inv Msg
+    can->RegisterUserMessage(0x289);//Outlander Inv Msg
+    can->RegisterUserMessage(0x299);//Outlander Inv Msg
+    can->RegisterUserMessage(0x733);//Outlander Inv Msg
 }
 
 void RearOutlanderInverter::DecodeCAN(int id, uint32_t data[2])
 {
-   uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
-   switch (id)
-   {
-   case 0x289:
-      //speed = (((data[0] >> 8)& 0xFF00) | ((data[0] >> 24) & 0x0FF)) - 20000;
-      //voltage = ((data[1] & 0xFF) << 8) | ((data[1] >> 8) & 0xFF);
-      speed = (bytes[2] * 256 | bytes[3]) - 20000;
-      voltage = (bytes[4] * 256) + bytes[5];
-      break;
-   case 0x299:
-      //motor_temp = bytes[0] -40;
-      inv_temp = ((bytes[1]-40) + (bytes[4] - 40)) / 2;
-      break;
-   case 0x733:
-      motor_temp = bytes[0] -40; //
-      break;
+    uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
+    switch (id)
+    {
+    case 0x289:
+        //speed = (((data[0] >> 8)& 0xFF00) | ((data[0] >> 24) & 0x0FF)) - 20000;
+        //voltage = ((data[1] & 0xFF) << 8) | ((data[1] >> 8) & 0xFF);
+        speed = (bytes[2] * 256 | bytes[3]) - 20000;
+        voltage = (bytes[4] * 256) + bytes[5];
+        break;
+    case 0x299:
+        //motor_temp = bytes[0] -40;
+        inv_temp = ((bytes[1]-40) + (bytes[4] - 40)) / 2;
+        break;
+    case 0x733:
+        motor_temp = bytes[0] -40; //
+        break;
 
 
-   }
+    }
 }
 
 
 
 void RearOutlanderInverter::SetTorque(float torquePercent)
 {
-   final_torque_request = (((torquePercent * 2000) / 100.0f ) * -1) + 10000; // *-1 reverses torque direction
+    final_torque_request = ((torquePercent * 2000) / 100.0f ); //!! Moved into parameter *-1 reverses torque direction
 
-
-   Param::SetInt(Param::torque,final_torque_request);//post processed final torque value sent to inv to web interface
+    if(Param::GetInt(Param::reversemotor) == 1)
+    {
+        final_torque_request *= -1;//reverse torque request to flip motor rotation
+    }
+    final_torque_request += 10000;
+    Param::SetInt(Param::torque,final_torque_request);//post processed final torque value sent to inv to web interface
 }
 
 void RearOutlanderInverter::Task10Ms()
 {
-   run10ms++;
+    run10ms++;
 
-   //Run every 50 ms
-   if (run10ms == 5)
-   {
-      uint32_t data[2];
-      run10ms = 0;
+    //Run every 50 ms
+    if (run10ms == 5)
+    {
+        uint32_t data[2];
+        run10ms = 0;
 
-      data[0] = (final_torque_request & 0xff)<<24 | (final_torque_request & 0xff00)<<8; // swap high and low bytes and shift 16 bit left
-	  // enable inverter. Byte 6 0x0 to disable inverter, 0x3 for drive ( torque > 0 )
-	  data[1] = (final_torque_request == 10000 ? 0x00 : 0x03)<<16;
+        data[0] = (final_torque_request & 0xff)<<24 | (final_torque_request & 0xff00)<<8; // swap high and low bytes and shift 16 bit left
+        // enable inverter. Byte 6 0x0 to disable inverter, 0x3 for drive ( torque > 0 )
+        data[1] = (final_torque_request == 10000 ? 0x00 : 0x03)<<16;
 
-      can->Send(0x287, data, 8);
-   }
+        can->Send(0x287, data, 8);
+    }
 }
 
 void RearOutlanderInverter::Task100Ms()
 {
-  int opmode = Param::GetInt(Param::opmode);
-  if(opmode==MOD_RUN)
-      {
-    uint32_t data[8];
+    int opmode = Param::GetInt(Param::opmode);
+    if(opmode==MOD_RUN)
+    {
+        uint32_t data[8];
 
-   data[0] = 0x00000030;
-   data[1] = 0x00000000;
+        data[0] = 0x00000030;
+        data[1] = 0x00000000;
 
-   can->Send(0x371, data, 8);
+        can->Send(0x371, data, 8);
 
-   data[0] = 0x39140000; // inverter enabled B2 0x10 - 0x1F
+        data[0] = 0x39140000; // inverter enabled B2 0x10 - 0x1F
 
-   can->Send(0x285, data, 8);
+        can->Send(0x285, data, 8);
 
-   data[0] = 0x3D000000;
-   data[1] = 0x00210000;
+        data[0] = 0x3D000000;
+        data[1] = 0x00210000;
 
-   can->Send(0x286, data, 8);
+        can->Send(0x286, data, 8);
 
-      }
+    }
 }

--- a/src/leafinv.cpp
+++ b/src/leafinv.cpp
@@ -61,519 +61,525 @@ PDM sends:
 
 void LeafINV::SetCanInterface(CanHardware* c)
 {
-   can = c;
+    can = c;
 
-   can->RegisterUserMessage(0x1DA);//Leaf inv msg
-   can->RegisterUserMessage(0x55A);//Leaf inv msg
-   can->RegisterUserMessage(0x679);//Leaf obc msg
-   can->RegisterUserMessage(0x390);//Leaf obc msg
+    can->RegisterUserMessage(0x1DA);//Leaf inv msg
+    can->RegisterUserMessage(0x55A);//Leaf inv msg
+    can->RegisterUserMessage(0x679);//Leaf obc msg
+    can->RegisterUserMessage(0x390);//Leaf obc msg
 }
 
 void LeafINV::DecodeCAN(int id, uint32_t data[2])
 {
-   uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
+    uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
 
-   if (id == 0x1DA)// THIS MSG CONTAINS INV VOLTAGE, MOTOR SPEED AND ERROR STATE
-   {
-      voltage = (bytes[0] << 2) | (bytes[1] >> 6);//MEASURED VOLTAGE FROM LEAF INVERTER
+    if (id == 0x1DA)// THIS MSG CONTAINS INV VOLTAGE, MOTOR SPEED AND ERROR STATE
+    {
+        voltage = (bytes[0] << 2) | (bytes[1] >> 6);//MEASURED VOLTAGE FROM LEAF INVERTER
 
-      int16_t parsed_speed = (bytes[4] << 8) | bytes[5];
-      speed = (parsed_speed == 0x7fff ? 0 : parsed_speed);//LEAF MOTOR RPM
+        int16_t parsed_speed = (bytes[4] << 7) | bytes[5]>>1;
+        if(parsed_speed> 0x3fff)parsed_speed -=0x7fff;//15 bit signed conversion
+        //speed = (parsed_speed == 0x7fff ? 0 : parsed_speed);//LEAF MOTOR RPM
+        speed = parsed_speed;
+        error = (bytes[6] & 0xb0) != 0x00;//INVERTER ERROR STATE
 
-      error = (bytes[6] & 0xb0) != 0x00;//INVERTER ERROR STATE
+    }
+    else if (id == 0x55A)// THIS MSG CONTAINS INV TEMP AND MOTOR TEMP
+    {
+        inv_temp = fahrenheit_to_celsius(bytes[2]);//INVERTER TEMP
+        motor_temp = fahrenheit_to_celsius(bytes[1]);//MOTOR TEMP
+    }
 
-   }
-   else if (id == 0x55A)// THIS MSG CONTAINS INV TEMP AND MOTOR TEMP
-   {
-      inv_temp = fahrenheit_to_celsius(bytes[2]);//INVERTER TEMP
-      motor_temp = fahrenheit_to_celsius(bytes[1]);//MOTOR TEMP
-   }
+    else if (id == 0x679)// THIS MSG FIRES ONCE ON CHARGE PLUG INSERT
+    {
+        uint8_t dummyVar = bytes[0];
+        dummyVar = dummyVar;
+        OBCwake = true;             //0x679 is received once when we plug in if pdm is asleep so wake wakey...
+    }
 
-   else if (id == 0x679)// THIS MSG FIRES ONCE ON CHARGE PLUG INSERT
-   {
-      uint8_t dummyVar = bytes[0];
-      dummyVar = dummyVar;
-      OBCwake = true;             //0x679 is received once when we plug in if pdm is asleep so wake wakey...
-   }
-
-   else if (id == 0x390)// THIS MSG FROM PDM
-   {
-      OBCVoltStat = (bytes[3] >> 3) & 0x03;
-      PlugStat = bytes[5] & 0x0F;
-      if(PlugStat == 0x08) PPStat = true; //plug inserted
-      if(PlugStat == 0x00) PPStat = false; //plug not inserted
-   }
+    else if (id == 0x390)// THIS MSG FROM PDM
+    {
+        OBCVoltStat = (bytes[3] >> 3) & 0x03;
+        PlugStat = bytes[5] & 0x0F;
+        if(PlugStat == 0x08) PPStat = true; //plug inserted
+        if(PlugStat == 0x00) PPStat = false; //plug not inserted
+    }
 }
 
 bool LeafINV::ControlCharge(bool RunCh)
 {
-   int opmode = Param::GetInt(Param::opmode);
-   if(opmode != MOD_CHARGE)
-   {
-      if(RunCh && OBCwake)
-      {
-         //OBCwake = false;//reset obc wake for next time
-         return true;
-      }
-   }
+    int opmode = Param::GetInt(Param::opmode);
+    if(opmode != MOD_CHARGE)
+    {
+        if(RunCh && OBCwake)
+        {
+            //OBCwake = false;//reset obc wake for next time
+            return true;
+        }
+    }
 
-   if(PPStat) return true;
-   if(!PPStat)
-   {
-      OBCwake = false;
-      return false;
-   }
-   return false;
+    if(PPStat) return true;
+    if(!PPStat)
+    {
+        OBCwake = false;
+        return false;
+    }
+    return false;
 }
 
 void LeafINV::SetTorque(float torquePercent)
 {
-   final_torque_request = (torquePercent * 2047) / 100.0f;
+    final_torque_request = (torquePercent * 2047) / 100.0f;
 
-   Param::SetInt(Param::torque,final_torque_request);//post processed final torque value sent to inv to web interface
+    if(Param::GetInt(Param::reversemotor) == 1)
+    {
+        final_torque_request *= -1;//reverse torque request to flip motor rotation
+    }
+
+    Param::SetInt(Param::torque,final_torque_request);//post processed final torque value sent to inv to web interface
 }
 
 void LeafINV::Task10Ms()
 {
-   int opmode = Param::GetInt(Param::opmode);
-
-   uint8_t bytes[8];
-
-   /////////////////////////////////////////////////////////////////////////////////////////////////
-   // CAN Messaage 0x11A
-
-   // Data taken from a gen1 inFrame where the car is starting to
-   // move at about 10% throttle: 4E400055 0000017D
-
-   // All possible gen1 values: 00 01 0D 11 1D 2D 2E 3D 3E 4D 4E
-   // MSB nibble: Selected gear (gen1/LeafLogs)
-   //   0: some kind of non-gear before driving
-   //      0: Park in Gen 2. byte 0 = 0x01 when in park and charging
-   //   1: some kind of non-gear after driving
-   //   2: R
-   //   3: N
-   //   4: D
-   // LSB nibble: ? (LeafLogs)
-   //   0: sometimes at startup, not always; never when the
-   //      inverted is powered on (0.06%)
-   //   1: this is the usual value (55% of the time in LeafLogs)
-   //   D: seems to occur for ~90ms when changing gears (0.2%)
-   //   E: this also is a usual value, but never occurs with the
-   //      non-gears 0 and 1 (44% of the time in LeafLogs)
-
-
-   //byte 0 determines motor rotation direction
-   if (opmode == MOD_CHARGE) bytes[0] = 0x01;//Car in park when charging
-   if (opmode != MOD_CHARGE) bytes[0] = 0x4E;
-   // 0x40 when car is ON, 0x80 when OFF, 0x50 when ECO. Car must be off when charing 0x80
-   if (opmode == MOD_CHARGE) bytes[1] = 0x80;
-   if (opmode != MOD_CHARGE) bytes[1] = 0x40;
-   // Usually 0x00, sometimes 0x80 (LeafLogs), 0x04 seen by canmsgs
-   bytes[2] = 0x00;
-
-   // Weird value at D3:4 that goes along with the counter
-   // NOTE: Not actually needed, you can just send constant AA C0
-   const static uint8_t weird_d34_values[4][2] =
-   {
-      {0xaa, 0xc0},
-      {0x55, 0x00},
-      {0x55, 0x40},
-      {0xaa, 0x80},
-   };
-
-
-
-   bytes[3] = weird_d34_values[counter_11a_d6][0];//0xAA;
-   bytes[4] = weird_d34_values[counter_11a_d6][1];//0xC0;
-
-   // Always 0x00 (LeafLogs, canmsgs)
-   bytes[5] = 0x00;
-
-   // A 2-bit counter
-   bytes[6] = counter_11a_d6;
-
-   counter_11a_d6++;
-   if(counter_11a_d6 >= 4)
-   {
-      counter_11a_d6 = 0;
-   }
-
-
-   // Extra CRC
-   nissan_crc(bytes, 0x85);//not sure if this is really working or just making me look like a muppet.
-
-
-
-   can->Send(0x11A, (uint32_t*)bytes, 8);
-
-
-   /////////////////////////////////////////////////////////////////////////////////////////////////
-   // CAN Message 0x1D4: Target Motor Torque
-
-   // Data taken from a gen1 inFrame where the car is starting to
-   // move at about 10% throttle: F70700E0C74430D4
-
-   // Usually F7, but can have values between 9A...F7 (gen1)
-   bytes[0] = 0xF7;
-   // 2016: 6E
-   // outFrame.data.bytes[0] = 0x6E;
-
-   // Usually 07, but can have values between 07...70 (gen1)
-   bytes[1] = 0x07;
-   // 2016: 6E
-   //outFrame.data.bytes[1] = 0x6E;
-
-   // override any torque commands if not in run mode.
-   if (opmode != MOD_RUN)
-   {
-      final_torque_request = 0;
-   }
-
-   // Requested torque (signed 12-bit value + always 0x0 in low nibble)
-   if(final_torque_request >= -2048 && final_torque_request <= 2047)
-   {
-      bytes[2] = ((final_torque_request < 0) ? 0x80 : 0) |((final_torque_request >> 4) & 0x7f);
-      bytes[3] = (final_torque_request << 4) & 0xf0;
-   }
-   else
-   {
-      bytes[2] = 0x00;
-      bytes[3] = 0x00;
-   }
-
-   // MSB nibble: Runs through the sequence 0, 4, 8, C
-   // LSB nibble: Precharge report (precedes actual precharge
-   //             control)
-   //   0: Discharging (5%)
-   //   2: Precharge not started (1.4%)
-   //   3: Precharging (0.4%)
-   //   5: Starting discharge (3x10ms) (2.0%)
-   //   7: Precharged (93%)
-   bytes[4] = 0x07 | (counter_1d4 << 6);
-   //bytes[4] = 0x02 | (counter_1d4 << 6);
-   //Bit 2 is HV status. 0x00 No HV, 0x01 HV On.
-
-   counter_1d4++;
-   if(counter_1d4 >= 4) counter_1d4 = 0;
-
-   // MSB nibble:
-   //   0: 35-40ms at startup when gear is 0, then at shutdown 40ms
-   //      after the car has been shut off (6% total)
-   //   4: Otherwise (94%)
-   // LSB nibble:
-   //   0: ~100ms when changing gear, along with 11A D0 b3:0 value
-   //      D (0.3%)
-   //   2: Reverse gear related (13%)
-   //   4: Forward gear related (21%)
-   //   6: Occurs always when gear 11A D0 is 01 or 11 (66%)
-   //outFrame.data.bytes[5] = 0x44;
-   //outFrame.data.bytes[5] = 0x46;
-
-   // 2016 drive cycle: 06, 46, precharge, 44, drive, 46, discharge, 06
-   // 0x46 requires ~25 torque to start
-   //outFrame.data.bytes[5] = 0x46;
-   // 0x44 requires ~8 torque to start
-   bytes[5] = 0x44;
-   //bit 6 is Main contactor status. 0x00 Not on, 0x01 on.
-
-   // MSB nibble:
-   //   In a drive cycle, this slowly changes between values (gen1):
-   //     leaf_on_off.txt:
-   //       5 7 3 2 0 1 3 7
-   //     leaf_on_rev_off.txt:
-   //       5 7 3 2 0 6
-   //     leaf_on_Dx3.txt:
-   //       5 7 3 2 0 2 3 2 0 2 3 2 0 2 3 7
-   //     leaf_on_stat_DRDRDR.txt:
-   //       0 1 3 7
-   //     leaf_on_Driveincircle_off.txt:
-   //       5 3 2 0 8 B 3 2 0 8 A B 3 2 0 8 A B A 8 0 2 3 7
-   //     leaf_on_wotind_off.txt:
-   //       3 2 0 8 A B 3 7
-   //     leaf_on_wotinr_off.txt:
-   //       5 7 3 2 0 8 A B 3 7
-   //     leaf_ac_charge.txt:
-   //       4 6 E 6
-   //   Possibly some kind of control flags, try to figure out
-   //   using:
-   //     grep 000001D4 leaf_on_wotind_off.txt | cut -d' ' -f10 | uniq | ~/projects/leaf_tools/util/hex_to_ascii_binary.py
-   //   2016:
-   //     Has different values!
-   // LSB nibble:
-   //   0: Always (gen1)
-   //   1:  (2016)
-
-   // 2016 drive cycle:
-   //   E0: to 0.15s
-   //   E1: 2 messages
-   //   61: to 2.06s (inverter is powered up and precharge
-   //                 starts and completes during this)
-   //   21: to 13.9s
-   //   01: to 17.9s
-   //   81: to 19.5s
-   //   A1: to 26.8s
-   //   21: to 31.0s
-   //   01: to 33.9s
-   //   81: to 48.8s
-   //   A1: to 53.0s
-   //   21: to 55.5s
-   //   61: 2 messages
-   //   60: to 55.9s
-   //   E0: to end of capture (discharge starts during this)
-
-   // This value has been chosen at the end of the hardest
-   // acceleration in the wide-open-throttle pull, with full-ish
-   // torque still being requested, in
-   //   LeafLogs/leaf_on_wotind_off.txt
-   //outFrame.data.bytes[6] = 0x00;
-
-   // This value has been chosen for being seen most of the time
-   // when, and before, applying throttle in the wide-open-throttle
-   // pull, in
-   //   LeafLogs/leaf_on_wotind_off.txt
-
-   if (opmode != MOD_CHARGE)  bytes[6] = 0x30;    //brake applied heavilly.
-   if (opmode == MOD_CHARGE)  bytes[6] = 0xE0;   //charging mode
-   //In Gen 2 byte 6 is Charge status.
-   //0x8C Charging interrupted
-   //0xE0 Charging
-
-   // Value chosen from a 2016 log
-   //outFrame.data.bytes[6] = 0x61;
-
-   // Value chosen from a 2016 log
-   // 2016-24kWh-ev-on-drive-park-off.pcap #12101 / 15.63s
-   // outFrame.data.bytes[6] = 0x01;
-   //byte 6 brake signal
-
-   // Extra CRC
-   nissan_crc(bytes, 0x85);
-
-   can->Send(0x1D4, (uint32_t*)bytes, 8);//send on can1
-
-
-   /////////////////////////////////////////////////////////////////////////////////////////////////
-   // CAN Message 0x1DB
-
-   //We need to send 0x1db here with voltage measured by inverter
-   //Zero seems to work also on my gen1
-   ////////////////////////////////////////////////////////////////
-   //Byte 1 bits 8-10 LB Failsafe Status
-   //0x00 Normal start req. seems to stay on this value most of the time
-   //0x01 Normal stop req
-   //0x02 Charge stop req
-   //0x03 Charge and normal stop req. Other values call for a caution lamp which we don't need
-   //bits 11-12 LB relay cut req
-   //0x00 no req
-   //0x01,0x02,0x03 main relay off req
-   s16fp TMP_battI = (Param::Get(Param::idc))*2;
-   s16fp TMP_battV = (Param::Get(Param::udc))*4;
-   bytes[0] = TMP_battI >> 8;     //MSB current. 11 bit signed MSBit first
-   bytes[1] = TMP_battI & 0xE0;  //LSB current bits 7-5. Dont need to mess with bits 0-4 for now as 0 works.
-   bytes[2] = TMP_battV >> 8;
-   bytes[3] = ((TMP_battV & 0xC0) | (0x2b)); //0x2b should give no cut req, main rly on permission,normal p limit.
-   bytes[4] = 0x40;  //SOC for dash in Leaf. fixed val.
-   bytes[5] = 0x00;
-   bytes[6] = counter_1db;
-
-
-
-   // Extra CRC in byte 7
-   nissan_crc(bytes, 0x85);
-
-
-   counter_1db++;
-   if(counter_1db >= 4) counter_1db = 0;
-
-   can->Send(0x1DB, (uint32_t*)bytes, 8);
-
-   /////////////////////////////////////////////////////////////////////////////////////////////////
-   // CAN Message 0x50B
-
-   // Statistics from 2016 capture:
-   //     10 00000000000000
-   //     21 000002c0000000
-   //    122 000000c0000000
-   //    513 000006c0000000
-
-   // Let's just send the most common one all the time
-   // FIXME: This is a very sloppy implementation. Thanks. I try:)
-   bytes[0] = 0x00;
-   bytes[1] = 0x00;
-   bytes[2] = 0x06;
-   bytes[3] = 0xc0;
-   bytes[4] = 0x00;
-   bytes[5] = 0x00;
-   bytes[6] = 0x00;
-
-   //possible problem here as 0x50B is DLC 7....
-   can->Send(0x50B, (uint32_t*)bytes, 7);
-
-
-   /////////////////////////////////////////////////////////////////////////////////////////////////
-   // CAN Message 0x1DC:
-
-   // 0x1dc from lbc. Contains chg power lims and disch power lims.
-   // Disch power lim in byte 0 and byte 1 bits 6-7. Just set to max for now.
-   // Max charging power in bits 13-20. 10 bit unsigned scale 0.25.Byte 1 limit in kw.
-   bytes[0]=0x6E;
-   bytes[1]=0x0A;
-   bytes[2]=0x05;
-   bytes[3]=0xD5;
-   bytes[4]=0x00;//may not need pairing code crap here...and we don't:)
-   bytes[5]=0x00;
-   bytes[6]=counter_1dc;
-   // Extra CRC in byte 7
-   nissan_crc(bytes, 0x85);
-
-   counter_1dc++;
-   if (counter_1dc >= 4)
-      counter_1dc = 0;
-
-   can->Send(0x1DC, (uint32_t*)bytes, 8);
-
-   /////////////////////////////////////////////////////////////////////////////////////////////////
-   // CAN Message 0x1F2: Charge Power and DC/DC Converter Control
-
-   // convert power setpoint to PDM format:
-   //    0x70 = 3 amps ish
-   //    0x6a = 1.4A
-   //    0x66 = 0.5A
-   //    0x65 = 0.3A
-   //    0x64 = no chg
-   //    so 0x64=100. 0xA0=160. so 60 decimal steps. 1 step=100W???
-   OBCpwrSP = (Param::GetInt(Param::Pwrspnt) / 100) + 0x64;
-
-   // get actual voltage and voltage setpoints
-   Vbatt = Param::GetInt(Param::udc);
-   VbattSP = Param::GetInt(Param::Voltspnt);
-
-   if (opmode == MOD_CHARGE && Param::GetInt(Param::Chgctrl) == ChargeControl::Enable)
-   {
-      // clamp min and max values
-      if (OBCpwrSP > 0xA0)
-         OBCpwrSP = 0xA0;
-      else if (OBCpwrSP < 0x64)
-         OBCpwrSP = 0x64;
-
-      // if measured vbatt is less than setpoint got to max power from web ui
-      if (Vbatt < VbattSP)
-         OBCpwr = OBCpwrSP;
-
-      // decrement charger power if volt setpoint is reached
-      if (Vbatt >= VbattSP)
-         OBCpwr--;
-   }
-   else
-   {
-      // set power to 0 if charge control is set to off or not in charge mode
-      OBCpwr = 0x64;
-   }
-
-
-   // Commanded chg power in byte 1 and byte 0 bits 0-1. 10 bit number.
-   // byte 1=0x64 and byte 0=0x00 at 0 power.
-   // 0x00 chg 0ff dcdc on.
-   bytes[0] = 0x30;  // msg is muxed but pdm doesn't seem to care.
-   bytes[1] = OBCpwr;
-   bytes[2] = 0x20;
-   bytes[3] = 0xAC;
-   bytes[4] = 0x00;
-   bytes[5] = 0x3C;
-   bytes[6] = counter_1f2;
-   bytes[7] = 0x8F;  //may not need checksum here?
-
-   counter_1f2++;
-   if (counter_1f2 >= 4)
-   {
-      counter_1f2 = 0;
-   }
-
-   can->Send(0x1F2, (uint32_t*)bytes, 8);
+    int opmode = Param::GetInt(Param::opmode);
+
+    uint8_t bytes[8];
+
+    /////////////////////////////////////////////////////////////////////////////////////////////////
+    // CAN Messaage 0x11A
+
+    // Data taken from a gen1 inFrame where the car is starting to
+    // move at about 10% throttle: 4E400055 0000017D
+
+    // All possible gen1 values: 00 01 0D 11 1D 2D 2E 3D 3E 4D 4E
+    // MSB nibble: Selected gear (gen1/LeafLogs)
+    //   0: some kind of non-gear before driving
+    //      0: Park in Gen 2. byte 0 = 0x01 when in park and charging
+    //   1: some kind of non-gear after driving
+    //   2: R
+    //   3: N
+    //   4: D
+    // LSB nibble: ? (LeafLogs)
+    //   0: sometimes at startup, not always; never when the
+    //      inverted is powered on (0.06%)
+    //   1: this is the usual value (55% of the time in LeafLogs)
+    //   D: seems to occur for ~90ms when changing gears (0.2%)
+    //   E: this also is a usual value, but never occurs with the
+    //      non-gears 0 and 1 (44% of the time in LeafLogs)
+
+
+    //byte 0 determines motor rotation direction
+    if (opmode == MOD_CHARGE) bytes[0] = 0x01;//Car in park when charging
+    if (opmode != MOD_CHARGE) bytes[0] = 0x4E;
+    // 0x40 when car is ON, 0x80 when OFF, 0x50 when ECO. Car must be off when charing 0x80
+    if (opmode == MOD_CHARGE) bytes[1] = 0x80;
+    if (opmode != MOD_CHARGE) bytes[1] = 0x40;
+    // Usually 0x00, sometimes 0x80 (LeafLogs), 0x04 seen by canmsgs
+    bytes[2] = 0x00;
+
+    // Weird value at D3:4 that goes along with the counter
+    // NOTE: Not actually needed, you can just send constant AA C0
+    const static uint8_t weird_d34_values[4][2] =
+    {
+        {0xaa, 0xc0},
+        {0x55, 0x00},
+        {0x55, 0x40},
+        {0xaa, 0x80},
+    };
+
+
+
+    bytes[3] = weird_d34_values[counter_11a_d6][0];//0xAA;
+    bytes[4] = weird_d34_values[counter_11a_d6][1];//0xC0;
+
+    // Always 0x00 (LeafLogs, canmsgs)
+    bytes[5] = 0x00;
+
+    // A 2-bit counter
+    bytes[6] = counter_11a_d6;
+
+    counter_11a_d6++;
+    if(counter_11a_d6 >= 4)
+    {
+        counter_11a_d6 = 0;
+    }
+
+
+    // Extra CRC
+    nissan_crc(bytes, 0x85);//not sure if this is really working or just making me look like a muppet.
+
+
+
+    can->Send(0x11A, (uint32_t*)bytes, 8);
+
+
+    /////////////////////////////////////////////////////////////////////////////////////////////////
+    // CAN Message 0x1D4: Target Motor Torque
+
+    // Data taken from a gen1 inFrame where the car is starting to
+    // move at about 10% throttle: F70700E0C74430D4
+
+    // Usually F7, but can have values between 9A...F7 (gen1)
+    bytes[0] = 0xF7;
+    // 2016: 6E
+    // outFrame.data.bytes[0] = 0x6E;
+
+    // Usually 07, but can have values between 07...70 (gen1)
+    bytes[1] = 0x07;
+    // 2016: 6E
+    //outFrame.data.bytes[1] = 0x6E;
+
+    // override any torque commands if not in run mode.
+    if (opmode != MOD_RUN)
+    {
+        final_torque_request = 0;
+    }
+
+    // Requested torque (signed 12-bit value + always 0x0 in low nibble)
+    if(final_torque_request >= -2048 && final_torque_request <= 2047)
+    {
+        bytes[2] = ((final_torque_request < 0) ? 0x80 : 0) |((final_torque_request >> 4) & 0x7f);
+        bytes[3] = (final_torque_request << 4) & 0xf0;
+    }
+    else
+    {
+        bytes[2] = 0x00;
+        bytes[3] = 0x00;
+    }
+
+    // MSB nibble: Runs through the sequence 0, 4, 8, C
+    // LSB nibble: Precharge report (precedes actual precharge
+    //             control)
+    //   0: Discharging (5%)
+    //   2: Precharge not started (1.4%)
+    //   3: Precharging (0.4%)
+    //   5: Starting discharge (3x10ms) (2.0%)
+    //   7: Precharged (93%)
+    bytes[4] = 0x07 | (counter_1d4 << 6);
+    //bytes[4] = 0x02 | (counter_1d4 << 6);
+    //Bit 2 is HV status. 0x00 No HV, 0x01 HV On.
+
+    counter_1d4++;
+    if(counter_1d4 >= 4) counter_1d4 = 0;
+
+    // MSB nibble:
+    //   0: 35-40ms at startup when gear is 0, then at shutdown 40ms
+    //      after the car has been shut off (6% total)
+    //   4: Otherwise (94%)
+    // LSB nibble:
+    //   0: ~100ms when changing gear, along with 11A D0 b3:0 value
+    //      D (0.3%)
+    //   2: Reverse gear related (13%)
+    //   4: Forward gear related (21%)
+    //   6: Occurs always when gear 11A D0 is 01 or 11 (66%)
+    //outFrame.data.bytes[5] = 0x44;
+    //outFrame.data.bytes[5] = 0x46;
+
+    // 2016 drive cycle: 06, 46, precharge, 44, drive, 46, discharge, 06
+    // 0x46 requires ~25 torque to start
+    //outFrame.data.bytes[5] = 0x46;
+    // 0x44 requires ~8 torque to start
+    bytes[5] = 0x44;
+    //bit 6 is Main contactor status. 0x00 Not on, 0x01 on.
+
+    // MSB nibble:
+    //   In a drive cycle, this slowly changes between values (gen1):
+    //     leaf_on_off.txt:
+    //       5 7 3 2 0 1 3 7
+    //     leaf_on_rev_off.txt:
+    //       5 7 3 2 0 6
+    //     leaf_on_Dx3.txt:
+    //       5 7 3 2 0 2 3 2 0 2 3 2 0 2 3 7
+    //     leaf_on_stat_DRDRDR.txt:
+    //       0 1 3 7
+    //     leaf_on_Driveincircle_off.txt:
+    //       5 3 2 0 8 B 3 2 0 8 A B 3 2 0 8 A B A 8 0 2 3 7
+    //     leaf_on_wotind_off.txt:
+    //       3 2 0 8 A B 3 7
+    //     leaf_on_wotinr_off.txt:
+    //       5 7 3 2 0 8 A B 3 7
+    //     leaf_ac_charge.txt:
+    //       4 6 E 6
+    //   Possibly some kind of control flags, try to figure out
+    //   using:
+    //     grep 000001D4 leaf_on_wotind_off.txt | cut -d' ' -f10 | uniq | ~/projects/leaf_tools/util/hex_to_ascii_binary.py
+    //   2016:
+    //     Has different values!
+    // LSB nibble:
+    //   0: Always (gen1)
+    //   1:  (2016)
+
+    // 2016 drive cycle:
+    //   E0: to 0.15s
+    //   E1: 2 messages
+    //   61: to 2.06s (inverter is powered up and precharge
+    //                 starts and completes during this)
+    //   21: to 13.9s
+    //   01: to 17.9s
+    //   81: to 19.5s
+    //   A1: to 26.8s
+    //   21: to 31.0s
+    //   01: to 33.9s
+    //   81: to 48.8s
+    //   A1: to 53.0s
+    //   21: to 55.5s
+    //   61: 2 messages
+    //   60: to 55.9s
+    //   E0: to end of capture (discharge starts during this)
+
+    // This value has been chosen at the end of the hardest
+    // acceleration in the wide-open-throttle pull, with full-ish
+    // torque still being requested, in
+    //   LeafLogs/leaf_on_wotind_off.txt
+    //outFrame.data.bytes[6] = 0x00;
+
+    // This value has been chosen for being seen most of the time
+    // when, and before, applying throttle in the wide-open-throttle
+    // pull, in
+    //   LeafLogs/leaf_on_wotind_off.txt
+
+    if (opmode != MOD_CHARGE)  bytes[6] = 0x30;    //brake applied heavilly.
+    if (opmode == MOD_CHARGE)  bytes[6] = 0xE0;   //charging mode
+    //In Gen 2 byte 6 is Charge status.
+    //0x8C Charging interrupted
+    //0xE0 Charging
+
+    // Value chosen from a 2016 log
+    //outFrame.data.bytes[6] = 0x61;
+
+    // Value chosen from a 2016 log
+    // 2016-24kWh-ev-on-drive-park-off.pcap #12101 / 15.63s
+    // outFrame.data.bytes[6] = 0x01;
+    //byte 6 brake signal
+
+    // Extra CRC
+    nissan_crc(bytes, 0x85);
+
+    can->Send(0x1D4, (uint32_t*)bytes, 8);//send on can1
+
+
+    /////////////////////////////////////////////////////////////////////////////////////////////////
+    // CAN Message 0x1DB
+
+    //We need to send 0x1db here with voltage measured by inverter
+    //Zero seems to work also on my gen1
+    ////////////////////////////////////////////////////////////////
+    //Byte 1 bits 8-10 LB Failsafe Status
+    //0x00 Normal start req. seems to stay on this value most of the time
+    //0x01 Normal stop req
+    //0x02 Charge stop req
+    //0x03 Charge and normal stop req. Other values call for a caution lamp which we don't need
+    //bits 11-12 LB relay cut req
+    //0x00 no req
+    //0x01,0x02,0x03 main relay off req
+    s16fp TMP_battI = (Param::Get(Param::idc))*2;
+    s16fp TMP_battV = (Param::Get(Param::udc))*4;
+    bytes[0] = TMP_battI >> 8;     //MSB current. 11 bit signed MSBit first
+    bytes[1] = TMP_battI & 0xE0;  //LSB current bits 7-5. Dont need to mess with bits 0-4 for now as 0 works.
+    bytes[2] = TMP_battV >> 8;
+    bytes[3] = ((TMP_battV & 0xC0) | (0x2b)); //0x2b should give no cut req, main rly on permission,normal p limit.
+    bytes[4] = 0x40;  //SOC for dash in Leaf. fixed val.
+    bytes[5] = 0x00;
+    bytes[6] = counter_1db;
+
+
+
+    // Extra CRC in byte 7
+    nissan_crc(bytes, 0x85);
+
+
+    counter_1db++;
+    if(counter_1db >= 4) counter_1db = 0;
+
+    can->Send(0x1DB, (uint32_t*)bytes, 8);
+
+    /////////////////////////////////////////////////////////////////////////////////////////////////
+    // CAN Message 0x50B
+
+    // Statistics from 2016 capture:
+    //     10 00000000000000
+    //     21 000002c0000000
+    //    122 000000c0000000
+    //    513 000006c0000000
+
+    // Let's just send the most common one all the time
+    // FIXME: This is a very sloppy implementation. Thanks. I try:)
+    bytes[0] = 0x00;
+    bytes[1] = 0x00;
+    bytes[2] = 0x06;
+    bytes[3] = 0xc0;
+    bytes[4] = 0x00;
+    bytes[5] = 0x00;
+    bytes[6] = 0x00;
+
+    //possible problem here as 0x50B is DLC 7....
+    can->Send(0x50B, (uint32_t*)bytes, 7);
+
+
+    /////////////////////////////////////////////////////////////////////////////////////////////////
+    // CAN Message 0x1DC:
+
+    // 0x1dc from lbc. Contains chg power lims and disch power lims.
+    // Disch power lim in byte 0 and byte 1 bits 6-7. Just set to max for now.
+    // Max charging power in bits 13-20. 10 bit unsigned scale 0.25.Byte 1 limit in kw.
+    bytes[0]=0x6E;
+    bytes[1]=0x0A;
+    bytes[2]=0x05;
+    bytes[3]=0xD5;
+    bytes[4]=0x00;//may not need pairing code crap here...and we don't:)
+    bytes[5]=0x00;
+    bytes[6]=counter_1dc;
+    // Extra CRC in byte 7
+    nissan_crc(bytes, 0x85);
+
+    counter_1dc++;
+    if (counter_1dc >= 4)
+        counter_1dc = 0;
+
+    can->Send(0x1DC, (uint32_t*)bytes, 8);
+
+    /////////////////////////////////////////////////////////////////////////////////////////////////
+    // CAN Message 0x1F2: Charge Power and DC/DC Converter Control
+
+    // convert power setpoint to PDM format:
+    //    0x70 = 3 amps ish
+    //    0x6a = 1.4A
+    //    0x66 = 0.5A
+    //    0x65 = 0.3A
+    //    0x64 = no chg
+    //    so 0x64=100. 0xA0=160. so 60 decimal steps. 1 step=100W???
+    OBCpwrSP = (Param::GetInt(Param::Pwrspnt) / 100) + 0x64;
+
+    // get actual voltage and voltage setpoints
+    Vbatt = Param::GetInt(Param::udc);
+    VbattSP = Param::GetInt(Param::Voltspnt);
+
+    if (opmode == MOD_CHARGE && Param::GetInt(Param::Chgctrl) == ChargeControl::Enable)
+    {
+        // clamp min and max values
+        if (OBCpwrSP > 0xA0)
+            OBCpwrSP = 0xA0;
+        else if (OBCpwrSP < 0x64)
+            OBCpwrSP = 0x64;
+
+        // if measured vbatt is less than setpoint got to max power from web ui
+        if (Vbatt < VbattSP)
+            OBCpwr = OBCpwrSP;
+
+        // decrement charger power if volt setpoint is reached
+        if (Vbatt >= VbattSP)
+            OBCpwr--;
+    }
+    else
+    {
+        // set power to 0 if charge control is set to off or not in charge mode
+        OBCpwr = 0x64;
+    }
+
+
+    // Commanded chg power in byte 1 and byte 0 bits 0-1. 10 bit number.
+    // byte 1=0x64 and byte 0=0x00 at 0 power.
+    // 0x00 chg 0ff dcdc on.
+    bytes[0] = 0x30;  // msg is muxed but pdm doesn't seem to care.
+    bytes[1] = OBCpwr;
+    bytes[2] = 0x20;
+    bytes[3] = 0xAC;
+    bytes[4] = 0x00;
+    bytes[5] = 0x3C;
+    bytes[6] = counter_1f2;
+    bytes[7] = 0x8F;  //may not need checksum here?
+
+    counter_1f2++;
+    if (counter_1f2 >= 4)
+    {
+        counter_1f2 = 0;
+    }
+
+    can->Send(0x1F2, (uint32_t*)bytes, 8);
 }
 
 void LeafINV::Task100Ms()
 {
 
-   // MSGS for charging with pdm
-   uint8_t bytes[8];
+    // MSGS for charging with pdm
+    uint8_t bytes[8];
 
-   /////////////////////////////////////////////////////////////////////////////////////////////////
-   // CAN Message 0x55B:
+    /////////////////////////////////////////////////////////////////////////////////////////////////
+    // CAN Message 0x55B:
 
-   bytes[0] = 0xA4;
-   bytes[1] = 0x40;
-   bytes[2] = 0xAA;
-   bytes[3] = 0x00;
-   bytes[4] = 0xDF;
-   bytes[5] = 0xC0;
-   bytes[6] = ((0x1 << 4) | (counter_55b));
-   // Extra CRC in byte 7
-   nissan_crc(bytes, 0x85);
+    bytes[0] = 0xA4;
+    bytes[1] = 0x40;
+    bytes[2] = 0xAA;
+    bytes[3] = 0x00;
+    bytes[4] = 0xDF;
+    bytes[5] = 0xC0;
+    bytes[6] = ((0x1 << 4) | (counter_55b));
+    // Extra CRC in byte 7
+    nissan_crc(bytes, 0x85);
 
-   counter_55b++;
-   if(counter_55b >= 4) counter_55b = 0;
+    counter_55b++;
+    if(counter_55b >= 4) counter_55b = 0;
 
-   can->Send(0x55b, (uint32_t*)bytes, 8);
+    can->Send(0x55b, (uint32_t*)bytes, 8);
 
-   /////////////////////////////////////////////////////////////////////////////////////////////////
-   // CAN Message 0x59E:
+    /////////////////////////////////////////////////////////////////////////////////////////////////
+    // CAN Message 0x59E:
 
-   bytes[0] = 0x00;//Static msg works fine here
-   bytes[1] = 0x00;//Batt capacity for chg and qc.
-   bytes[2] = 0x0c;
-   bytes[3] = 0x76;
-   bytes[4] = 0x18;
-   bytes[5] = 0x00;
-   bytes[6] = 0x00;
-   bytes[7] = 0x00;
+    bytes[0] = 0x00;//Static msg works fine here
+    bytes[1] = 0x00;//Batt capacity for chg and qc.
+    bytes[2] = 0x0c;
+    bytes[3] = 0x76;
+    bytes[4] = 0x18;
+    bytes[5] = 0x00;
+    bytes[6] = 0x00;
+    bytes[7] = 0x00;
 
-   can->Send(0x59e, (uint32_t*)bytes, 8);
+    can->Send(0x59e, (uint32_t*)bytes, 8);
 
-   /////////////////////////////////////////////////////////////////////////////////////////////////
-   // CAN Message 0x5BC:
+    /////////////////////////////////////////////////////////////////////////////////////////////////
+    // CAN Message 0x5BC:
 
-   // muxed msg with info for gids etc. Will try static for a test.
-   bytes[0] = 0x3D;//Static msg works fine here
-   bytes[1] = 0x80;
-   bytes[2] = 0xF0;
-   bytes[3] = 0x64;
-   bytes[4] = 0xB0;
-   bytes[5] = 0x01;
-   bytes[6] = 0x00;
-   bytes[7] = 0x32;
+    // muxed msg with info for gids etc. Will try static for a test.
+    bytes[0] = 0x3D;//Static msg works fine here
+    bytes[1] = 0x80;
+    bytes[2] = 0xF0;
+    bytes[3] = 0x64;
+    bytes[4] = 0xB0;
+    bytes[5] = 0x01;
+    bytes[6] = 0x00;
+    bytes[7] = 0x32;
 
-   can->Send(0x5bc, (uint32_t*)bytes, 8);
+    can->Send(0x5bc, (uint32_t*)bytes, 8);
 }
 
 
 int8_t LeafINV::fahrenheit_to_celsius(uint16_t fahrenheit)
 {
-   int16_t result = ((int16_t)fahrenheit - 32) * 5 / 9;
-   if(result < -128)
-      return -128;
-   if(result > 127)
-      return 127;
-   return result;
+    int16_t result = ((int16_t)fahrenheit - 32) * 5 / 9;
+    if(result < -128)
+        return -128;
+    if(result > 127)
+        return 127;
+    return result;
 }
 
 
 
 void LeafINV::nissan_crc(uint8_t *data, uint8_t polynomial)
 {
-   // We want to process 8 bytes with the 8th byte being zero
-   data[7] = 0;
-   uint8_t crc = 0;
-   for(int b=0; b<8; b++)
-   {
-      for(int i=7; i>=0; i--)
-      {
-         uint8_t bit = ((data[b] &(1 << i)) > 0) ? 1 : 0;
-         if(crc >= 0x80)
-            crc = (uint8_t)(((crc << 1) + bit) ^ polynomial);
-         else
-            crc = (uint8_t)((crc << 1) + bit);
-      }
-   }
-   data[7] = crc;
+    // We want to process 8 bytes with the 8th byte being zero
+    data[7] = 0;
+    uint8_t crc = 0;
+    for(int b=0; b<8; b++)
+    {
+        for(int i=7; i>=0; i--)
+        {
+            uint8_t bit = ((data[b] &(1 << i)) > 0) ? 1 : 0;
+            if(crc >= 0x80)
+                crc = (uint8_t)(((crc << 1) + bit) ^ polynomial);
+            else
+                crc = (uint8_t)((crc << 1) + bit);
+        }
+    }
+    data[7] = crc;
 }

--- a/src/stm32_vcu.cpp
+++ b/src/stm32_vcu.cpp
@@ -98,8 +98,6 @@ static Shifter shifterNone;
 static RearOutlanderInverter rearoutlanderInv;
 static LinBus* lin;
 
-uCAN_MSG xMessage;
-
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 static void Ms200Task(void)
 {
@@ -334,22 +332,6 @@ static void Ms100Task(void)
     }
 
     Param::SetInt(Param::HeatReq,IOMatrix::GetPin(IOMatrix::HEATREQ)->Get());
-
-
-    ///!!!! TOM CHEATING CODE for FT CAN!!////
-
-    xMessage.frame.idType = dSTANDARD_CAN_MSG_ID_2_0B;
-    xMessage.frame.id = 0x130;
-    xMessage.frame.dlc = 5;
-    xMessage.frame.data0 = 0x45;
-    xMessage.frame.data1 = 0x40;
-    xMessage.frame.data2 = 0x21;
-    xMessage.frame.data3 = 0x8F;
-    xMessage.frame.data4 = 0xFE;
-    xMessage.frame.data5 = 0x00;
-    xMessage.frame.data6 = 0x00;
-    xMessage.frame.data7 = 0x00;
-    CANSPI_Transmit(&xMessage);
 }
 
 static void ControlCabHeater(int opmode)
@@ -410,15 +392,9 @@ int rollingDirection = 0;
             {
                 torquePercent = -torquePercent;
             }
-
-        }
-        else if (torquePercent >= 0)
-        {
-            torquePercent *= requestedDirection;
         }
 
-
-        //torquePercent *= requestedDirection; //torque requests invert when reverse direction is selected
+        torquePercent *= requestedDirection; //torque requests invert when reverse direction is selected
 
         selectedInverter->Task10Ms();
     }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -11,38 +11,38 @@ int32_t NetWh=0;
 
 int32_t change(int32_t x, int32_t in_min, int32_t in_max, int32_t out_min, int32_t out_max)
 {
-   return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;
+    return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;
 }
 
 void PostErrorIfRunning(ERROR_MESSAGE_NUM err)
 {
-   if (Param::GetInt(Param::opmode) == MOD_RUN)
-   {
-      ErrorMessage::Post(err);
-   }
+    if (Param::GetInt(Param::opmode) == MOD_RUN)
+    {
+        ErrorMessage::Post(err);
+    }
 }
 
 void GetDigInputs(CanHardware* can)
 {
-   static bool canIoActive = false;
-   int canio = Param::GetInt(Param::canio);
+    static bool canIoActive = false;
+    int canio = Param::GetInt(Param::canio);
 
-   canIoActive |= canio != 0;
+    canIoActive |= canio != 0;
 
-   if ((rtc_get_counter_val() - can->GetLastRxTimestamp()) >= CAN_TIMEOUT && canIoActive)
-   {
-      canio = 0;
-      Param::SetInt(Param::canio, 0);
-      ErrorMessage::Post(ERR_CANTIMEOUT);
-   }
+    if ((rtc_get_counter_val() - can->GetLastRxTimestamp()) >= CAN_TIMEOUT && canIoActive)
+    {
+        canio = 0;
+        Param::SetInt(Param::canio, 0);
+        ErrorMessage::Post(ERR_CANTIMEOUT);
+    }
 
-   Param::SetInt(Param::din_cruise, ((canio & CAN_IO_CRUISE) != 0));
-   Param::SetInt(Param::din_start, DigIo::start_in.Get() | ((canio & CAN_IO_START) != 0));
-   Param::SetInt(Param::din_brake, DigIo::brake_in.Get() | ((canio & CAN_IO_BRAKE) != 0));
-   Param::SetInt(Param::din_forward, DigIo::fwd_in.Get() | ((canio & CAN_IO_FWD) != 0));
-   Param::SetInt(Param::din_reverse, DigIo::rev_in.Get() | ((canio & CAN_IO_REV) != 0));
-   Param::SetInt(Param::din_bms, (canio & CAN_IO_BMS) != 0);
-   Param::SetInt(Param::din_12Vgp, DigIo::gp_12Vin.Get());
+    Param::SetInt(Param::din_cruise, ((canio & CAN_IO_CRUISE) != 0));
+    Param::SetInt(Param::din_start, DigIo::start_in.Get() | ((canio & CAN_IO_START) != 0));
+    Param::SetInt(Param::din_brake, DigIo::brake_in.Get() | ((canio & CAN_IO_BRAKE) != 0));
+    Param::SetInt(Param::din_forward, DigIo::fwd_in.Get() | ((canio & CAN_IO_FWD) != 0));
+    Param::SetInt(Param::din_reverse, DigIo::rev_in.Get() | ((canio & CAN_IO_REV) != 0));
+    Param::SetInt(Param::din_bms, (canio & CAN_IO_BMS) != 0);
+    Param::SetInt(Param::din_12Vgp, DigIo::gp_12Vin.Get());
 }
 
 /**
@@ -59,455 +59,455 @@ void GetDigInputs(CanHardware* can)
  */
 float GetUserThrottleCommand()
 {
-   bool brake = Param::GetBool(Param::din_brake);
-   int potmode = Param::GetInt(Param::potmode);
-   int direction = Param::GetInt(Param::dir);
+    bool brake = Param::GetBool(Param::din_brake);
+    int potmode = Param::GetInt(Param::potmode);
+    int direction = Param::GetInt(Param::dir);
 
-   int pot1val = AnaIn::throttle1.Get();
-   int pot2val = AnaIn::throttle2.Get();
-   Param::SetInt(Param::pot, pot1val);
-   Param::SetInt(Param::pot2, pot2val);
+    int pot1val = AnaIn::throttle1.Get();
+    int pot2val = AnaIn::throttle2.Get();
+    Param::SetInt(Param::pot, pot1val);
+    Param::SetInt(Param::pot2, pot2val);
 
-   bool inRange1 = Throttle::CheckAndLimitRange(&pot1val, 0);
-   bool inRange2 = Throttle::CheckAndLimitRange(&pot2val, 1);
-   int useChannel = 0; // default case: use Throttle 1
+    bool inRange1 = Throttle::CheckAndLimitRange(&pot1val, 0);
+    bool inRange2 = Throttle::CheckAndLimitRange(&pot2val, 1);
+    int useChannel = 0; // default case: use Throttle 1
 
-   // check the throttle values for plausibility
-   if (potmode == POTMODE_SINGLECHANNEL)
-   {
-      if(!inRange1)
-      {
-         //DigIo::err_out.Set();
-         utils::PostErrorIfRunning(ERR_THROTTLE1);
-         Param::SetInt(Param::potnom, 0);
-         return 0.0;
-      }
+    // check the throttle values for plausibility
+    if (potmode == POTMODE_SINGLECHANNEL)
+    {
+        if(!inRange1)
+        {
+            //DigIo::err_out.Set();
+            utils::PostErrorIfRunning(ERR_THROTTLE1);
+            Param::SetInt(Param::potnom, 0);
+            return 0.0;
+        }
 
-      useChannel = 0;
-   }
-   else if(potmode == POTMODE_DUALCHANNEL)
-   {
-      // when there's something wrong with the dual throttle values,
-      // we try to make the best of it and use the valid one
-      if(inRange1 && inRange2)
-      {
-         // These are only temporary values, because they can change
-         // if the "limp mode" is activated.
-         float pot1nomTmp = Throttle::NormalizeThrottle(pot1val, 0);
-         float pot2nomTmp = Throttle::NormalizeThrottle(pot2val, 1);
+        useChannel = 0;
+    }
+    else if(potmode == POTMODE_DUALCHANNEL)
+    {
+        // when there's something wrong with the dual throttle values,
+        // we try to make the best of it and use the valid one
+        if(inRange1 && inRange2)
+        {
+            // These are only temporary values, because they can change
+            // if the "limp mode" is activated.
+            float pot1nomTmp = Throttle::NormalizeThrottle(pot1val, 0);
+            float pot2nomTmp = Throttle::NormalizeThrottle(pot2val, 1);
 
-         if(ABS(pot2nomTmp - pot1nomTmp) > 10.0f)
-         {
-            utils::PostErrorIfRunning(ERR_THROTTLE12DIFF);
-
-            // simple implementation of a limp mode: select the lower of
-            // the two throttle inputs and limiting the throttle value
-            // to 50%
-            if(pot1nomTmp < pot2nomTmp)
+            if(ABS(pot2nomTmp - pot1nomTmp) > 10.0f)
             {
-               if(pot1nomTmp > 50.0f)
-                  pot1val = Throttle::potmax[0] / 2;
+                utils::PostErrorIfRunning(ERR_THROTTLE12DIFF);
 
-               useChannel = 0;
+                // simple implementation of a limp mode: select the lower of
+                // the two throttle inputs and limiting the throttle value
+                // to 50%
+                if(pot1nomTmp < pot2nomTmp)
+                {
+                    if(pot1nomTmp > 50.0f)
+                        pot1val = Throttle::potmax[0] / 2;
+
+                    useChannel = 0;
+                }
+                else
+                {
+                    if(pot2nomTmp > 50.0f)
+                        pot2val = Throttle::potmax[1] / 2;
+
+                    useChannel = 1;
+                }
             }
-            else
-            {
-               if(pot2nomTmp > 50.0f)
-                  pot2val = Throttle::potmax[1] / 2;
+        }
+        else if(inRange1 && !inRange2)
+        {
+            utils::PostErrorIfRunning(ERR_THROTTLE2);
 
-               useChannel = 1;
-            }
-         }
-      }
-      else if(inRange1 && !inRange2)
-      {
-         utils::PostErrorIfRunning(ERR_THROTTLE2);
+            useChannel = 0; // use throttle channel 1
+        }
+        else if(!inRange1 && inRange2)
+        {
+            utils::PostErrorIfRunning(ERR_THROTTLE1);
 
-         useChannel = 0; // use throttle channel 1
-      }
-      else if(!inRange1 && inRange2)
-      {
-         utils::PostErrorIfRunning(ERR_THROTTLE1);
+            useChannel = 1; // use throttle channel 2
+        }
+        else // !inRange1 && !inRange2
+        {
+            utils::PostErrorIfRunning(ERR_THROTTLE12);
 
-         useChannel = 1; // use throttle channel 2
-      }
-      else // !inRange1 && !inRange2
-      {
-         utils::PostErrorIfRunning(ERR_THROTTLE12);
+            return 0.0;
+        }
+    }
+    else // (yet) unknown throttle mode
+    {
+        utils::PostErrorIfRunning(ERR_THROTTLEMODE);
 
-         return 0.0;
-      }
-   }
-   else // (yet) unknown throttle mode
-   {
-      utils::PostErrorIfRunning(ERR_THROTTLEMODE);
+        return 0.0;
+    }
 
-      return 0.0;
-   }
+    // don't return a throttle value if we are in neutral
+    // TODO: the direction for FORWARD/NEUTRAL/REVERSE needs an enum in param_prj.h as well
+    if (direction == 0)
+        return 0.0;
 
-   // don't return a throttle value if we are in neutral
-   // TODO: the direction for FORWARD/NEUTRAL/REVERSE needs an enum in param_prj.h as well
-   if (direction == 0)
-      return 0.0;
+    if (direction == 2)//No throttle val if in PARK also.
+        return 0.0;
 
-   if (direction == 2)//No throttle val if in PARK also.
-      return 0.0;
-
-   // calculate the throttle depending on the channel we've decided to use
-   if (useChannel == 0)
-      return Throttle::CalcThrottle(pot1val, 0, brake);
-   else if(useChannel == 1)
-      return Throttle::CalcThrottle(pot2val, 1, brake);
-   else
-      return 0.0;
+    // calculate the throttle depending on the channel we've decided to use
+    if (useChannel == 0)
+        return Throttle::CalcThrottle(pot1val, 0, brake);
+    else if(useChannel == 1)
+        return Throttle::CalcThrottle(pot2val, 1, brake);
+    else
+        return 0.0;
 }
 
 
 void SelectDirection(Vehicle* vehicle, Shifter* shifter)
 {
-   Vehicle::gear gear;
-   Shifter::Sgear gearS;
-   int8_t selectedDir = Param::GetInt(Param::dir);
-   int8_t userDirSelection = 0;
-   int8_t dirSign = (Param::GetInt(Param::dirmode) & DIR_REVERSED) ? -1 : 1;
+    Vehicle::gear gear;
+    Shifter::Sgear gearS;
+    int8_t selectedDir = Param::GetInt(Param::dir);
+    int8_t userDirSelection = 0;
+    int8_t dirSign = (Param::GetInt(Param::dirmode) & DIR_REVERSED) ? -1 : 1;
 
-   if (vehicle->GetGear(gear))
-   {
-      // if the vehicle class supplies gear selection then use that
-      switch (gear)
-      {
-      case Vehicle::PARK:
-         selectedDir = 2; // Park
-         break;
-      case Vehicle::REVERSE:
-         selectedDir = -1; // Reverse
-         break;
-      case Vehicle::NEUTRAL:
-         selectedDir = 0; // Neutral
-         break;
-      case Vehicle::DRIVE:
-         selectedDir = 1; // Drive
-         break;
-      }
-   }
-   else if (shifter->GetGear(gearS))
-   {
-      // if the shifter class supplies gear selection then use that
-      switch (gearS)
-      {
-      case Shifter::PARK:
-         selectedDir = 2; // Park
-         break;
-      case Shifter::REVERSE:
-         selectedDir = -1; // Reverse
-         break;
-      case Shifter::NEUTRAL:
-         selectedDir = 0; // Neutral
-         break;
-      case Shifter::DRIVE:
-         selectedDir = 1; // Drive
-         break;
-      }
-   }
+    if (vehicle->GetGear(gear))
+    {
+        // if the vehicle class supplies gear selection then use that
+        switch (gear)
+        {
+        case Vehicle::PARK:
+            selectedDir = 2; // Park
+            break;
+        case Vehicle::REVERSE:
+            selectedDir = -1; // Reverse
+            break;
+        case Vehicle::NEUTRAL:
+            selectedDir = 0; // Neutral
+            break;
+        case Vehicle::DRIVE:
+            selectedDir = 1; // Drive
+            break;
+        }
+    }
+    else if (shifter->GetGear(gearS))
+    {
+        // if the shifter class supplies gear selection then use that
+        switch (gearS)
+        {
+        case Shifter::PARK:
+            selectedDir = 2; // Park
+            break;
+        case Shifter::REVERSE:
+            selectedDir = -1; // Reverse
+            break;
+        case Shifter::NEUTRAL:
+            selectedDir = 0; // Neutral
+            break;
+        case Shifter::DRIVE:
+            selectedDir = 1; // Drive
+            break;
+        }
+    }
 
-   else
-   {
-      // otherwise use the traditional inputs
-      if (Param::GetInt(Param::dirmode) == DIR_DEFAULTFORWARD)
-      {
-         if (Param::GetBool(Param::din_forward) && Param::GetBool(Param::din_reverse))
-            selectedDir = 0;
-         else if (Param::GetBool(Param::din_reverse))
-            userDirSelection = -1;
-         else
-            userDirSelection = 1;
-      }
-      else if ((Param::GetInt(Param::dirmode) & 1) == DIR_BUTTON)
-      {
-         /* if forward AND reverse selected, force neutral, because it's charge mode */
-         if (Param::GetBool(Param::din_forward) && Param::GetBool(Param::din_reverse))
-            selectedDir = 0;
-         else if (Param::GetBool(Param::din_forward))
-            userDirSelection = 1 * dirSign;
-         else if (Param::GetBool(Param::din_reverse))
-            userDirSelection = -1 * dirSign;
-         else
-            userDirSelection = selectedDir;
-      }
-      else
-      {
-         /* neither forward nor reverse or both forward and reverse -> neutral */
-         if (!(Param::GetBool(Param::din_forward) ^ Param::GetBool(Param::din_reverse)))
-            selectedDir = 0;
-         else if (Param::GetBool(Param::din_forward))
-            userDirSelection = 1 * dirSign;
-         else if (Param::GetBool(Param::din_reverse))
-            userDirSelection = -1 * dirSign;
-      }
+    else
+    {
+        // otherwise use the traditional inputs
+        if (Param::GetInt(Param::dirmode) == DIR_DEFAULTFORWARD)
+        {
+            if (Param::GetBool(Param::din_forward) && Param::GetBool(Param::din_reverse))
+                selectedDir = 0;
+            else if (Param::GetBool(Param::din_reverse))
+                userDirSelection = -1;
+            else
+                userDirSelection = 1;
+        }
+        else if ((Param::GetInt(Param::dirmode) & 1) == DIR_BUTTON)
+        {
+            /* if forward AND reverse selected, force neutral, because it's charge mode */
+            if (Param::GetBool(Param::din_forward) && Param::GetBool(Param::din_reverse))
+                selectedDir = 0;
+            else if (Param::GetBool(Param::din_forward))
+                userDirSelection = 1 * dirSign;
+            else if (Param::GetBool(Param::din_reverse))
+                userDirSelection = -1 * dirSign;
+            else
+                userDirSelection = selectedDir;
+        }
+        else
+        {
+            /* neither forward nor reverse or both forward and reverse -> neutral */
+            if (!(Param::GetBool(Param::din_forward) ^ Param::GetBool(Param::din_reverse)))
+                selectedDir = 0;
+            else if (Param::GetBool(Param::din_forward))
+                userDirSelection = 1 * dirSign;
+            else if (Param::GetBool(Param::din_reverse))
+                userDirSelection = -1 * dirSign;
+        }
 
-      /* Only change direction when below certain motor speed */
+        /* Only change direction when below certain motor speed */
 //   if ((int)Encoder::GetSpeed() < Param::GetInt(Param::dirchrpm))
-      selectedDir = userDirSelection;
+        selectedDir = userDirSelection;
 
-      /* Current direction doesn't match selected direction -> neutral */
-      if (selectedDir != userDirSelection)
-         selectedDir = 0;
-   }
+        /* Current direction doesn't match selected direction -> neutral */
+        if (selectedDir != userDirSelection)
+            selectedDir = 0;
+    }
 
-   Param::SetInt(Param::dir, selectedDir);
+    Param::SetInt(Param::dir, selectedDir);
 }
 
 float ProcessUdc(int motorSpeed)
 {
 
-if (Param::GetInt(Param::Type) == 0)
-{
-   float udc = ((float)ISA::Voltage)/1000;//get voltage from isa sensor and post to parameter database
-   Param::SetFloat(Param::udc, udc);
-   float udc2 = ((float)ISA::Voltage2)/1000;//get voltage from isa sensor and post to parameter database
-   Param::SetFloat(Param::udc2, udc2);
-   float udc3 = ((float)ISA::Voltage3)/1000;//get voltage from isa sensor and post to parameter database
-   Param::SetFloat(Param::udc3, udc3);
-   float idc = ((float)ISA::Amperes)/1000;//get current from isa sensor and post to parameter database
-   Param::SetFloat(Param::idc, idc);
-   float kw = ((float)ISA::KW)/1000;//get power from isa sensor and post to parameter database
-   Param::SetFloat(Param::power, kw);
-   float kwh = ((float)ISA::KWh)/1000;//get kwh from isa sensor and post to parameter database
-   Param::SetFloat(Param::KWh, kwh);
-   float Amph = ((float)ISA::Ah)/3600;//get Ah from isa sensor and post to parameter database
-   Param::SetFloat(Param::AMPh, Amph);
-   float deltaVolts1 = (udc2 / 2) - udc3;
-   float deltaVolts2 = (udc2 + udc3) - udc;
-   Param::SetFloat(Param::deltaV, MAX(deltaVolts1, deltaVolts2));
-}
+    if (Param::GetInt(Param::Type) == 0)
+    {
+        float udc = ((float)ISA::Voltage)/1000;//get voltage from isa sensor and post to parameter database
+        Param::SetFloat(Param::udc, udc);
+        float udc2 = ((float)ISA::Voltage2)/1000;//get voltage from isa sensor and post to parameter database
+        Param::SetFloat(Param::udc2, udc2);
+        float udc3 = ((float)ISA::Voltage3)/1000;//get voltage from isa sensor and post to parameter database
+        Param::SetFloat(Param::udc3, udc3);
+        float idc = ((float)ISA::Amperes)/1000;//get current from isa sensor and post to parameter database
+        Param::SetFloat(Param::idc, idc);
+        float kw = ((float)ISA::KW)/1000;//get power from isa sensor and post to parameter database
+        Param::SetFloat(Param::power, kw);
+        float kwh = ((float)ISA::KWh)/1000;//get kwh from isa sensor and post to parameter database
+        Param::SetFloat(Param::KWh, kwh);
+        float Amph = ((float)ISA::Ah)/3600;//get Ah from isa sensor and post to parameter database
+        Param::SetFloat(Param::AMPh, Amph);
+        float deltaVolts1 = (udc2 / 2) - udc3;
+        float deltaVolts2 = (udc2 + udc3) - udc;
+        Param::SetFloat(Param::deltaV, MAX(deltaVolts1, deltaVolts2));
+    }
 
-else if (Param::GetInt(Param::Type) == 1)
+    else if (Param::GetInt(Param::Type) == 1)
 
-{
-   float udc = ((float)SBOX::Voltage2)/1000;//get output voltage from sbox sensor and post to parameter database
-   Param::SetFloat(Param::udc, udc);
-   float udc2 = ((float)SBOX::Voltage)/1000;//get battery voltage from sbox sensor and post to parameter database
-   Param::SetFloat(Param::udc2, udc2);
-   float udc3 = 0;//((float)ISA::Voltage3)/1000;//get voltage from isa sensor and post to parameter database
-   Param::SetFloat(Param::udc3, udc3);
-   float idc = ((float)SBOX::Amperes)/1000;//get current from sbox sensor and post to parameter database
-   Param::SetFloat(Param::idc, idc);
-}
+    {
+        float udc = ((float)SBOX::Voltage2)/1000;//get output voltage from sbox sensor and post to parameter database
+        Param::SetFloat(Param::udc, udc);
+        float udc2 = ((float)SBOX::Voltage)/1000;//get battery voltage from sbox sensor and post to parameter database
+        Param::SetFloat(Param::udc2, udc2);
+        float udc3 = 0;//((float)ISA::Voltage3)/1000;//get voltage from isa sensor and post to parameter database
+        Param::SetFloat(Param::udc3, udc3);
+        float idc = ((float)SBOX::Amperes)/1000;//get current from sbox sensor and post to parameter database
+        Param::SetFloat(Param::idc, idc);
+    }
 
-else if (Param::GetInt(Param::Type) == 2)
+    else if (Param::GetInt(Param::Type) == 2)
 
-{
-   float udc = ((float)VWBOX::Voltage)*0.5;//get output voltage from sbox sensor and post to parameter database
-   Param::SetFloat(Param::udc, udc);
-   float udc2 = ((float)VWBOX::Voltage2)*0.0625;//get battery voltage from sbox sensor and post to parameter database
-   Param::SetFloat(Param::udc2, udc2);
-   float udc3 = 0;//((float)ISA::Voltage3)/1000;//get voltage from isa sensor and post to parameter database
-   Param::SetFloat(Param::udc3, udc3);
-   float idc = ((float)VWBOX::Amperes)*0.1;//get current from sbox sensor and post to parameter database
-   Param::SetFloat(Param::idc, idc);
-}
-   float udclim = Param::GetFloat(Param::udclim);
-   float udc = Param::GetFloat(Param::udc);
-   // Currently unused parameters:
-   // s32fp udcmin = Param::Get(Param::udcmin);
-   // s32fp udcmax = Param::Get(Param::udcmax);
+    {
+        float udc = ((float)VWBOX::Voltage)*0.5;//get output voltage from sbox sensor and post to parameter database
+        Param::SetFloat(Param::udc, udc);
+        float udc2 = ((float)VWBOX::Voltage2)*0.0625;//get battery voltage from sbox sensor and post to parameter database
+        Param::SetFloat(Param::udc2, udc2);
+        float udc3 = 0;//((float)ISA::Voltage3)/1000;//get voltage from isa sensor and post to parameter database
+        Param::SetFloat(Param::udc3, udc3);
+        float idc = ((float)VWBOX::Amperes)*0.1;//get current from sbox sensor and post to parameter database
+        Param::SetFloat(Param::idc, idc);
+    }
+    float udclim = Param::GetFloat(Param::udclim);
+    float udc = Param::GetFloat(Param::udc);
+    // Currently unused parameters:
+    // s32fp udcmin = Param::Get(Param::udcmin);
+    // s32fp udcmax = Param::Get(Param::udcmax);
 
 
-   //Calculate "12V" supply voltage from voltage divider on mprot pin
-   //1.2/(4.7+1.2)/3.33*4095 = 250 -> make it a bit less for pin losses etc
-   //HW_REV1 had 3.9k resistors
-   int uauxGain = 210;
-   Param::SetFloat(Param::uaux, ((float)AnaIn::uaux.Get()) / uauxGain);
+    //Calculate "12V" supply voltage from voltage divider on mprot pin
+    //1.2/(4.7+1.2)/3.33*4095 = 250 -> make it a bit less for pin losses etc
+    //HW_REV1 had 3.9k resistors
+    int uauxGain = 210;
+    Param::SetFloat(Param::uaux, ((float)AnaIn::uaux.Get()) / uauxGain);
 
-   if (udc > udclim)
-   {
-      if (ABS(motorSpeed) < 50) //If motor is stationary, over voltage comes from outside
-      {
-         DigIo::dcsw_out.Clear();  //In this case, open DC switch
-         DigIo::prec_out.Clear();  //and
+    if (udc > udclim)
+    {
+        if (ABS(motorSpeed) < 50) //If motor is stationary, over voltage comes from outside
+        {
+            DigIo::dcsw_out.Clear();  //In this case, open DC switch
+            DigIo::prec_out.Clear();  //and
 
-      }
+        }
 
-      Param::SetInt(Param::opmode, MOD_OFF);
-      ErrorMessage::Post(ERR_OVERVOLTAGE);
-   }
-/*
-   if(opmode == MOD_PRECHARGE)
-   {
-      if (udc < (udcsw) && rtc_get_counter_val() > (oldTime + PRECHARGE_TIMEOUT) && DigIo::prec_out.Get())
-      {
-         DigIo::prec_out.Clear();
-         ErrorMessage::Post(ERR_PRECHARGE);
-         Param::SetInt(Param::opmode, MOD_PCHFAIL);
-      }
-   }
-*/
-   return udc;
+        Param::SetInt(Param::opmode, MOD_OFF);
+        ErrorMessage::Post(ERR_OVERVOLTAGE);
+    }
+    /*
+       if(opmode == MOD_PRECHARGE)
+       {
+          if (udc < (udcsw) && rtc_get_counter_val() > (oldTime + PRECHARGE_TIMEOUT) && DigIo::prec_out.Get())
+          {
+             DigIo::prec_out.Clear();
+             ErrorMessage::Post(ERR_PRECHARGE);
+             Param::SetInt(Param::opmode, MOD_PCHFAIL);
+          }
+       }
+    */
+    return udc;
 }
 
 float ProcessThrottle(int speed)
 {
-   float finalSpnt;
+    float finalSpnt;
 
-   if (speed < Param::GetInt(Param::throtramprpm))
-      Throttle::throttleRamp = Param::Get(Param::throtramp);
-   else
-      Throttle::throttleRamp = Param::GetAttrib(Param::throtramp)->max;
+    if (speed < Param::GetInt(Param::throtramprpm))
+        Throttle::throttleRamp = Param::Get(Param::throtramp);
+    else
+        Throttle::throttleRamp = Param::GetAttrib(Param::throtramp)->max;
 
-   finalSpnt = utils::GetUserThrottleCommand();
+    finalSpnt = utils::GetUserThrottleCommand();
 
-   if (Param::Get(Param::cruisespeed) > 0)
-   {
-      Throttle::brkcruise = 0;
-      Throttle::speedflt = 5;
-      Throttle::speedkp = 0.25f;
-      Throttle::cruiseSpeed = Param::GetInt(Param::cruisespeed);
-      float cruiseThrottle = Throttle::CalcCruiseSpeed(Param::GetInt(Param::speed));
-      finalSpnt = MAX(cruiseThrottle, finalSpnt);
-   }
+    if (Param::Get(Param::cruisespeed) > 0)
+    {
+        Throttle::brkcruise = 0;
+        Throttle::speedflt = 5;
+        Throttle::speedkp = 0.25f;
+        Throttle::cruiseSpeed = Param::GetInt(Param::cruisespeed);
+        float cruiseThrottle = Throttle::CalcCruiseSpeed(ABS(Param::GetInt(Param::speed)));
+                               finalSpnt = MAX(cruiseThrottle, finalSpnt);
+    }
 
-   finalSpnt = Throttle::RampThrottle(finalSpnt);
+                           finalSpnt = Throttle::RampThrottle(finalSpnt);
 
 
-   Throttle::UdcLimitCommand(finalSpnt,Param::GetFloat(Param::udc));
-   Throttle::IdcLimitCommand(finalSpnt, ABS(Param::GetFloat(Param::idc)));
-   Throttle::SpeedLimitCommand(finalSpnt, ABS(speed));
+    Throttle::UdcLimitCommand(finalSpnt,Param::GetFloat(Param::udc));
+    Throttle::IdcLimitCommand(finalSpnt, ABS(Param::GetFloat(Param::idc)));
+    Throttle::SpeedLimitCommand(finalSpnt, ABS(speed));
 
-   if (Throttle::TemperatureDerate(Param::Get(Param::tmphs), Param::Get(Param::tmphsmax), finalSpnt))
-   {
-      ErrorMessage::Post(ERR_TMPHSMAX);
-   }
+    if (Throttle::TemperatureDerate(Param::Get(Param::tmphs), Param::Get(Param::tmphsmax), finalSpnt))
+    {
+        ErrorMessage::Post(ERR_TMPHSMAX);
+    }
 
-   if (Throttle::TemperatureDerate(Param::Get(Param::tmpm), Param::Get(Param::tmpmmax), finalSpnt))
-   {
-      ErrorMessage::Post(ERR_TMPMMAX);
-   }
+    if (Throttle::TemperatureDerate(Param::Get(Param::tmpm), Param::Get(Param::tmpmmax), finalSpnt))
+    {
+        ErrorMessage::Post(ERR_TMPMMAX);
+    }
 
-   // make sure the torque percentage is NEVER out of range
-   if (finalSpnt < -100.0f)
-      finalSpnt = -100.0f;
-   else if (finalSpnt > 100.0f)
-      finalSpnt = 100.0f;
+    // make sure the torque percentage is NEVER out of range
+    if (finalSpnt < -100.0f)
+        finalSpnt = -100.0f;
+    else if (finalSpnt > 100.0f)
+        finalSpnt = 100.0f;
 
-   Param::SetFloat(Param::potnom, finalSpnt);
+    Param::SetFloat(Param::potnom, finalSpnt);
 
-   return finalSpnt;
+    return finalSpnt;
 }
 
 
 void displayThrottle()
 {
-   uint16_t potdisp = AnaIn::throttle1.Get();
-   uint16_t pot2disp = AnaIn::throttle2.Get();
-   Param::SetInt(Param::pot, potdisp);
-   Param::SetInt(Param::pot2, pot2disp);
+    uint16_t potdisp = AnaIn::throttle1.Get();
+    uint16_t pot2disp = AnaIn::throttle2.Get();
+    Param::SetInt(Param::pot, potdisp);
+    Param::SetInt(Param::pot2, pot2disp);
 }
 
 
 void CalcSOC()
 {
-   float Capacity_Parm = Param::GetFloat(Param::BattCap);
-   float kwh_Used = ABS(Param::GetFloat(Param::KWh));
+    float Capacity_Parm = Param::GetFloat(Param::BattCap);
+    float kwh_Used = ABS(Param::GetFloat(Param::KWh));
 
-   SOCVal = 100.0f - 100.0f * kwh_Used / Capacity_Parm;
+    SOCVal = 100.0f - 100.0f * kwh_Used / Capacity_Parm;
 
-   if(SOCVal > 100) SOCVal = 100;
-   Param::SetFloat(Param::SOC,SOCVal);
+    if(SOCVal > 100) SOCVal = 100;
+    Param::SetFloat(Param::SOC,SOCVal);
 }
 
 void ProcessCruiseControlButtons()
 {
-   static bool transition = false;
-   static int cruiseTarget = 0;
-   int cruisespeed = Param::GetInt(Param::cruisespeed);
-   int cruisestt = Param::GetInt(Param::cruisestt);
+    static bool transition = false;
+    static int cruiseTarget = 0;
+    int cruisespeed = Param::GetInt(Param::cruisespeed);
+    int cruisestt = Param::GetInt(Param::cruisestt);
 
-   if (transition)
-   {
-      if ((cruisestt & (Vehicle::CC_RESUME | Vehicle::CC_SET)) == 0)
-      {
-         transition = false;
-      }
-      return;
-   }
-   else
-   {
-      if (cruisestt & (Vehicle::CC_RESUME | Vehicle::CC_SET))
-      {
-         transition = true;
-      }
-   }
+    if (transition)
+    {
+        if ((cruisestt & (Vehicle::CC_RESUME | Vehicle::CC_SET)) == 0)
+        {
+            transition = false;
+        }
+        return;
+    }
+    else
+    {
+        if (cruisestt & (Vehicle::CC_RESUME | Vehicle::CC_SET))
+        {
+            transition = true;
+        }
+    }
 
-   if (cruisestt & Vehicle::CC_ON && Param::GetInt(Param::opmode) == MOD_RUN)
-   {
-      if (cruisespeed <= 0)
-      {
-         int currentSpeed = Param::GetInt(Param::speed);
+    if (cruisestt & Vehicle::CC_ON && Param::GetInt(Param::opmode) == MOD_RUN)
+    {
+        if (cruisespeed <= 0)
+        {
+            int currentSpeed = Param::GetInt(Param::speed);
 
-         if (cruisestt & Vehicle::CC_SET && currentSpeed > 500) //Start cruise control at current speed
-         {
-            cruiseTarget = currentSpeed;
-            cruisespeed = cruiseTarget;
-         }
-         else if (cruisestt & Vehicle::CC_RESUME && cruiseTarget > 0) //resume via ramp
-         {
-            cruisespeed = currentSpeed;
-         }
-      }
-      else
-      {
-         if (cruisestt & Vehicle::CC_CANCEL || Param::GetBool(Param::din_brake))
-         {
-            cruisespeed = 0;
-         }
-         else if (cruisestt & Vehicle::CC_RESUME)
-         {
-            cruiseTarget += Param::GetInt(Param::cruisestep);
-         }
-         else if (cruisestt & Vehicle::CC_SET)
-         {
-            cruiseTarget -= Param::GetInt(Param::cruisestep);
-         }
-      }
-   }
-   else
-   {
-      cruisespeed = 0;
-      cruiseTarget = 0;
+            if (cruisestt & Vehicle::CC_SET && currentSpeed > 500) //Start cruise control at current speed
+            {
+                cruiseTarget = currentSpeed;
+                cruisespeed = cruiseTarget;
+            }
+            else if (cruisestt & Vehicle::CC_RESUME && cruiseTarget > 0) //resume via ramp
+            {
+                cruisespeed = currentSpeed;
+            }
+        }
+        else
+        {
+            if (cruisestt & Vehicle::CC_CANCEL || Param::GetBool(Param::din_brake))
+            {
+                cruisespeed = 0;
+            }
+            else if (cruisestt & Vehicle::CC_RESUME)
+            {
+                cruiseTarget += Param::GetInt(Param::cruisestep);
+            }
+            else if (cruisestt & Vehicle::CC_SET)
+            {
+                cruiseTarget -= Param::GetInt(Param::cruisestep);
+            }
+        }
+    }
+    else
+    {
+        cruisespeed = 0;
+        cruiseTarget = 0;
 
-      //When pressing cruise control buttons while cruise control is off
-      //Use them to adjust regen level
-      int regenLevel = Param::GetInt(Param::regenlevel);
-      if (cruisestt & Vehicle::CC_RESUME)
-      {
-         regenLevel++;
-         regenLevel = MIN(3, regenLevel);
-      }
-      else if (cruisestt & Vehicle::CC_SET)
-      {
-         regenLevel--;
-         regenLevel = MAX(0, regenLevel);
-      }
+        //When pressing cruise control buttons while cruise control is off
+        //Use them to adjust regen level
+        int regenLevel = Param::GetInt(Param::regenlevel);
+        if (cruisestt & Vehicle::CC_RESUME)
+        {
+            regenLevel++;
+            regenLevel = MIN(3, regenLevel);
+        }
+        else if (cruisestt & Vehicle::CC_SET)
+        {
+            regenLevel--;
+            regenLevel = MAX(0, regenLevel);
+        }
 
-      Param::SetInt(Param::regenlevel, regenLevel);
-   }
+        Param::SetInt(Param::regenlevel, regenLevel);
+    }
 
-   if (cruisespeed <= 0)
-   {
-      Param::SetInt(Param::cruisespeed, 0);
-   }
-   else if (cruisespeed < cruiseTarget)
-   {
-      Param::SetInt(Param::cruisespeed, RAMPUP(cruisespeed, cruiseTarget, Param::GetInt(Param::cruiseramp)));
-   }
-   else if (cruisespeed > cruiseTarget)
-   {
-      Param::SetInt(Param::cruisespeed, RAMPDOWN(cruisespeed, cruiseTarget, Param::GetInt(Param::cruiseramp)));
-   }
-   else
-   {
-      Param::SetInt(Param::cruisespeed, cruisespeed);
-   }
+    if (cruisespeed <= 0)
+    {
+        Param::SetInt(Param::cruisespeed, 0);
+    }
+    else if (cruisespeed < cruiseTarget)
+    {
+        Param::SetInt(Param::cruisespeed, RAMPUP(cruisespeed, cruiseTarget, Param::GetInt(Param::cruiseramp)));
+    }
+    else if (cruisespeed > cruiseTarget)
+    {
+        Param::SetInt(Param::cruisespeed, RAMPDOWN(cruisespeed, cruiseTarget, Param::GetInt(Param::cruiseramp)));
+    }
+    else
+    {
+        Param::SetInt(Param::cruisespeed, cruisespeed);
+    }
 }
 
 } // namespace utils

--- a/stm32-vcu.cbp
+++ b/stm32-vcu.cbp
@@ -92,6 +92,7 @@
 		<Unit filename="include/outlanderCharger.h" />
 		<Unit filename="include/outlanderinverter.h" />
 		<Unit filename="include/param_prj.h" />
+		<Unit filename="include/rearoutlanderinverter.h" />
 		<Unit filename="include/shifter.h" />
 		<Unit filename="include/simpbms.h" />
 		<Unit filename="include/stm32_vcu.h" />
@@ -148,6 +149,7 @@
 		<Unit filename="src/GS450H.cpp" />
 		<Unit filename="src/MCP2515.cpp" />
 		<Unit filename="src/NissanPDM.cpp" />
+		<Unit filename="src/RearOutlanderinverter.cpp" />
 		<Unit filename="src/TeslaDCDC.cpp" />
 		<Unit filename="src/VWheater.cpp" />
 		<Unit filename="src/amperacharger.cpp" />


### PR DESCRIPTION
Param:Speed has now been cleaned up in all files, making sure only the use ABS when required.
Created Param to inverter motor rotation - only really applicable to Outlander, but also implemented on Leaf.

Implemented, if pedal is steady no regen allowed but still taper the PotNom on speed base.

Clean up work in GS450h
-Checksum
-Create template for Prius, IS300h and GS450h specifics within functions

clean up work in Leaf
-Propper 15bit decoding of speed
-Added reversemotor

RearOutlander
-Added reversemotor

Param
-Added reversemotor param
      Created Param to inverter motor rotation - only really applicable to Outlander, but also implemented on Leaf.
-Added regenendrpm
     rpm under which regen is forced to 0, to remove jerkyness
-can3speed
    added 100kbps