### PR TITLE
Leaf Updates 241113

### DIFF
--- a/include/leafinv.h
+++ b/include/leafinv.h
@@ -35,7 +35,7 @@ public:
    void SetTorque(float torque);
    float GetMotorTemperature() { return motor_temp; }
    float GetInverterTemperature() { return inv_temp; }
-   float GetInverterVoltage() { return voltage / 2; }
+   float GetInverterVoltage() { return voltage; }
    float GetMotorSpeed() { return speed; }
    int GetInverterState() { return error; }
    void SetCanInterface(CanHardware* c);


### PR DESCRIPTION
Leaf Inv UDCinv fix, remove /2 from .h

Leaf PDM fix, only use 0x390 for determining to start charge Add info on available AC current from power

Setup to allow potential using of Spoofed CP and PP with other charge interfaces.