### PR TITLE
Nissan LEAF: Increase robustness by using CRC bit on incoming messages

### DIFF
--- a/include/leafbms.h
+++ b/include/leafbms.h
@@ -25,6 +25,8 @@ class LeafBMS: public BMS
 public:
     void SetCanInterface(CanHardware* can) override;
     void DecodeCAN(int id, uint8_t * data) override;
+private:
+    bool isMessageCorrupt(uint8_t *data);
 };
 
 #endif // LEAFBMS_H

--- a/include/leafinv.h
+++ b/include/leafinv.h
@@ -39,9 +39,8 @@ public:
    float GetMotorSpeed() { return speed; }
    int GetInverterState() { return error; }
    void SetCanInterface(CanHardware* c);
-
 private:
-   static void nissan_crc(uint8_t *data, uint8_t polynomial);
+   uint8_t nissan_crc(uint8_t *data);
    static int8_t fahrenheit_to_celsius(uint16_t fahrenheit);
    uint32_t lastRecv;
    int16_t speed;

--- a/src/leafbms.cpp
+++ b/src/leafbms.cpp
@@ -44,107 +44,140 @@ void LeafBMS::DecodeCAN(int id, uint8_t * data)
 {
     uint8_t* bytes = (uint8_t*)data;
 
-    if (id == 0x1DB)
-    {
-        float cur = uint16_t(bytes[0] << 3) + uint16_t(bytes[1] >>5);
-        if(cur>1023)cur -=2047; //check if negative
-        uint16_t udc = uint16_t(bytes[2] << 2) + uint16_t(bytes[3] >>6);
-        //bool interlock = (bytes[3] & (1 << 3)) >> 3;
-        //bool full = (bytes[3] & (1 << 4)) >> 4;
+    switch (id) {
+        case 0x1DB:{
+            if (isMessageCorrupt(bytes)) {
+                //Message content malformed, abort reading data from it! Raise flag!
+                break;
+            }
+            float cur = uint16_t(bytes[0] << 3) + uint16_t(bytes[1] >>5);
+            if(cur>1023)cur -=2047; //check if negative
+            uint16_t udc = uint16_t(bytes[2] << 2) + uint16_t(bytes[3] >>6);
+            //bool interlock = (bytes[3] & (1 << 3)) >> 3;
+            //bool full = (bytes[3] & (1 << 4)) >> 4;
 
-        if (Param::GetInt(Param::ShuntType) == 0)//Only populate if no shunt is used
-        {
-            float BattCur = cur / 2;
-            float BattVoltage = udc / 2;
-            Param::SetFloat(Param::idc, BattCur);
-            if(BattVoltage < 450)Param::SetFloat(Param::udc2, BattVoltage);
-            if(BattVoltage > 200)Param::SetFloat(Param::udcsw, BattVoltage - 20); //Set for precharging based on actual voltage
-            float kw = (BattVoltage*BattCur)/1000;//get power from isa sensor and post to parameter database
-            Param::SetFloat(Param::power, kw);
+            if (Param::GetInt(Param::ShuntType) == 0)//Only populate if no shunt is used
+            {
+                float BattCur = cur / 2;
+                float BattVoltage = udc / 2;
+                Param::SetFloat(Param::idc, BattCur);
+                if(BattVoltage < 450)Param::SetFloat(Param::udc2, BattVoltage);
+                if(BattVoltage > 200)Param::SetFloat(Param::udcsw, BattVoltage - 20); //Set for precharging based on actual voltage
+                float kw = (BattVoltage*BattCur)/1000;//get power from isa sensor and post to parameter database
+                Param::SetFloat(Param::power, kw);
+            }
+            break;
+        }
+        case 0x1DC: {
+            if (isMessageCorrupt(bytes)) {
+                //Message content malformed, abort reading data from it! Raise flag!
+                break;
+            }
+            float dislimit = uint16_t(bytes[0] << 2) + uint16_t(bytes[1] >>6);
+            dislimit = dislimit*0.25; //Kw discharge limit
+            float chglimit = uint16_t((bytes[1] & 0x3F) << 4) + uint16_t(bytes[2] >>4);
+            chglimit = chglimit*0.25; //Kw charge limit
+            float chargelimit = uint16_t((bytes[2] & 0x0F) << 6) + uint16_t(bytes[3] >>2);
+            chargelimit = chargelimit*0.1; //Kw charger limit
+
+            chargelimit = chargelimit*1000 / Param::GetFloat(Param::udc2);//Transform into Amps
+            //Param::SetFixed(Param::dislim, dislimit / 4);
+
+            Param::SetFloat(Param::BMS_ChargeLim, chargelimit);
+            Param::SetInt(Param::BMS_MaxInput, chglimit);
+            Param::SetInt(Param::BMS_MaxOutput, dislimit);
+            break;
+        }
+        case 0x55B: {
+            if (isMessageCorrupt(bytes)) {
+                //Message content malformed, abort reading data from it! Raise flag!
+                break;
+            }
+            float soc = uint16_t(bytes[0] << 2) + uint16_t(bytes[1] >> 6);
+            if (Param::GetInt(Param::ShuntType) == 0)//Only populate if no shunt is used
+            {
+                soc = soc*0.1;
+                Param::SetFloat(Param::SOC, soc);
+            }
+
+            uint16_t IsoTemp = uint16_t(bytes[4] << 2) + uint16_t(bytes[5] >> 6);
+
+            Param::SetInt(Param::BMS_IsoMeas,IsoTemp);
+            break;
+        }
+        case 0x5BC: {
+            /*
+            int soh = bytes[4] >> 1;
+            int cond = (bytes[6] >> 5) + ((bytes[5] & 0x3) << 3);
+            /nt limres = bytes[5] >> 5;
+
+            //Param::SetInt(Param::limreason, limres);
+
+            //Only acquire quick charge remaining time
+            if (cond == 0)
+            {
+                int time = bytes[7] + ((bytes[6] & 0x1F) << 8);
+
+                //Param::SetInt(Param::chgtime, time);
+            }
+            
+
+            //Param::SetInt(Param::soh, soh);
+            */
+            //0x5BC only contains average battery temperature on ZE0
+            if (LEAF_battery_Type == ZE0_BATTERY) { 
+                temperature = (bytes[3] - 40);
+                Param::SetInt(Param::BMS_Tavg, temperature);
+            }
+            break;
+        }
+        case 0x5C0: {
+            //This temperature only works for 2013-2017 AZE0 LEAF packs, the mux is different on other generations
+            if (LEAF_battery_Type == AZE0_BATTERY) {
+                if ((bytes[0] >> 6) == 1) {  // Mux signalling MAX value 
+                    temperature = ((bytes[2] / 2) - 40); //Effectively has only 7-bit precision, bottom bit is always 0
+                    Param::SetInt(Param::BMS_Tavg, temperature);
+                }
+            }
+            break;
+        }
+        case 0x59E: {
+            //AZE0 2013-2017 or ZE1 2018-2023 battery detected
+            //Only detect as AZE0 if not already set as ZE1
+            if (LEAF_battery_Type != ZE1_BATTERY) {
+                LEAF_battery_Type = AZE0_BATTERY;
+            }
+            break;
+        }
+        case 0x1C2: {
+            //ZE1 2018-2023 battery detected!
+            LEAF_battery_Type = ZE1_BATTERY;
+            break;
+        }
+        case 0x1ED: {
+            //ZE1 62kWh battery detected!
+            LEAF_battery_Type = ZE1_BATTERY;
+            break;
+        }
+        default:
+            break;
+    }
+}
+
+bool LeafBMS::isMessageCorrupt(uint8_t *data)
+{
+    uint8_t crc = 0;
+    uint8_t polynomial = 0x85;
+
+    for (int b = 0; b < 8; b++) {
+        uint8_t byte = (b == 7) ? 0 : data[b]; // Treat 8th byte as 0 during calculation.
+        for (int i = 7; i >= 0; i--) {
+            uint8_t bit = ((byte & (1 << i)) > 0) ? 1 : 0;
+            if (crc >= 0x80)
+                crc = (uint8_t)(((crc << 1) + bit) ^ polynomial);
+            else
+                crc = (uint8_t)((crc << 1) + bit);
         }
     }
-    else if (id == 0x1DC)
-    {
-        float dislimit = uint16_t(bytes[0] << 2) + uint16_t(bytes[1] >>6);
-        dislimit = dislimit*0.25; //Kw discharge limit
-        float chglimit = uint16_t((bytes[1] & 0x3F) << 4) + uint16_t(bytes[2] >>4);
-        chglimit = chglimit*0.25; //Kw charge limit
-        float chargelimit = uint16_t((bytes[2] & 0x0F) << 6) + uint16_t(bytes[3] >>2);
-        chargelimit = chargelimit*0.1; //Kw charger limit
-
-        chargelimit = chargelimit*1000 / Param::GetFloat(Param::udc2);//Transform into Amps
-        //Param::SetFixed(Param::dislim, dislimit / 4);
-
-        Param::SetFloat(Param::BMS_ChargeLim, chargelimit);
-
-        Param::SetInt(Param::BMS_MaxInput, chglimit);
-        Param::SetInt(Param::BMS_MaxOutput, dislimit);
-    }
-    else if (id == 0x55B)
-    {
-        float soc = uint16_t(bytes[0] << 2) + uint16_t(bytes[1] >> 6);
-        if (Param::GetInt(Param::ShuntType) == 0)//Only populate if no shunt is used
-        {
-            soc = soc*0.1;
-            Param::SetFloat(Param::SOC, soc);
-        }
-
-        uint16_t IsoTemp = uint16_t(bytes[4] << 2) + uint16_t(bytes[5] >> 6);
-
-        Param::SetInt(Param::BMS_IsoMeas,IsoTemp);
-    }
-    else if (id == 0x5BC)
-    {
-        /*
-        int soh = bytes[4] >> 1;
-        int cond = (bytes[6] >> 5) + ((bytes[5] & 0x3) << 3);
-        /nt limres = bytes[5] >> 5;
-
-        //Param::SetInt(Param::limreason, limres);
-
-        //Only acquire quick charge remaining time
-        if (cond == 0)
-        {
-            int time = bytes[7] + ((bytes[6] & 0x1F) << 8);
-
-            //Param::SetInt(Param::chgtime, time);
-        }
-        
-
-        //Param::SetInt(Param::soh, soh);
-        */
-        //0x5BC only contains average battery temperature on ZE0
-        if (LEAF_battery_Type == ZE0_BATTERY) { 
-            temperature = (bytes[3] - 40);
-            Param::SetInt(Param::BMS_Tavg, temperature);
-        }
-    }
-    else if (id == 0x5C0)
-    {
-      //This temperature only works for 2013-2017 AZE0 LEAF packs, the mux is different on other generations
-      if (LEAF_battery_Type == AZE0_BATTERY) {
-        if ((bytes[0] >> 6) == 1) {  // Mux signalling MAX value 
-          temperature = ((bytes[2] / 2) - 40); //Effectively has only 7-bit precision, bottom bit is always 0
-          Param::SetInt(Param::BMS_Tavg, temperature);
-        }
-      }
-    }
-    else if (id == 0x59E)
-    {
-      //AZE0 2013-2017 or ZE1 2018-2023 battery detected
-      //Only detect as AZE0 if not already set as ZE1
-      if (LEAF_battery_Type != ZE1_BATTERY) {
-        LEAF_battery_Type = AZE0_BATTERY;
-      }
-    }
-    else if (id == 0x1C2)
-    {
-      //ZE1 2018-2023 battery detected!
-      LEAF_battery_Type = ZE1_BATTERY;
-    }
-    else if (id == 0x1ED)
-    {
-      //ZE1 62kWh battery detected!
-      LEAF_battery_Type = ZE1_BATTERY;
-    }
+    return crc != data[7];
 }


### PR DESCRIPTION
### What
This PR adds CRC checking on all incoming LEAF BMS messages that have a CRC

### Why
EV conversions and high voltage systems are noisy. Incase a high voltage connection comes too close to an unshielded CAN network, message data can become corrupt. Incase the VCU interprets one of these corrupt frames, it can wreck havoc on the decision making (Imagine suddenly seeing undervoltage and the vehicle cuts out at a critical moment!). This is why OEMs use CRCs, counters and other methods to ensure CAN data is valid.

### How
We now use the already existing CRC algorithm used to sign outgoing messages, in reverse. Incoming messages get their CRC byte inspected, incase we notice that the actual value deviates from the calculated CRC, we simply discard the message.

> [!WARNING]  
> Code has not been tested on a vehicle, only on simulated values. Please test on a vehicle equipped with LEAF BMS before merging.

For future development, we should consider incrementing a counter/flag/event that corrupted CAN messages have been detected.
