### PR TITLE
Fix Regen ramping + 0.1 Dec Potnom created

### DIFF
--- a/include/param_prj.h
+++ b/include/param_prj.h
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#define VER 2.10.XX
+#define VER 2.11.XX
 
 
 /* Entries must be ordered as follows:

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -363,10 +363,10 @@ float ProcessThrottle(int speed)
         Throttle::speedkp = 0.25f;
         Throttle::cruiseSpeed = Param::GetInt(Param::cruisespeed);
         float cruiseThrottle = Throttle::CalcCruiseSpeed(ABS(Param::GetInt(Param::speed)));
-                               finalSpnt = MAX(cruiseThrottle, finalSpnt);
+        finalSpnt = MAX(cruiseThrottle, finalSpnt);
     }
 
-                           finalSpnt = Throttle::RampThrottle(finalSpnt);
+    finalSpnt = Throttle::RampThrottle(finalSpnt);
 
 
     Throttle::UdcLimitCommand(finalSpnt,Param::GetFloat(Param::udc));


### PR DESCRIPTION
Regen ramping up and down fixed. Was not working in the ramp in

Potnom is now forced into a decimal value with one place.0.1
Was limited due to the function change (map) being interger based instead of float.
