### PR TITLE
Fix unit test build

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -8,7 +8,11 @@
 
 namespace utils
 {
-    int32_t change(int32_t x, int32_t in_min, int32_t in_max, int32_t out_min, int32_t out_max);
+    inline int32_t change(int32_t x, int32_t in_min, int32_t in_max, int32_t out_min, int32_t out_max)
+    {
+        return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;
+    }
+
     float GetUserThrottleCommand(CanHardware*);
     float ProcessThrottle(int);
     float ProcessUdc(int);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -20,12 +20,6 @@ int32_t NetWh=0;
 
 bool Timer1Run = false;
 
-
-int32_t change(int32_t x, int32_t in_min, int32_t in_max, int32_t out_min, int32_t out_max)
-{
-    return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;
-}
-
 void PostErrorIfRunning(ERROR_MESSAGE_NUM err)
 {
     if (Param::GetInt(Param::opmode) == MOD_RUN)


### PR DESCRIPTION
Reinstate the move of utils::change() to be an inline function similar to commit 467955d7. This allows
utils.h to be used in both the Linux and STM32 builds. Currently utils.cpp is highly platform specific and cannot be built for Linux x86.

Tests:
 - Build for STM32 and x86 Linux
 - Run unit tests on Linux successfully