### PR TITLE
IS300h FIX

### DIFF
--- a/include/param_prj.h
+++ b/include/param_prj.h
@@ -18,7 +18,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#define VER 2.20.A
+#define VER 2.21.A
 
 
 /* Entries must be ordered as follows:

--- a/src/GS450H.cpp
+++ b/src/GS450H.cpp
@@ -704,11 +704,14 @@ void GS450HClass::Task1Ms()
 
             statusInv=0;
             //inv_status=0; Stop reinit of inverter
+            /* PART OF 2.20A Changes that stopped working
+            //inv_status=0; Stop reinit of inverter
             //set speeds to 0 to prevent dynamic throttle/regen issues
             mg1_speed=0;
             mg2_speed=0;
             //disable cruise
             Param::SetInt(Param::cruisespeed, 0);
+            */
         }
         else
         {


### PR DESCRIPTION
IS300h had issues of inverter comms being dead. Now resolved  by removing MG1 and MG2 speed reset. Needs further investigation in the future on how to resolve comms loss.

-Tested on Andybp Z4 with IS300h

ADDED uprevision in release prep.