### PR TITLE
Fixing the 0xAA message that was causing the DSC error

### DIFF
--- a/include/param_prj.h
+++ b/include/param_prj.h
@@ -52,11 +52,11 @@
     PARAM_ENTRY(CAT_THROTTLE,  regenendrpm,"rpm",     100,      10000,  100,  126 ) \
     PARAM_ENTRY(CAT_THROTTLE,  regenmax,     "%",     -30,   0,     -10,     61 ) \
     PARAM_ENTRY(CAT_THROTTLE,  regenBrake,    "%",    -30,   0,     -10,     122 ) \
-    PARAM_ENTRY(CAT_THROTTLE,  regenramp,   "%/10ms",  0.1,    100,    100,    68 ) \
+    PARAM_ENTRY(CAT_THROTTLE,  regenramp,   "%/10ms",  0.1,    100,    1,      68 ) \
     PARAM_ENTRY(CAT_THROTTLE,  potmode,     POTMODES,  0,      1,      0,      11 ) \
     PARAM_ENTRY(CAT_THROTTLE,  dirmode,     DIRMODES,  0,      4,      1,      12 ) \
     PARAM_ENTRY(CAT_THROTTLE,  reversemotor,  ONOFF,  0,      1,      0,      127 ) \
-    PARAM_ENTRY(CAT_THROTTLE,  throtramp,   "%/10ms",  0.1,    100,    100,    13 ) \
+    PARAM_ENTRY(CAT_THROTTLE,  throtramp,   "%/10ms",  0.1,    100,    10,     13 ) \
     PARAM_ENTRY(CAT_THROTTLE,  throtramprpm,"rpm",     0,      20000,  20000,  14 ) \
     PARAM_ENTRY(CAT_THROTTLE,  revlim,      "rpm",     0,      20000,  6000,   15 ) \
     PARAM_ENTRY(CAT_THROTTLE,  bmslimhigh,  "%",       0,      100,    50,     17 ) \

--- a/src/BMW_E65.cpp
+++ b/src/BMW_E65.cpp
@@ -15,7 +15,7 @@ uint8_t A90=0xe9;//0x0A9 first counter byte
 uint8_t A91=0x00;//0x0A9 second counter byte
 uint8_t BA5=0x4d;//0x0BA first counter byte(byte 5)
 uint8_t BA6=0x80;//0x0BA second counter byte(byte 6)
-uint8_t AA1=0x0F;
+uint8_t AA1=0x0F;//0x0AA first counter byte(byte 1)
 
 void BMW_E65::SetCanInterface(CanHardware* c)
 {
@@ -156,13 +156,14 @@ void BMW_E65::Task10Ms()
         int rpm = 0;
         if (Ready())
         {
-            data[1] = 0x50 | AA1;  //Counter for 0xAA Byte 0
+            data[1] = 0x50 | AA1;  //Counter for 0xAA Byte 1
             data[2] = 0x07;
             data[6] = 0x94;
             data[7] = 0x00;
             rpm =  MAX(750, revCounter) * 4; // rpm value for E65
+            rpm = MIN(rpm, 16383); // prevent an overflow for (very) high RPMs
         } else {
-            data[1] = 0x30 | AA1;  //Counter for 0xAA Byte 0
+            data[1] = 0x30 | AA1;  //Counter for 0xAA Byte 1
             data[2] = 0xFE;
             data[6] = 0x84;
             data[7] = 0x00;
@@ -170,8 +171,8 @@ void BMW_E65::Task10Ms()
 
 
         data[3] = 0x00;  //Pedal position 0-255
-        data[4] = rpm;   //lowByte(RPM_A);
-        data[5] = rpm >> 8;  //highByte(RPM_A);
+        data[4] = (uint8_t)(rpm & 0x00FF);   //lowByte(RPM_A);
+        data[5] = (uint8_t)((rpm & 0xFF00) >> 8);  //highByte(RPM_A);
 
         int16_t check_AA = (data[1] + data[2] + data[3] + data[4] + data[5] + data[6] + data[7] + 0xAA);
         check_AA = (check_AA / 0x100) + (check_AA & 0xff);


### PR DESCRIPTION
Pretty much a rip off of TDBs mini code, so should also work on the BMW mini, E65 and E90s