### PR TITLE
HeatReq Fix + PB123 Mapable

### DIFF
--- a/include/digio_prj.h
+++ b/include/digio_prj.h
@@ -2,6 +2,7 @@
  * This file is part of the ZombieVerter project.
  *
  * Copyright (C) 2019-2022 Damien Maguire <info@evbmw.com>
+ * Changes by Tom de Bree <tom@voltinflux.com> 2024
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -42,9 +43,9 @@
     DIG_IO_ENTRY(SL1_out,   GPIOC, GPIO9,  PinMode::OUTPUT)      \
     DIG_IO_ENTRY(SL2_out,   GPIOC, GPIO8,  PinMode::OUTPUT)      \
     DIG_IO_ENTRY(SP_out,    GPIOD, GPIO12, PinMode::OUTPUT)      \
-    DIG_IO_ENTRY(gear1_in,  GPIOE, GPIO3,  PinMode::INPUT_FLT)   \
-    DIG_IO_ENTRY(gear2_in,  GPIOE, GPIO4,  PinMode::INPUT_FLT)   \
-    DIG_IO_ENTRY(gear3_in,  GPIOE, GPIO5,  PinMode::INPUT_FLT)   \
+    DIG_IO_ENTRY(gear1_in,  GPIOE, GPIO3,  PinMode::INPUT_FLT_INV)   \
+    DIG_IO_ENTRY(gear2_in,  GPIOE, GPIO4,  PinMode::INPUT_FLT_INV)   \
+    DIG_IO_ENTRY(gear3_in,  GPIOE, GPIO5,  PinMode::INPUT_FLT_INV)   \
     DIG_IO_ENTRY(req_out,   GPIOE, GPIO6,  PinMode::OUTPUT)      \
     DIG_IO_ENTRY(pot1_cs,   GPIOD, GPIO3,  PinMode::OUTPUT)      \
     DIG_IO_ENTRY(pot2_cs,   GPIOD, GPIO2,  PinMode::OUTPUT)      \

--- a/include/iomatrix.h
+++ b/include/iomatrix.h
@@ -2,6 +2,7 @@
  * This file is part of the tumanako_vc project.
  *
  * Copyright (C) 2018 Johannes Huebner <dev@johanneshuebner.com>
+ * Changes by Tom de Bree <tom@voltinflux.com> 2024
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -46,7 +47,7 @@ class IOMatrix
 
    private:
       static DigIo* functionToPin[LAST];
-      static const int numPins = 10;
+      static const int numPins = 13;
       static DigIo* const paramToPin[numPins];
 
       static AnaIn* functionToPinAnalgoue[LAST_ANAL];

--- a/include/param_prj.h
+++ b/include/param_prj.h
@@ -3,6 +3,7 @@
  *
  * Copyright (C) 2011-2019 Johannes Huebner <dev@johanneshuebner.com>
  * Copyright (C) 2019-2022 Damien Maguire <info@evbmw.com>
+ * Changes by Tom de Bree <tom@voltinflux.com> 2024
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,7 +18,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#define VER 2.20.TN
+#define VER 2.20.TP1
 
 
 /* Entries must be ordered as follows:
@@ -127,7 +128,10 @@
     PARAM_ENTRY(CAT_IOPINS,    PWM2Func,    PINFUNCS,  0,      18,     4,      86 ) \
     PARAM_ENTRY(CAT_IOPINS,    PWM3Func,    PINFUNCS,  0,      18,     2,      87 ) \
     PARAM_ENTRY(CAT_IOPINS,    GP12VInFunc, PINFUNCS,  0,      13,     12,     98 ) \
-    PARAM_ENTRY(CAT_IOPINS,    HVReqFunc,   PINFUNCS,  0,      13,     11,     99 ) \
+    PARAM_ENTRY(CAT_IOPINS,    PB1InFunc,   PINFUNCS,  0,      13,     12,     140 ) \
+    PARAM_ENTRY(CAT_IOPINS,    PB2InFunc,   PINFUNCS,  0,      13,     12,     141 ) \
+    PARAM_ENTRY(CAT_IOPINS,    PB3InFunc,   PINFUNCS,  0,      13,     12,     142 ) \
+    PARAM_ENTRY(CAT_IOPINS,    HVReqFunc,   PINFUNCS,  0,      13,     12,     99 ) \
     PARAM_ENTRY(CAT_IOPINS,    GPA1Func,    APINFUNCS, 0,      2,      0,      110 ) \
     PARAM_ENTRY(CAT_IOPINS,    GPA2Func,    APINFUNCS, 0,      2,      0,      111 ) \
     PARAM_ENTRY(CAT_IOPINS,    ppthresh,    "dig",     0,      4095,   2500,   114 ) \
@@ -317,6 +321,7 @@
 #define CAN_PERIOD_10MS     1
 
 #define FIRST_IO_PARAM Param::Out1Func
+#define SEC_IO_PARAM Param::PB1InFunc
 #define FIRST_AI_PARAM Param::GPA1Func
 enum modes
 {

--- a/src/GS450H.cpp
+++ b/src/GS450H.cpp
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the ZombieVerter project.
+ *
+ * Copyright (C) 2019-2022 Damien Maguire <info@evbmw.com>
+ * Changes by Tom de Bree <tom@voltinflux.com> 2024
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "GS450H.h"
 #include "hwinit.h"
 #include "temp_meas.h"
@@ -318,10 +338,9 @@ void GS450HClass::GS450Houtput()//!!! should be ran every 10ms
 
     if (Param::GetInt(Param::opmode) == MOD_RUN)
     {
-
-        Param::SetInt(Param::Gear1,!DigIo::gear1_in.Get());//update web interface with status of gearbox PB feedbacks for diag purposes.
-        Param::SetInt(Param::Gear2,!DigIo::gear2_in.Get());
-        Param::SetInt(Param::Gear3,!DigIo::gear3_in.Get());
+        Param::SetInt(Param::Gear1,DigIo::gear1_in.Get());//update web interface with status of gearbox PB feedbacks for diag purposes.
+        Param::SetInt(Param::Gear2,DigIo::gear2_in.Get());
+        Param::SetInt(Param::Gear3,DigIo::gear3_in.Get());
         GearSW=((!DigIo::gear3_in.Get()<<2)|(!DigIo::gear2_in.Get()<<1)|(!DigIo::gear1_in.Get()));
         if(GearSW==6) Param::SetInt(Param::GearFB,LOW_Gear);// set low gear
         if(GearSW==5) Param::SetInt(Param::GearFB,HIGH_Gear);// set high gear

--- a/src/iomatrix.cpp
+++ b/src/iomatrix.cpp
@@ -1,6 +1,7 @@
 /*
  * This file is part of the stm32-... project.
  *
+ * Copyright (C) 2024 Tom de Bree <tom@voltinflux.com>
  * Copyright (C) 2021 Johannes Huebner <dev@johanneshuebner.com>
  *
  * This program is free software: you can redistribute it and/or modify
@@ -21,7 +22,7 @@
 DigIo* const IOMatrix::paramToPin[] = { &DigIo::gp_out1, &DigIo::gp_out2, &DigIo::gp_out3,
                                         &DigIo::SL1_out, &DigIo::SL2_out,
                                         &DigIo::PWM1, &DigIo::PWM2, &DigIo::PWM3,&DigIo::gp_12Vin,
-                                        &DigIo::HV_req};
+                                        &DigIo::HV_req,&DigIo::gear1_in,&DigIo::gear2_in,&DigIo::gear3_in};
                                         //order of these matters!
 
 AnaIn* const IOMatrix::paramToPinAnalgue[] = {
@@ -37,9 +38,14 @@ void IOMatrix::AssignFromParams()
       functionToPin[i] = &DigIo::dummypin;
    }
 
-   for (int i = 0; i < numPins; i++)
+   for (int i = 0; i < 10; i++)//First orignal IO pin params
    {
-      functionToPin[Param::GetInt((Param::PARAM_NUM)(FIRST_IO_PARAM + i))] = paramToPin[i];
+      functionToPin[Param::GetInt((Param::PARAM_NUM)(FIRST_IO_PARAM + i))] = paramToPin[i]; //Hard coded so hard coded bodge to fix
+   }
+
+   for (int i = 10; i < numPins; i++)//PB1 PB2 PB3 params
+   {
+      functionToPin[Param::GetInt((Param::PARAM_NUM)(SEC_IO_PARAM + i-10))] = paramToPin[i]; //Hard coded so hard coded bodge to fix
    }
 }
 

--- a/src/stm32_vcu.cpp
+++ b/src/stm32_vcu.cpp
@@ -1,6 +1,7 @@
 /*
  * This file is part of the ZombieVerter project.
  *
+ * Copyright (C) 2024 Tom de Bree <tom@voltinflux.com>
  * Copyright (C) 2010 Johannes Huebner <contact@johanneshuebner.com>
  * Copyright (C) 2010 Edward Cheeseman <cheesemanedward@gmail.com>
  * Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
@@ -438,7 +439,10 @@ static void Ms100Task(void)
         ACrequest=selectedChargeInt->ACRequest(RunChg);
     }
 
-    Param::SetInt(Param::HeatReq,IOMatrix::GetPin(IOMatrix::HEATREQ)->Get());
+    if (IOMatrix::GetPin(IOMatrix::HEATREQ) != &DigIo::dummypin)
+    {
+        Param::SetInt(Param::HeatReq,IOMatrix::GetPin(IOMatrix::HEATREQ)->Get());
+    }
 
     DigiPot::SetPot1Step(); //just for dev
     DigiPot::SetPot2Step(); //just for dev
@@ -680,11 +684,11 @@ static void Ms10Task(void)
             DigIo::dcsw_out.Set();
         }
         ErrorMessage::UnpostAll();
-        if(!chargeMode)		
-		{
-			opmode = MOD_OFF;
-			rlyDly=250;//Recharge sequence timer for delayed shutdown
-		}
+        if(!chargeMode)
+        {
+            opmode = MOD_OFF;
+            rlyDly=250;//Recharge sequence timer for delayed shutdown
+        }
         Param::SetInt(Param::opmode, opmode);
         break;
 
@@ -698,10 +702,10 @@ static void Ms10Task(void)
         Param::SetInt(Param::opmode, MOD_RUN);
         ErrorMessage::UnpostAll();
         if(!selectedVehicle->Ready())
-		{
-			opmode = MOD_OFF;
-			rlyDly=250;//Recharge sequence timer for delayed shutdown
-		}
+        {
+            opmode = MOD_OFF;
+            rlyDly=250;//Recharge sequence timer for delayed shutdown
+        }
         Param::SetInt(Param::opmode, opmode);
         break;
     }


### PR DESCRIPTION
HeatReq - if no input selected it no longer forces a state

Input PB1 PB2 and PB3 are also now mappable. Added Inverter logic options for the pin types.

!!!requires the latest libopeninv