### PR TITLE
Reverse Motor Fix Outland Rear

### DIFF
--- a/include/param_prj.h
+++ b/include/param_prj.h
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#define VER 2.15.A
+#define VER 2.17.A
 
 
 /* Entries must be ordered as follows:

--- a/src/RearOutlanderinverter.cpp
+++ b/src/RearOutlanderinverter.cpp
@@ -58,17 +58,19 @@ void RearOutlanderInverter::DecodeCAN(int id, uint32_t data[2])
     }
 }
 
-
-
 void RearOutlanderInverter::SetTorque(float torquePercent)
 {
-    final_torque_request = ((torquePercent * 2000) / 100.0f ); //!! Moved into parameter *-1 reverses torque direction
 
-    if(Param::GetInt(Param::reversemotor) == 1)
+    if(Param::GetInt(Param::reversemotor) == 0)
     {
-        final_torque_request *= -1;//reverse torque request to flip motor rotation
+
+        final_torque_request = 10000 + (torquePercent * 20); //!! Moved into parameter *-1 reverses torque direction
     }
-    final_torque_request += 10000;
+    else
+    {
+        final_torque_request = 10000 - (torquePercent * 20);
+    }
+
     Param::SetInt(Param::torque,final_torque_request);//post processed final torque value sent to inv to web interface
 }
 

--- a/src/stm32_vcu.cpp
+++ b/src/stm32_vcu.cpp
@@ -532,8 +532,8 @@ static void Ms10Task(void)
         if(rlyDly!=0) rlyDly--;//here we are going to pause before energising precharge to prevent too many contactors pulling amps at the same time
         if(rlyDly==0)
         {
-        DigIo::dcsw_out.Set();
-        DigIo::inv_out.Set();//inverter power on
+            DigIo::dcsw_out.Set();
+            DigIo::inv_out.Set();//inverter power on
         }
         Param::SetInt(Param::opmode, MOD_RUN);
         ErrorMessage::UnpostAll();
@@ -631,8 +631,6 @@ static void UpdateVehicle()
     //This will call SetCanFilters() via the Clear Callback
     canInterface[0]->ClearUserMessages();
     canInterface[1]->ClearUserMessages();
-
-    Param::SetFloat(Param::AC_Amps, Param::Vehicle);
 }
 
 static void UpdateCharger()
@@ -878,7 +876,11 @@ void Param::Change(Param::PARAM_NUM paramNum)
 
     if(Param::GetInt(Param::reversemotor) != 0)
     {
-        if(Param::GetInt(Param::Inverter) != InvModes::Leaf_Gen1 ||Param::GetInt(Param::Inverter) != InvModes::RearOutlander)
+        if(Param::GetInt(Param::Inverter) == InvModes::RearOutlander)
+        {
+
+        }
+        else
         {
             Param::SetInt(Param::reversemotor,0);
         }

--- a/src/throttle.cpp
+++ b/src/throttle.cpp
@@ -167,7 +167,6 @@ float Throttle::CalcThrottle(int potval, int potIdx, bool brkpedal)
 
     speed = SpeedFiltered;
 
-    Param::SetFloat(Param::AC_Volts, speed);
     ///////////////////////
 
     if(dir == 0)//neutral no torque command


### PR DESCRIPTION
Clean up the serttings of reversemotor param, force zero for all except outlander rear.

Correction for unsigned torque request number when using negatives.