### PR TITLE
Simplify CAN callbacks to use bytes rather than 32-bit words

### DIFF
--- a/include/BMW_E31.h
+++ b/include/BMW_E31.h
@@ -39,7 +39,7 @@ public:
    void Task1Ms();
    void SetRevCounter(int s);
    void SetTemperatureGauge(float temp);
-   void DecodeCAN(int id, uint32_t* data);
+   void DecodeCAN(int id, const uint8_t bytes[8]) override;
    bool Ready();
    bool Start();
 

--- a/include/BMW_E39.h
+++ b/include/BMW_E39.h
@@ -36,7 +36,7 @@ public:
    void Task100Ms();
    void SetRevCounter(int s) { speed = s; }
    void SetTemperatureGauge(float temp);
-   void DecodeCAN(int id, uint32_t* data);
+   void DecodeCAN(int id, const uint8_t bytes[8]) override;
    bool Ready();
    bool Start();
    void SetE46(bool e46) { isE46 = e46; }

--- a/include/BMW_E65.h
+++ b/include/BMW_E65.h
@@ -20,14 +20,14 @@ public:
    void Task200Ms();
    void SetRevCounter(int speed) { revCounter = speed; }
    void SetTemperatureGauge(float temp) { temperature = temp; }
-   void DecodeCAN(int, uint32_t* data);
+   void DecodeCAN(int id, const uint8_t bytes[8]) override;
    bool Ready() { return terminal15On; }
    bool Start() { return terminal15On; }
    void DashOff();
-   void handle130(uint32_t data[2]);
-   void handle1A0(uint32_t data[2]);
-   void handle2FC(uint32_t data[2]);
-   void handle480(uint32_t data[2]);
+   void handle130(const uint8_t bytes[8]);
+   void handle1A0(const uint8_t bytes[8]);
+   void handle2FC(const uint8_t bytes[8]);
+   void handle480(const uint8_t bytes[8]);
    void SetE90(bool e90) { isE90 = e90; }
    void Engine_Data();
    void SetFuelGauge(float level);

--- a/include/CPC.h
+++ b/include/CPC.h
@@ -17,7 +17,7 @@ class CPCClass: public Chargerint
 
 public:
       void SetCanInterface(CanHardware* c);
-      void DecodeCAN(int id, uint32_t data[2]);
+      void DecodeCAN(int id, const uint8_t bytes[8]) override;
       void Task10Ms();
       void Task100Ms();
       void Task200Ms();
@@ -25,7 +25,7 @@ public:
       bool ACRequest(bool RunCh);
 
 private:
-static void handle357(uint32_t data[2]);
+static void handle357(const uint8_t bytes[8]);
 
 static void Chg_Timers();
 };

--- a/include/Can_OBD2.h
+++ b/include/Can_OBD2.h
@@ -25,7 +25,7 @@ class Can_OBD2
 {
 public:
   void SetCanInterface(CanHardware *c);
-  void DecodeCAN(int id, uint32_t data[2]);
+  void DecodeCAN(int id, const uint8_t bytes[8]);
 
 protected:
   CanHardware *can;

--- a/include/Can_OI.h
+++ b/include/Can_OI.h
@@ -30,7 +30,7 @@ class Can_OI: public Inverter
 {
 public:
    void Task100Ms() override;
-   void DecodeCAN(int, uint32_t*) override;
+   void DecodeCAN(int id, const uint8_t bytes[8]) override;
    void SetTorque(float torquePercent) override;
    float GetMotorTemperature() override { return motor_temp; }
    float GetInverterTemperature() override { return inv_temp; }

--- a/include/E65_Lever.h
+++ b/include/E65_Lever.h
@@ -35,7 +35,7 @@ public:
 
    void Task10Ms();
    void Task100Ms();
-   void DecodeCAN(int, uint32_t*);
+   void DecodeCAN(int id, const uint8_t bytes[8]) override;
    bool GetGear(Shifter::Sgear& outGear);//if shifter class knows gear return true and set dir
    void SetCanInterface(CanHardware* c);
 

--- a/include/ElconCharger.h
+++ b/include/ElconCharger.h
@@ -16,11 +16,11 @@ class ElconCharger: public Chargerhw
 {
 
 public:
-void DecodeCAN(int id, uint32_t data[2]);
+void DecodeCAN(int id, const uint8_t bytes[8]) override;
 void Task200Ms();
 bool ControlCharge(bool RunCh, bool ACReq);
 void SetCanInterface(CanHardware* c);
-void handle18FF50E5(uint32_t data[2]);
+void handle18FF50E5(const uint8_t bytes[8]);
 /*
 static void handle108(uint32_t data[2]);
 static bool HVreq;

--- a/include/F30_Lever.h
+++ b/include/F30_Lever.h
@@ -37,7 +37,7 @@ public:
 
    void Task10Ms();
    void Task100Ms();
-   void DecodeCAN(int, uint32_t*);
+   void DecodeCAN(int id, const uint8_t bytes[8]) override;
    bool GetGear(Shifter::Sgear& outGear);//if shifter class knows gear return true and set dir
    void SetCanInterface(CanHardware* c);
 

--- a/include/Focci.h
+++ b/include/Focci.h
@@ -21,7 +21,7 @@ class FocciClass: public Chargerint
 
 public:
       void SetCanInterface(CanHardware* c);
-      void DecodeCAN(int id, uint32_t data[2]);
+      void DecodeCAN(int id, const uint8_t bytes[8]) override;
       void Task10Ms();
       void Task100Ms();
       void Task200Ms();
@@ -31,9 +31,9 @@ public:
       void CCS_Pwr_Con();
 
 private:
-static void handle357(uint32_t data[2]);
-static void handle109(uint32_t data[2]);
-static void handle596(uint32_t data[2]);
+static void handle357(const uint8_t bytes[8]);
+static void handle109(const uint8_t bytes[8]);
+static void handle596(const uint8_t bytes[8]);
 static void Chg_Timers();
 };
 

--- a/include/JLR_G1.h
+++ b/include/JLR_G1.h
@@ -34,7 +34,7 @@ public:
 
    void Task10Ms();
    void Task100Ms();
-   void DecodeCAN(int, uint32_t*);
+   void DecodeCAN(int id, const uint8_t bytes[8]) override;
    bool GetGear(Shifter::Sgear& outGear);//if shifter class knows gear return true and set dir
    void SetCanInterface(CanHardware* c);
 

--- a/include/JLR_G2.h
+++ b/include/JLR_G2.h
@@ -34,7 +34,7 @@ public:
 
    void Task10Ms();
    void Task100Ms();
-   void DecodeCAN(int, uint32_t*);
+   void DecodeCAN(int id, const uint8_t bytes[8]) override;
    bool GetGear(Shifter::Sgear& outGear);//if shifter class knows gear return true and set dir
    void SetCanInterface(CanHardware* c);
 

--- a/include/NissanPDM.h
+++ b/include/NissanPDM.h
@@ -28,7 +28,7 @@
 class NissanPDM: public Chargerhw
 {
 public:
-   void DecodeCAN(int id, uint32_t data[2]);
+   void DecodeCAN(int id, const uint8_t bytes[8]) override;
    void Task10Ms();
    void Task100Ms();
    bool ControlCharge(bool RunCh, bool ACReq);

--- a/include/OutlanderCanHeater.h
+++ b/include/OutlanderCanHeater.h
@@ -28,7 +28,7 @@ class OutlanderCanHeater : public Heater
    public:
       void SetTargetTemperature(float temp);
       void SetCanInterface(CanHardware* c);
-      void DecodeCAN(int id, uint32_t data[2]);
+      void DecodeCAN(int id, const uint8_t bytes[8]);
       void SetPower(uint16_t power, bool HeatReq);
       void Task100Ms();
 
@@ -37,7 +37,7 @@ class OutlanderCanHeater : public Heater
       int8_t desiredTemperature;
 
       bool shouldHeat;
-      static void handle398(uint32_t data[2]);
+      static void handle398(const uint8_t bytes[8]);
 
 };
 

--- a/include/bms.h
+++ b/include/bms.h
@@ -38,7 +38,7 @@
 class BMS
 {
    public:
-      virtual void DecodeCAN(int, uint8_t *) {};
+      virtual void DecodeCAN(int, const uint8_t[8]) {};
       virtual void DeInit() {};
       virtual float MaxChargeCurrent() { return 9999.0; };
       virtual void Task100Ms() {

--- a/include/bmw_sbox.h
+++ b/include/bmw_sbox.h
@@ -22,7 +22,7 @@ class SBOX
 
 public:
     static void RegisterCanMessages(CanHardware* can);
-    static void DecodeCAN(int id, uint32_t data[2]);
+    static void DecodeCAN(int id, const uint8_t bytes[8]);
     static void ControlContactors(int opmode, CanHardware* can);
 
     static int32_t Voltage;
@@ -37,9 +37,9 @@ public:
 private:
 
 
-    static void handle200(uint32_t data[2]);
-    static void handle210(uint32_t data[2]);
-    static void handle220(uint32_t data[2]);
+    static void handle200(const uint8_t bytes[8]);
+    static void handle210(const uint8_t bytes[8]);
+    static void handle220(const uint8_t bytes[8]);
 
 };
 

--- a/include/chademo.h
+++ b/include/chademo.h
@@ -31,7 +31,7 @@
 class FCChademo: public Chargerint
 {
    public:
-      void DecodeCAN(int id, uint32_t data[2]);
+      void DecodeCAN(int id, const uint8_t bytes[8]) override;
       void Task100Ms();//Must be called every 100ms
       void Task200Ms();
       bool DCFCRequest(bool RunCh);

--- a/include/chargerhw.h
+++ b/include/chargerhw.h
@@ -29,7 +29,7 @@ public:
    virtual void Task10Ms() {} //Default does nothing
    virtual void Task100Ms() {} //Default does nothing
    virtual void Task200Ms() {} //Default does nothing
-   virtual void DecodeCAN(int, uint32_t*) {};
+   virtual void DecodeCAN(int, const uint8_t[8]) {};
    virtual bool ControlCharge(bool, bool) {return false;};
    virtual void DeInit() {} //called when switching to another charger, similar to a destructor
    virtual void SetCanInterface(CanHardware* c) { can = c; }

--- a/include/chargerint.h
+++ b/include/chargerint.h
@@ -29,7 +29,7 @@ public:
    virtual void Task10Ms() {} //Default does nothing
    virtual void Task100Ms() {} //Default does nothing
    virtual void Task200Ms() {} //Default does nothing
-   virtual void DecodeCAN(int, uint32_t*) {};
+   virtual void DecodeCAN(int, const uint8_t[8]) {};
    virtual bool DCFCRequest(bool) {return false;};
    virtual bool ACRequest(bool) {return false;};
    virtual void DeInit() {} //called when switching to another charger, similar to a destructor

--- a/include/daisychainbms.h
+++ b/include/daisychainbms.h
@@ -28,7 +28,7 @@ class DaisychainBMS: public BMS
 {
    public:
       void SetCanInterface(CanHardware* c) override;
-      void DecodeCAN(int id, uint8_t * data) override;
+      void DecodeCAN(int id, const uint8_t data[8]) override;
       float MaxChargeCurrent() override;
       void Task100Ms() override;
    private:

--- a/include/dcdc.h
+++ b/include/dcdc.h
@@ -26,7 +26,7 @@
 class DCDC
 {
    public:
-      virtual void DecodeCAN(int, uint8_t *) {};
+      virtual void DecodeCAN(int, const uint8_t[8]) {};
       virtual void DeInit() {};
       virtual void Task1Ms() {};
       virtual void Task10Ms() {};

--- a/include/heater.h
+++ b/include/heater.h
@@ -12,7 +12,7 @@
 class Heater
 {
 public:
-   virtual void DecodeCAN(int, uint32_t*) {};
+   virtual void DecodeCAN(int, const uint8_t[8]) {};
    virtual float GetTemperature() { return 0; }
    virtual void SetTargetTemperature(float temp) = 0; //target temperature in °C
    virtual void SetPower(uint16_t power, bool HeatReq) = 0; //Must be called cyclically with power in watts

--- a/include/i3LIM.h
+++ b/include/i3LIM.h
@@ -13,7 +13,7 @@ class i3LIMClass: public Chargerint
 {
 public:
       void SetCanInterface(CanHardware* c) override;
-      void DecodeCAN(int id, uint32_t* data) override;
+      void DecodeCAN(int id, const uint8_t bytes[8]) override;
       void Task10Ms() override;
       void Task100Ms() override;
       void Task200Ms() override;
@@ -21,11 +21,11 @@ public:
       bool ACRequest(bool RunCh) override;
 
 private:
-      void handle3B4(uint32_t data[2]);
-      void handle29E(uint32_t data[2]);
-      void handle2B2(uint32_t data[2]);
-      void handle2EF(uint32_t data[2]);
-      void handle272(uint32_t data[2]);
+      void handle3B4(const uint8_t bytes[8]);
+      void handle29E(const uint8_t bytes[8]);
+      void handle2B2(const uint8_t bytes[8]);
+      void handle2EF(const uint8_t bytes[8]);
+      void handle272(const uint8_t bytes[8]);
       void CCS_Pwr_Con();
       void Chg_Timers();
 };

--- a/include/inverter.h
+++ b/include/inverter.h
@@ -28,7 +28,7 @@ public:
    virtual void Task1Ms() {} //Default does nothing
    virtual void Task10Ms() {} //Default does nothing
    virtual void Task100Ms() {} //Default does nothing
-   virtual void DecodeCAN(int, uint32_t*) {};
+   virtual void DecodeCAN(int, const uint8_t[8]) {};
    virtual void SetTorque(float torquePercent) = 0;
    virtual float GetMotorTemperature() = 0;
    virtual float GetInverterTemperature() = 0;

--- a/include/isa_shunt.h
+++ b/include/isa_shunt.h
@@ -29,7 +29,7 @@ public:
     static void START(CanHardware* can);
     static void RESTART(CanHardware* can);
     static void deFAULT(CanHardware* can);
-    static void DecodeCAN(int id, uint32_t data[2]);
+    static void DecodeCAN(int id, const uint8_t bytes[8]);
 
     static int32_t Voltage;
     static int32_t Voltage2;
@@ -42,14 +42,14 @@ public:
 
 
 private:
-    static void handle521(uint32_t data[2]);
-    static void handle522(uint32_t data[2]);
-    static void handle523(uint32_t data[2]);
-    static void handle524(uint32_t data[2]);
-    static void handle525(uint32_t data[2]);
-    static void handle526(uint32_t data[2]);
-    static void handle527(uint32_t data[2]);
-    static void handle528(uint32_t data[2]);
+    static void handle521(const uint8_t bytes[8]);
+    static void handle522(const uint8_t bytes[8]);
+    static void handle523(const uint8_t bytes[8]);
+    static void handle524(const uint8_t bytes[8]);
+    static void handle525(const uint8_t bytes[8]);
+    static void handle526(const uint8_t bytes[8]);
+    static void handle527(const uint8_t bytes[8]);
+    static void handle528(const uint8_t bytes[8]);
 };
 
 #endif /* SimpleISA_h */

--- a/include/kangoobms.h
+++ b/include/kangoobms.h
@@ -29,7 +29,7 @@ class KangooBMS: public BMS
 {
    public:
       void SetCanInterface(CanHardware* c) override;
-      void DecodeCAN(int id, uint8_t * data) override;
+      void DecodeCAN(int id, const uint8_t data[8]) override;
       float MaxChargeCurrent() override;
       void Task100Ms() override;
 

--- a/include/leafbms.h
+++ b/include/leafbms.h
@@ -24,7 +24,7 @@ class LeafBMS: public BMS
 {
 public:
     void SetCanInterface(CanHardware* can) override;
-    void DecodeCAN(int id, uint8_t * data) override;
+    void DecodeCAN(int id, const uint8_t bytes[8]) override;
 };
 
 #endif // LEAFBMS_H

--- a/include/leafinv.h
+++ b/include/leafinv.h
@@ -28,7 +28,7 @@
 class LeafINV: public Inverter
 {
 public:
-   void DecodeCAN(int id, uint32_t data[2]);
+   void DecodeCAN(int id, const uint8_t bytes[8]) override;
    void Task10Ms();
    void Task100Ms();
    static bool ControlCharge(bool RunCh);

--- a/include/outlanderCharger.h
+++ b/include/outlanderCharger.h
@@ -35,7 +35,7 @@ class outlanderCharger: public Chargerhw
 {
 
 public:
-void DecodeCAN(int id, uint32_t data[2]);
+void DecodeCAN(int id, const uint8_t bytes[8]) override;
 void Task100Ms();
 bool ControlCharge(bool RunCh, bool ACReq);
 void SetCanInterface(CanHardware* c);
@@ -51,9 +51,9 @@ static uint8_t chgStatus , evseDuty;
 static float dcBusV , temp_1 , temp_2 , ACVolts , DCAmps , ACAmps;
 static float LV_Volts , LV_Amps;
 
-static void handle377(uint32_t data[2]);
-static void handle389(uint32_t data[2]);
-static void handle38A(uint32_t data[2]);
+static void handle377(const uint8_t bytes[8]);
+static void handle389(const uint8_t bytes[8]);
+static void handle38A(const uint8_t bytes[8]);
 };
 
 #endif // OUTLANDERCHARGER_H

--- a/include/outlanderinverter.h
+++ b/include/outlanderinverter.h
@@ -27,7 +27,7 @@ class OutlanderInverter : public Inverter
 public:
    OutlanderInverter();
    void SetCanInterface(CanHardware* c);
-   void DecodeCAN(int id, uint32_t data[2]);
+   void DecodeCAN(int id, const uint8_t bytes[8]) override;
    void Task10Ms();
    void Task100Ms();
    void SetTorque(float torque);

--- a/include/rearoutlanderinverter.h
+++ b/include/rearoutlanderinverter.h
@@ -27,7 +27,7 @@ class RearOutlanderInverter : public Inverter
 public:
    RearOutlanderInverter();
    void SetCanInterface(CanHardware* c);
-   void DecodeCAN(int id, uint32_t data[2]);
+   void DecodeCAN(int id, const uint8_t bytes[8]) override;
    void Task10Ms();
    void Task100Ms();
    void SetTorque(float torque);

--- a/include/shifter.h
+++ b/include/shifter.h
@@ -31,7 +31,7 @@ public:
    virtual void Task10Ms() {} //Default does nothing
    virtual void Task100Ms() {} //Default does nothing
    virtual void Task200Ms() {} //Default does nothing
-   virtual void DecodeCAN(int, uint32_t*) {};
+   virtual void DecodeCAN(int, const uint8_t[8]) {};
    virtual bool GetGear(Sgear&) { return false; } //if shifter class knows gear return true and set dir
    virtual void SetCanInterface(CanHardware* c) { can = c; }
 

--- a/include/simpbms.h
+++ b/include/simpbms.h
@@ -28,7 +28,7 @@ class SimpBMS: public BMS
 {
    public:
       void SetCanInterface(CanHardware* c) override;
-      void DecodeCAN(int id, uint8_t * data) override;
+      void DecodeCAN(int id, const uint8_t data[8]) override;
       float MaxChargeCurrent() override;
       void Task100Ms() override;
    private:

--- a/include/teslaCharger.h
+++ b/include/teslaCharger.h
@@ -12,7 +12,7 @@
 class teslaCharger: public Chargerhw
 {
 public:
-    void DecodeCAN(int id, uint32_t data[2]) override;
+    void DecodeCAN(int id, const uint8_t bytes[8]) override;
     void Task100Ms() override;
     bool ControlCharge(bool RunCh, bool ACReq) override;
     void SetCanInterface(CanHardware* c) override;

--- a/include/vag_sbox.h
+++ b/include/vag_sbox.h
@@ -22,7 +22,7 @@ class VWBOX
 
 public:
     static void RegisterCanMessages(CanHardware* can);
-    static void DecodeCAN(int id, uint32_t data[2]);
+    static void DecodeCAN(int id, const uint8_t bytes[8]);
     static void ControlContactors(int opmode, CanHardware* can);
 
     static float Voltage;
@@ -37,7 +37,7 @@ public:
 private:
 
 
-    static void handle0BB(uint32_t data[2]);
+    static void handle0BB(const uint8_t bytes[8]);
     static uint8_t vw_crc_calc(uint8_t *data);
 
 };

--- a/include/vehicle.h
+++ b/include/vehicle.h
@@ -32,7 +32,7 @@ public:
    virtual void Task10Ms() {} //Default does nothing
    virtual void Task100Ms() {} //Default does nothing
    virtual void Task200Ms() {} //Default does nothing
-   virtual void DecodeCAN(int, uint32_t*) {};
+   virtual void DecodeCAN(int, const uint8_t[8]) {};
    virtual void DashOff() {}
    virtual void SetRevCounter(int speed) = 0;
    virtual void SetTemperatureGauge(float temp) = 0;

--- a/src/BMW_E31.cpp
+++ b/src/BMW_E31.cpp
@@ -56,9 +56,9 @@ void BMW_E31::SetTemperatureGauge(float temp)
     dc = dc;
 }
 
-void BMW_E31::DecodeCAN(int id, uint32_t* data)
+void BMW_E31::DecodeCAN(int id, const uint8_t bytes[8])
 {
-    uint8_t* bytes = (uint8_t*)data;//E31 CAN to be added here
+    //E31 CAN to be added here
 
     if (id == 0x153)// ASC1 contains road speed signal. Unsure if applies to E31 as yet ....
     {

--- a/src/BMW_E39.cpp
+++ b/src/BMW_E39.cpp
@@ -370,7 +370,7 @@ void BMW_E39::Msg43F(int8_t gear)
     can->Send(0x43F, bytes, 8);
 }
 
-void BMW_E39::DecodeCAN(int id, uint32_t* data)
+void BMW_E39::DecodeCAN(int id, const uint8_t bytes[8])
 {
     //ASC1 message data 0x153
     /*
@@ -422,8 +422,6 @@ void BMW_E39::DecodeCAN(int id, uint32_t* data)
 
     Byte 7 - ASC ALIVE
     */
-
-    uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
 
     if (id == 0x153)// ASC1 contains road speed signal.
     {

--- a/src/BMW_E65.cpp
+++ b/src/BMW_E65.cpp
@@ -30,25 +30,25 @@ void BMW_E65::SetCanInterface(CanHardware* c)
 /////////////////////////////////////////////////////////////////////////////////////////////////////
 ///////Handle incomming pt can messages from the car here
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-void BMW_E65::DecodeCAN(int id, uint32_t* data)
+void BMW_E65::DecodeCAN(int id, const uint8_t bytes[8])
 {
 
     switch (id)
     {
     case 0x130:
-        BMW_E65::handle130(data);
+        BMW_E65::handle130(bytes);
         break;
 
     case 0x1A0:
-        BMW_E65::handle1A0(data);
+        BMW_E65::handle1A0(bytes);
         break;
 
     case 0x2FC:
-        BMW_E65::handle2FC(data);
+        BMW_E65::handle2FC(bytes);
         break;
 
     case 0x480:
-        BMW_E65::handle480(data);
+        BMW_E65::handle480(bytes);
         break;
 
     default:
@@ -56,9 +56,8 @@ void BMW_E65::DecodeCAN(int id, uint32_t* data)
     }
 }
 
-void BMW_E65::handle130(uint32_t data[2])
+void BMW_E65::handle130(const uint8_t bytes[8])
 {
-    uint8_t* bytes = (uint8_t*)data;
     /*
         if ((bytes[0] == 0x45) || (bytes[0] == 0x55))
         {
@@ -107,17 +106,14 @@ void BMW_E65::handle130(uint32_t data[2])
     }
 }
 
-void BMW_E65::handle1A0(uint32_t data[2])
+void BMW_E65::handle1A0(const uint8_t bytes[8])
 {
-    uint8_t* bytes = (uint8_t*)data;
-
     float kph = (bytes[0] + uint16_t((bytes[1]&0x0F)<<8)) * 0.1;
     Param::SetFloat(Param::Veh_Speed, kph * 0.621371f);
 }
 
-void BMW_E65::handle2FC(uint32_t data[2])
+void BMW_E65::handle2FC(const uint8_t bytes[8])
 {
-    uint8_t* bytes = (uint8_t*)data;
     if (bytes[0] == 0x84)//Locked
     {
         Param::SetInt(Param::VehLockSt,1);
@@ -128,10 +124,9 @@ void BMW_E65::handle2FC(uint32_t data[2])
     }
 }
 
-void BMW_E65::handle480(uint32_t data[2])
-{
-    uint8_t* bytes = (uint8_t*)data;
 
+void BMW_E65::handle480(const uint8_t bytes[8])
+{
     if (bytes[1] == 0x32)
     {
         CANWake = false;

--- a/src/CPC.cpp
+++ b/src/CPC.cpp
@@ -32,13 +32,13 @@ void CPCClass::SetCanInterface(CanHardware* c)
     can->RegisterUserMessage(0x357);
 }
 
-void CPCClass::DecodeCAN(int id, uint32_t* data)
+void CPCClass::DecodeCAN(int id, const uint8_t bytes[8])
 {
 
     switch(id)
     {
     case 0x357:
-        CPCClass::handle357(data);
+        CPCClass::handle357(bytes);
         break;
 
 
@@ -48,10 +48,8 @@ void CPCClass::DecodeCAN(int id, uint32_t* data)
     }
 }
 
-void CPCClass::handle357(uint32_t data[2])  //Lim data
+void CPCClass::handle357(const uint8_t bytes[8])  //Lim data
 {
-    uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
-
     ChargePort_IsoStop = bytes[0];
     ChargePort_ACLimit = bytes[2] * 256 + bytes[1];
     ChargePort_Status = bytes[3];

--- a/src/Can_OBD2.cpp
+++ b/src/Can_OBD2.cpp
@@ -75,9 +75,8 @@ void Can_OBD2::SetCanInterface(CanHardware *c)
    can->RegisterUserMessage(0x7DF);
 }
 
-void Can_OBD2::DecodeCAN(int id, uint32_t data[2])
+void Can_OBD2::DecodeCAN(int id, const uint8_t bytes[8])
 {
-  uint8_t *bytes = (uint8_t *)data; // arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
   uint8_t response[8];
   uint16_t speed;
 

--- a/src/Can_OI.cpp
+++ b/src/Can_OI.cpp
@@ -44,13 +44,11 @@ void Can_OI::SetCanInterface(CanHardware* c)
    can->RegisterUserMessage(0x1AE);//Open Inv Msg. Dec 430 for Opmode.
 }
 
-void Can_OI::DecodeCAN(int id, uint32_t* data)
+void Can_OI::DecodeCAN(int id, const uint8_t bytes[8])
 {
 //0x1A4 bits 0-15 inverter voltage x10
 //0x190 bits 0-15 motor rpm x1
 //0x19A bits 0-15 heatsink temp x10
-
-   uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
 
    if (id == 0x1A4)// THIS MSG CONTAINS INV VOLTAGE
    {

--- a/src/E65_Lever.cpp
+++ b/src/E65_Lever.cpp
@@ -28,8 +28,10 @@ void E65_Lever::SetCanInterface(CanHardware* c)
     can->RegisterUserMessage(0x192);//GWS status msg. Contains info on buttons pressed and lever location.
 }
 
-void E65_Lever::DecodeCAN(int id, uint32_t* data)
+void E65_Lever::DecodeCAN(int id, const uint8_t bytes[8])
 {
+    uint32_t* data = (uint32_t*)bytes;
+
     if (id == 0x192)
     {
         uint32_t GLeaver = data[0] & 0x00ffffff;  //unsigned int to contain result of message 0x192. Gear selector lever position

--- a/src/ElconCharger.cpp
+++ b/src/ElconCharger.cpp
@@ -18,12 +18,12 @@ void ElconCharger::SetCanInterface(CanHardware* c)
 
 }
 
-void ElconCharger::DecodeCAN(int id, uint32_t data[2])
+void ElconCharger::DecodeCAN(int id, const uint8_t bytes[8])
 {
     switch (id)
     {
     case 0x18FF50E5:
-        ElconCharger::handle18FF50E5(data);
+        ElconCharger::handle18FF50E5(bytes);
         break;
 
     default:
@@ -31,9 +31,8 @@ void ElconCharger::DecodeCAN(int id, uint32_t data[2])
     }
 }
 
-void ElconCharger::handle18FF50E5(uint32_t data[2])
+void ElconCharger::handle18FF50E5(const uint8_t bytes[8])
 {
-    uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes.
     ChargerHVbatteryVolts = (bytes[0] * 256 + bytes[1]) * 0.1;
     ChargerHVcurrent = (bytes[2] * 256 + bytes[3]) * 0.1;
     ChargerStatus = bytes[4];

--- a/src/F30_Lever.cpp
+++ b/src/F30_Lever.cpp
@@ -93,9 +93,8 @@ remainder = remainder^final;
 }
 
 
-void F30_Lever::DecodeCAN(int id, uint32_t* data)
+void F30_Lever::DecodeCAN(int id, const uint8_t bytes[8])
 {
-   uint8_t* bytes = (uint8_t*)data;
    if (id == 0x197)
    {
      Up1 = false;

--- a/src/Focci.cpp
+++ b/src/Focci.cpp
@@ -71,19 +71,19 @@ void FocciClass::SetCanInterface(CanHardware* c)
     can->RegisterUserMessage(0x596);
 }
 
-void FocciClass::DecodeCAN(int id, uint32_t* data)
+void FocciClass::DecodeCAN(int id, const uint8_t bytes[8])
 {
 
     switch(id)
     {
     case 0x109:
-        handle109(data);
+        handle109(bytes);
         break;
     case 0x357:
-        handle357(data);
+        handle357(bytes);
         break;
     case 0x596:
-        handle596(data);
+        handle596(bytes);
         break;
 
 
@@ -93,21 +93,16 @@ void FocciClass::DecodeCAN(int id, uint32_t* data)
     }
 }
 
-void FocciClass::handle109(uint32_t data[2])  //FOCCI DCFC info
+void FocciClass::handle109(const uint8_t bytes[8])  //FOCCI DCFC info
 {
-    uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
-
     Param::SetInt(Param::CCS_V,bytes[1] * 256 + bytes[0]);
     Param::SetInt(Param::CCS_I,bytes[3] * 256 + bytes[2]);
     Param::SetInt(Param::CCS_I_Avail,bytes[5] * 256 + bytes[4]);
     Param::SetInt(Param::CCS_V_Avail,bytes[7] * 256 + bytes[6]);
-
 }
 
-void FocciClass::handle357(uint32_t data[2])  //FOCCI Charge Port Info
+void FocciClass::handle357(const uint8_t bytes[8])  //FOCCI Charge Port Info
 {
-    uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
-
     ChargePort_IsoStop = bytes[0];
     ChargePort_ACLimit = bytes[2] * 256 + bytes[1];
     ChargePort_Status = bytes[3];
@@ -170,9 +165,8 @@ void FocciClass::handle357(uint32_t data[2])  //FOCCI Charge Port Info
     Param::SetInt(Param::PilotTyp,CP_Mode);
 }
 
-void FocciClass::handle596(uint32_t data[2])  //FOCCI SDO responses
+void FocciClass::handle596(const uint8_t bytes[8])  //FOCCI SDO responses
 {
-    uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
     if(RespondReq == 1)//only look at this if we have sent a message looking for a response
     {
         if(bytes[0] == 0x80)

--- a/src/JLR_G1.cpp
+++ b/src/JLR_G1.cpp
@@ -44,15 +44,13 @@ void JLR_G1::SetCanInterface(CanHardware* c)
 }
 
 
-void JLR_G1::DecodeCAN(int id, uint32_t* data)
+void JLR_G1::DecodeCAN(int id, const uint8_t bytes[8])
 {
-    uint8_t* bytes = (uint8_t*)data;
     if (id == 0x312)
     {
         Cnt312 = bytes[7] & 0x0F;
         DirJLRG1 = bytes[3] >> 4;
     }
-
 }
 
 void JLR_G1::sendcan()

--- a/src/JLR_G2.cpp
+++ b/src/JLR_G2.cpp
@@ -58,9 +58,8 @@ void JLR_G2::SetCanInterface(CanHardware* c)
 }
 
 
-void JLR_G2::DecodeCAN(int id, uint32_t* data)
+void JLR_G2::DecodeCAN(int id, const uint8_t bytes[8])
 {
-    uint8_t* bytes = (uint8_t*)data;
     if (id == 0x0E0)
     {
         Cnt0E0 = bytes[4];

--- a/src/NissanPDM.cpp
+++ b/src/NissanPDM.cpp
@@ -89,10 +89,8 @@ void NissanPDM::SetCanInterface(CanHardware* c)
     can->RegisterUserMessage(0x390);//Leaf obc msg
 }
 
-void NissanPDM::DecodeCAN(int id, uint32_t data[2])
+void NissanPDM::DecodeCAN(int id, const uint8_t bytes[8])
 {
-    uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
-
     if (id == 0x679)// THIS MSG FIRES ONCE ON CHARGE PLUG INSERT
     {
         uint8_t dummyVar = bytes[0];

--- a/src/OutlanderCanHeater.cpp
+++ b/src/OutlanderCanHeater.cpp
@@ -69,19 +69,18 @@ void OutlanderCanHeater::SetTargetTemperature(float temp)
     desiredTemperature = temp;
 }
 
-void OutlanderCanHeater::DecodeCAN(int id, uint32_t data[2])
+void OutlanderCanHeater::DecodeCAN(int id, const uint8_t bytes[8])
 {
     switch (id)
     {
     case 0x398:
-        OutlanderCanHeater::handle398(data);
+        OutlanderCanHeater::handle398(bytes);
         break;
     }
 }
 
-void OutlanderCanHeater::handle398(uint32_t data[2])
+void OutlanderCanHeater::handle398(const uint8_t bytes[8])
 {
-    uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
     unsigned int temp1 = bytes[3] - 40;
     unsigned int temp2 = bytes[4] - 40;
     if (temp2 > temp1)

--- a/src/RearOutlanderinverter.cpp
+++ b/src/RearOutlanderinverter.cpp
@@ -38,9 +38,8 @@ void RearOutlanderInverter::SetCanInterface(CanHardware* c)
     can->RegisterUserMessage(0x733);//Outlander Inv Msg
 }
 
-void RearOutlanderInverter::DecodeCAN(int id, uint32_t data[2])
+void RearOutlanderInverter::DecodeCAN(int id, const uint8_t bytes[8])
 {
-    uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
     switch (id)
     {
     case 0x289:

--- a/src/bmw_sbox.cpp
+++ b/src/bmw_sbox.cpp
@@ -95,47 +95,39 @@ void SBOX::RegisterCanMessages(CanHardware* can)
 
 }
 
-void SBOX::DecodeCAN(int id, uint32_t data[2])
+void SBOX::DecodeCAN(int id, const uint8_t bytes[8])
 {
    switch (id)
    {
    case 0x200:
-      SBOX::handle200(data);//SBOX CAN MESSAGE
+      SBOX::handle200(bytes);//SBOX CAN MESSAGE
       break;
    case 0x210:
-      SBOX::handle210(data);//SBOX CAN MESSAGE
+      SBOX::handle210(bytes);//SBOX CAN MESSAGE
       break;
    case 0x220:
-      SBOX::handle220(data);//SBOX CAN MESSAGE
+      SBOX::handle220(bytes);//SBOX CAN MESSAGE
       break;
    }
 }
 
 
-void SBOX::handle200(uint32_t data[2])  //SBOX Current
-
+void SBOX::handle200(const uint8_t bytes[8])  //SBOX Current
 {
-   uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
    Amperes = ((bytes[2] << 16) | (bytes[1] << 8) | (bytes[0]));
    Amperes = (Amperes<<8) >> 8;//extend sign bit as its a 24 bit signed value in a 32bit int! AAAHHHHHH!
-
 }
 
-void SBOX::handle210(uint32_t data[2])  //SBOX battery voltage
-
+void SBOX::handle210(const uint8_t bytes[8])  //SBOX battery voltage
 {
-   uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
    Voltage=((bytes[2] << 16) | (bytes[1] << 8) | (bytes[0]));
    Voltage = (Voltage<<8) >> 8;//extend sign bit as its a 24 bit signed value in a 32bit int! AAAHHHHHH!
 }
 
-void SBOX::handle220(uint32_t data[2]) //SBOX Output voltage
-
+void SBOX::handle220(const uint8_t bytes[8]) //SBOX Output voltage
 {
-   uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
    Voltage2=((bytes[2] << 16) | (bytes[1] << 8) | (bytes[0]));
    Voltage2 = (Voltage2<<8) >> 8;//extend sign bit as its a 24 bit signed value in a 32bit int! AAAHHHHHH!
-
 }
 
 void SBOX::ControlContactors(int opmode, CanHardware* can)

--- a/src/chademo.cpp
+++ b/src/chademo.cpp
@@ -47,21 +47,24 @@ static void delay(void)
       __asm__("nop");
 }
 
-void FCChademo::DecodeCAN(int id, uint32_t data[2])
+void FCChademo::DecodeCAN(int id, const uint8_t bytes[8])
 {
-if (id == 0x108)
-{
-    chargerMaxCurrent = data[0] >> 24;
-    chargerMaxVoltage = data[0] >> 8;
-}
+   // TODO: Refactor to access the bytes this is looking for
+   const uint32_t* data = (uint32_t*)bytes;
+
+   if (id == 0x108)
+   {
+      chargerMaxCurrent = data[0] >> 24;
+      chargerMaxVoltage = data[0] >> 8;
+   }
 
 
-if (id == 0x109)
-{
-   chargerOutputVoltage = data[0] >> 8;
-   chargerOutputCurrent = data[0] >> 24;
-   chargerStatus = (data[1] >> 8) & 0x3F;
-}
+   if (id == 0x109)
+   {
+      chargerOutputVoltage = data[0] >> 8;
+      chargerOutputCurrent = data[0] >> 24;
+      chargerStatus = (data[1] >> 8) & 0x3F;
+   }
 }
 
 

--- a/src/charger.cpp
+++ b/src/charger.cpp
@@ -4,10 +4,8 @@ bool chargerClass::HVreq=false;
 static uint8_t counter_109 = 0;
 
 
-void chargerClass::handle108(uint32_t data[2])  //HV request
-
+void chargerClass::handle108(const uint8_t bytes[8])  //HV request
 {
-   uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
    if(bytes[0]==0xAA) HVreq=true;
    if(bytes[0]==0xCC) HVreq=false;
    //Counter in byte 7 to validate msg.

--- a/src/daisychainbms.cpp
+++ b/src/daisychainbms.cpp
@@ -76,7 +76,7 @@ float DaisychainBMS::MaxChargeCurrent()
 }
 
 // Process voltage and temperature message from TI Daisychain BMS.
-void DaisychainBMS::DecodeCAN(int id, uint8_t *data)
+void DaisychainBMS::DecodeCAN(int id, const uint8_t data[8])
 {
    int bms = -1;
    if (id == 0x4f1) bms = 0;

--- a/src/i3LIM.cpp
+++ b/src/i3LIM.cpp
@@ -86,25 +86,25 @@ void i3LIMClass::SetCanInterface(CanHardware* c)
     can->RegisterUserMessage(0x2EF);
 }
 
-void i3LIMClass::DecodeCAN(int id, uint32_t* data)
+void i3LIMClass::DecodeCAN(int id, const uint8_t bytes[8])
 {
 
     switch(id)
     {
     case 0x3B4:
-        handle3B4(data);
+        handle3B4(bytes);
         break;
     case 0x272:
-        handle272(data);
+        handle272(bytes);
         break;
     case 0x29E:
-        handle29E(data);
+        handle29E(bytes);
         break;
     case 0x2B2:
-        handle2B2(data);
+        handle2B2(bytes);
         break;
     case 0x2EF:
-        handle2EF(data);
+        handle2EF(bytes);
         break;
 
     default:
@@ -113,7 +113,7 @@ void i3LIMClass::DecodeCAN(int id, uint32_t* data)
     }
 }
 
-void i3LIMClass::handle3B4(uint32_t data[2])  //Lim data
+void i3LIMClass::handle3B4(const uint8_t bytes[8])  //Lim data
 
 {
     /*
@@ -127,7 +127,6 @@ void i3LIMClass::handle3B4(uint32_t data[2])  //Lim data
     6=pilot static
     */
 
-    uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
     uint8_t CP_Amps=bytes[0];
     Param::SetInt(Param::PilotLim,CP_Amps);
     uint8_t PP_Amps=bytes[1];
@@ -160,10 +159,8 @@ void i3LIMClass::handle3B4(uint32_t data[2])  //Lim data
 
 }
 
-void i3LIMClass::handle29E(uint32_t data[2])  //Lim data. Available current and voltage from the ccs charger
-
+void i3LIMClass::handle29E(const uint8_t bytes[8])  //Lim data. Available current and voltage from the ccs charger
 {
-    uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
     uint16_t V_Avail=((bytes[2]<<8)|(bytes[1]));
     V_Avail=FP_TOINT(FP_DIV(V_Avail,10));
     Param::SetInt(Param::CCS_V_Avail,V_Avail);//available voltage from ccs charger
@@ -175,13 +172,10 @@ void i3LIMClass::handle29E(uint32_t data[2])  //Lim data. Available current and 
     CCS_Iso = (bytes[0]>>6)&0x03;
     CCS_IntStat = (bytes[0]>>2)&0x0f;
     Param::SetInt(Param::CCS_COND,CCS_IntStat);//update evse condition on webui
-
 }
 
-void i3LIMClass::handle2B2(uint32_t data[2])  //Lim data. Current and Votage as measured by the ccs charger
-
+void i3LIMClass::handle2B2(const uint8_t bytes[8])  //Lim data. Current and Votage as measured by the ccs charger
 {
-    uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
     uint16_t CCS_Vmeas=((bytes[1]<<8)|(bytes[0]));
     CCS_Vmeas=FP_TOINT(FP_DIV(CCS_Vmeas,10));
     Param::SetInt(Param::CCS_V,CCS_Vmeas);//Voltage measurement from ccs charger
@@ -199,21 +193,17 @@ void i3LIMClass::handle2B2(uint32_t data[2])  //Lim data. Current and Votage as 
     CCS_Stop = (bytes[5]>>2)&0x03;
 }
 
-void i3LIMClass::handle2EF(uint32_t data[2])  //Lim data. Min available voltage from the ccs charger.
-
+void i3LIMClass::handle2EF(const uint8_t bytes[8])  //Lim data. Min available voltage from the ccs charger.
 {
-    uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
     uint16_t minV_Avail=((bytes[1]<<8)|(bytes[0]));
     minV_Avail=FP_TOINT(FP_DIV(minV_Avail,10));
     Param::SetInt(Param::CCS_V_Min,minV_Avail);//minimum available voltage from ccs charger
 
     CCS_Plim = (bytes[6]>>4)&0x03;
-
 }
 
-void i3LIMClass::handle272(uint32_t data[2])  //Lim data. CCS contactor state and charge flap open/close status.
+void i3LIMClass::handle272(const uint8_t bytes[8])  //Lim data. CCS contactor state and charge flap open/close status.
 {
-    uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
 // Only the top 6-bits indicate the contactor state
     uint8_t Cont_stat=bytes[2] >> 2;
     Param::SetInt(Param::CCS_Contactor,Cont_stat);

--- a/src/isa_shunt.cpp
+++ b/src/isa_shunt.cpp
@@ -37,33 +37,33 @@ static void delay(void) //delay used for isa setup fumction. probably much bette
       __asm__("nop");
 }
 
-void ISA::DecodeCAN(int id, uint32_t data[2])
+void ISA::DecodeCAN(int id, const uint8_t bytes[8])
 {
    switch (id)
    {
    case 0x521:
-      ISA::handle521(data);//ISA CAN MESSAGE
+      ISA::handle521(bytes);//ISA CAN MESSAGE
       break;
    case 0x522:
-      ISA::handle522(data);//ISA CAN MESSAGE
+      ISA::handle522(bytes);//ISA CAN MESSAGE
       break;
    case 0x523:
-      ISA::handle523(data);//ISA CAN MESSAGE
+      ISA::handle523(bytes);//ISA CAN MESSAGE
       break;
    case 0x524:
-      ISA::handle524(data);//ISA CAN MESSAGE
+      ISA::handle524(bytes);//ISA CAN MESSAGE
       break;
    case 0x525:
-      ISA::handle525(data);//ISA CAN MESSAGE
+      ISA::handle525(bytes);//ISA CAN MESSAGE
       break;
    case 0x526:
-      ISA::handle526(data);//ISA CAN MESSAGE
+      ISA::handle526(bytes);//ISA CAN MESSAGE
       break;
    case 0x527:
-      ISA::handle527(data);//ISA CAN MESSAGE
+      ISA::handle527(bytes);//ISA CAN MESSAGE
       break;
    case 0x528:
-      ISA::handle528(data);//ISA CAN MESSAGE
+      ISA::handle528(bytes);//ISA CAN MESSAGE
       break;
    }
 }
@@ -225,66 +225,50 @@ void ISA::initCurrent(CanHardware* can)
 
 /********* Private functions *******/
 
-void ISA::handle521(uint32_t data[2])  //Amperes
+void ISA::handle521(const uint8_t bytes[8])  //Amperes
 
 {
-   uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
    Amperes = ((bytes[5] << 24) | (bytes[4] << 16) | (bytes[3] << 8) | (bytes[2]));
 }
 
-void ISA::handle522(uint32_t data[2])  //Voltage
+void ISA::handle522(const uint8_t bytes[8])  //Voltage
 
 {
-   uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
    Voltage=((bytes[5] << 24) | (bytes[4] << 16) | (bytes[3] << 8) | (bytes[2]));
 }
 
-void ISA::handle523(uint32_t data[2]) //Voltage2
+void ISA::handle523(const uint8_t bytes[8]) //Voltage2
 
 {
-   uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
    Voltage2 = (uint32_t)((bytes[5] << 24) | (bytes[4] << 16) | (bytes[3] << 8) | (bytes[2]));
-
-
 }
 
-void ISA::handle524(uint32_t data[2])  //Voltage3
-
+void ISA::handle524(const uint8_t bytes[8])  //Voltage3
 {
-   uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
    Voltage3 = (uint32_t)((bytes[5] << 24) | (bytes[4] << 16) | (bytes[3] << 8) | (bytes[2]));
-
 }
 
-void ISA::handle525(uint32_t data[2])  //Temperature
+void ISA::handle525(const uint8_t bytes[8])  //Temperature
 {
-   uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
    framecount++;
    int32_t temp=0;
    temp = (int32_t)((bytes[5] << 24) | (bytes[4] << 16) | (bytes[3] << 8) | (bytes[2]));
 
    Temperature=temp/10;
-
 }
 
-void ISA::handle526(uint32_t data[2]) //Kilowatts
+void ISA::handle526(const uint8_t bytes[8]) //Kilowatts
 {
-   uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
    KW = (int32_t)((bytes[5] << 24) | (bytes[4] << 16) | (bytes[3] << 8) | (bytes[2]));
 }
 
 
-void ISA::handle527(uint32_t data[2]) //Ampere-Hours
-
+void ISA::handle527(const uint8_t bytes[8]) //Ampere-Hours
 {
-   uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
    Ah = (bytes[5] << 24) | (bytes[4] << 16) | (bytes[3] << 8) | (bytes[2]);
 }
 
-void ISA::handle528(uint32_t data[2])  //kiloWatt-hours
-
+void ISA::handle528(const uint8_t bytes[8])  //kiloWatt-hours
 {
-   uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
    KWh=((bytes[5] << 24) | (bytes[4] << 16) | (bytes[3] << 8) | (bytes[2]));
-
 }

--- a/src/kangoobms.cpp
+++ b/src/kangoobms.cpp
@@ -53,7 +53,7 @@ float KangooBMS::MaxChargeCurrent()
 }
 
 // Process voltage and temperature message from SimpBMS.
-void KangooBMS::DecodeCAN(int id, uint8_t *data)
+void KangooBMS::DecodeCAN(int id, const uint8_t data[8])
 {
    if (id == 0x155)
    {

--- a/src/leafbms.cpp
+++ b/src/leafbms.cpp
@@ -31,10 +31,8 @@ void LeafBMS::SetCanInterface(CanHardware* can)
     //can->RegisterUserMessage(0x59E);//Leaf BMS message 500ms
 }
 
-void LeafBMS::DecodeCAN(int id, uint8_t * data)
+void LeafBMS::DecodeCAN(int id, const uint8_t bytes[8])
 {
-    uint8_t* bytes = (uint8_t*)data;
-
     if (id == 0x1DB)
     {
         float cur = uint16_t(bytes[0] << 3) + uint16_t(bytes[1] >>5);

--- a/src/leafinv.cpp
+++ b/src/leafinv.cpp
@@ -63,10 +63,8 @@ void LeafINV::SetCanInterface(CanHardware* c)
     can->RegisterUserMessage(0x55A);//Leaf inv msg
 }
 
-void LeafINV::DecodeCAN(int id, uint32_t data[2])
+void LeafINV::DecodeCAN(int id, const uint8_t bytes[8])
 {
-    uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
-
     if (id == 0x1DA)// THIS MSG CONTAINS INV VOLTAGE, MOTOR SPEED AND ERROR STATE
     {
         voltage = ((bytes[0] << 2) | (bytes[1] >> 6)) * 0.5;//MEASURED VOLTAGE FROM LEAF INVERTER

--- a/src/outlanderCharger.cpp
+++ b/src/outlanderCharger.cpp
@@ -124,18 +124,18 @@ void outlanderCharger::SetCanInterface(CanHardware* c)
     can->RegisterUserMessage(0x38A);//charger status 2
 }
 
-void outlanderCharger::DecodeCAN(int id, uint32_t data[2])
+void outlanderCharger::DecodeCAN(int id, const uint8_t bytes[8])
 {
     switch (id)
     {
     case 0x377:
-        outlanderCharger::handle377(data);
+        outlanderCharger::handle377(bytes);
         break;
     case 0x389:
-        outlanderCharger::handle389(data);
+        outlanderCharger::handle389(bytes);
         break;
     case 0x38A:
-        outlanderCharger::handle38A(data);
+        outlanderCharger::handle38A(bytes);
         break;
     }
 }
@@ -212,21 +212,16 @@ void outlanderCharger::Task100Ms()
     }
 }
 
-void outlanderCharger::handle377(uint32_t data[2])
-
+void outlanderCharger::handle377(const uint8_t bytes[8])
 {
-    uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
     LV_Volts = ((bytes[0]<<8) | (bytes[1]))*0.01;
     LV_Amps = ((bytes[2]<<8) | (bytes[3]))*0.1;
     Param::SetFloat(Param::U12V, LV_Volts);
     Param::SetFloat(Param::I12V, LV_Amps);
-
 }
 
-void outlanderCharger::handle389(uint32_t data[2])
-
+void outlanderCharger::handle389(const uint8_t bytes[8])
 {
-    uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
     ACVolts = bytes[1]; //AC voltage measured at charger. Scale 1 to 1.
     ACAmps = bytes[6] * 0.1; //Current in Amps from mains. scale 0.1.
     DCAmps = bytes[2] * 0.1; //Current in Amps from charger to battery. scale 0.1.
@@ -234,10 +229,8 @@ void outlanderCharger::handle389(uint32_t data[2])
     Param::SetFloat(Param::AC_Amps, ACAmps);
 }
 
-void outlanderCharger::handle38A(uint32_t data[2])
-
+void outlanderCharger::handle38A(const uint8_t bytes[8])
 {
-    uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
     chgStatus = bytes[4];
     evseDuty = bytes[3];
     dcBusV = bytes[2]*2;// Volts scale 2
@@ -245,5 +238,3 @@ void outlanderCharger::handle38A(uint32_t data[2])
     temp_2 = bytes[1]-45;//degC bias -45
     Param::SetFloat(Param::ChgTemp, MAX(temp_1, temp_2));
 }
-
-

--- a/src/outlanderinverter.cpp
+++ b/src/outlanderinverter.cpp
@@ -35,8 +35,10 @@ void OutlanderInverter::SetCanInterface(CanHardware* c)
    can->RegisterUserMessage(0x733);//Outlander Inv Msg
 }
 
-void OutlanderInverter::DecodeCAN(int id, uint32_t data[2])
+void OutlanderInverter::DecodeCAN(int id, const uint8_t bytes[8])
 {
+   const uint32_t* data = (uint32_t*)bytes;
+
    switch (id)
    {
    case 0x289:

--- a/src/simpbms.cpp
+++ b/src/simpbms.cpp
@@ -68,7 +68,7 @@ float SimpBMS::MaxChargeCurrent()
 }
 
 // Process voltage and temperature message from SimpBMS.
-void SimpBMS::DecodeCAN(int id, uint8_t *data)
+void SimpBMS::DecodeCAN(int id, const uint8_t data[8])
 {
    if (id == 0x373)
    {

--- a/src/teslaCharger.cpp
+++ b/src/teslaCharger.cpp
@@ -21,9 +21,8 @@ void teslaCharger::SetCanInterface(CanHardware* c)
 
 }
 
-void teslaCharger::DecodeCAN(int id, uint32_t data[2])
+void teslaCharger::DecodeCAN(int id, const uint8_t bytes[8])
 {
-   uint8_t* bytes = (uint8_t*)data;
    if (id == 0x108)
    {
    if(bytes[0]==0xAA) HVreq=true;

--- a/src/vag_sbox.cpp
+++ b/src/vag_sbox.cpp
@@ -49,22 +49,20 @@ void VWBOX::RegisterCanMessages(CanHardware* can)
 
 }
 
-void VWBOX::DecodeCAN(int id, uint32_t data[2])
+void VWBOX::DecodeCAN(int id, const uint8_t bytes[8])
 {
    switch (id)
    {
    case 0x0BB:
-      VWBOX::handle0BB(data);//VWBOX CAN MESSAGE
+      VWBOX::handle0BB(bytes);//VWBOX CAN MESSAGE
       break;
 
    }
 }
 
 
-void VWBOX::handle0BB(uint32_t data[2])  //VWBOX Current and voltages
-
+void VWBOX::handle0BB(const uint8_t bytes[8])  //VWBOX Current and voltages
 {
-   uint8_t* bytes = (uint8_t*)data;// arrgghhh this converts the two 32bit array into bytes. See comments are useful:)
    q12 = (((bytes[2])<<4) | ((bytes[1])>>4));
    Amperes=(q12&0x0800)?(q12|0xF800):q12;//Step1: Copy , Step2: Paste , Step3: Profit!
    Voltage=((bytes[5] << 4) | ((bytes[4]>>4)&0xF));//output voltage


### PR DESCRIPTION
Virtually all CAN callbacks cast the two 32-bit words the libopeninv library presents an incoming CAN
frame in to bytes. Rather than repeat this cast all over the place replace with one central cast and change the interface of the DecodeCAN callback methods.

The exceptions which require reverse casts of byte- arrays back to 32-bit words are:
 - FCChademo
 - E65_Lever
 - OutlanderInverter

These could be changed to access the bytes directly but this would require greater understanding and testing of the code.

The changes are mechanical in nature and should not affect the operation of the code.

Where applicable "override" is used for virtual methods to make it clear to the compiler that virtual functions are being overridden.

Tests:
 - Build for STM32 and Linux