### PR TITLE
Set motor speeds to 0 if comms fails, also set cruise control speed t…

### DIFF
--- a/src/GS450H.cpp
+++ b/src/GS450H.cpp
@@ -387,6 +387,11 @@ void GS450HClass::Task1Ms()
         if(VerifyMTHChecksum(100)==0 || dma_get_interrupt_flag(DMA1, DMA_CHANNEL6, DMA_TCIF)==0)
         {
             statusInv=0;
+            //set speeds to 0 to prevent dynamic throttle/regen issues
+            mg1_speed=0;
+            mg2_speed=0;
+            //disable cruise
+            Param::SetInt(Param::cruisespeed, 0);
         }
         else
         {
@@ -495,8 +500,12 @@ void GS450HClass::Task1Ms()
     case 8:
         if(VerifyMTHChecksum(120)==0 || dma_get_interrupt_flag(DMA1, DMA_CHANNEL6, DMA_TCIF)==0)
         {
-
             statusInv=0;
+            //set speeds to 0 to prevent dynamic throttle/regen issues
+            mg1_speed=0;
+            mg2_speed=0;
+            //disable cruise
+            Param::SetInt(Param::cruisespeed, 0);
         }
         else
         {
@@ -615,6 +624,11 @@ void GS450HClass::Task1Ms()
 
             statusInv=0;
             inv_status=0;
+            //set speeds to 0 to prevent dynamic throttle/regen issues
+            mg1_speed=0;
+            mg2_speed=0;
+            //disable cruise
+            Param::SetInt(Param::cruisespeed, 0);
         }
         else
         {


### PR DESCRIPTION
Sets motor speeds and cruise control speeds to 0 if serial comms feedback fails.

It looks like theres potential unintended throttle application if comms fails. For example if regen is used and the motors are spinning at 4000 rpm and a negative torque is applied for regen and then the message are failing to be received. Once the car is at standstill, the code will still have the motors spinning at 4000 rpm and requesting negative torque causing reverse. 