### PR TITLE
Fix clean build due to change in libopencm3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ ifneq ($(shell test -s libopencm3/lib/libopencm3_stm32f1.a && echo -n yes),yes)
 	@printf "  GIT SUBMODULE\n"
 	$(Q)git submodule update --init
 	@printf "  MAKE libopencm3\n"
-	$(Q)${MAKE} -C libopencm3
+	$(Q)${MAKE} -C libopencm3 TARGETS=stm32/f1
 endif
 
 Test:


### PR DESCRIPTION
Commit 48d6693e pulled in an updated libopencm3
for undocumented reasons. In principle this is a good idea as it fixes a nasty stack initialization bug fixed by @uhi22 as discussed in
https://github.com/uhi22/ccs32clara/issues/17.
Unfortunately the fix breaks the libopencm3 build for all platforms except STM32F1.

The fix is to limit the build of libopencm3 to just the STM32F1 platform in the same way as the CCS32clara firmware.

Tests:
 - Carry out a full clean build locally
 - Check GitHub CI build after push before raising a PR