### PR TITLE
Deal with ppValue == ppThresh scenario

### DIFF
--- a/src/stm32_vcu.cpp
+++ b/src/stm32_vcu.cpp
@@ -122,7 +122,7 @@ static CanHardware* canInterface[3];
 static CanMap* canMap;
 static ChargeModes targetCharger;
 static ChargeInterfaces targetChgint;
-static uint8_t ChgSet;
+static uint8_t ChgSet;  // Temp variable storing Param::Chgctrl. 0=enable, 1=disable, 2=timer.
 static bool RunChg;
 static uint8_t ChgHrs_tmp;
 static uint8_t ChgMins_tmp;
@@ -248,13 +248,11 @@ static void Ms200Task(void)
     if(Param::GetInt(Param::GPA1Func) == IOMatrix::PILOT_PROX || Param::GetInt(Param::GPA2Func) == IOMatrix::PILOT_PROX )
     {
         int ppThresh = Param::GetInt(Param::ppthresh);
-
         int ppValue = IOMatrix::GetAnaloguePin(IOMatrix::PILOT_PROX)->Get();
         Param::SetInt(Param::PPVal, ppValue);
 
-
-        //if PP is less than threshold and currently disabled and not already finished
-        if (ppValue < ppThresh && ChgSet==1 && !ChgLck)
+        // If PP is at or below threshold and currently disabled and not already finished
+        if (ppValue <= ppThresh && ChgSet==1 && !ChgLck)
         {
             RunChg=true;
         }


### PR DESCRIPTION
There's a possible bug here. The code deals with `ppValue < ppThresh` and `ppValue > ppThresh` but not `ppValue == ppThresh`. It's probably not likely that this would occur often, but it could lead weird behavior when ppValue is near ppThresh. Noise could possibly produce irratic results. E.g., plug in first time, charge fails, plug in second time, charge succeeds.

I've set the `==` condition on the positive side because I think that is what the user expectation would be.

Another option would be to set the `==` on the negative side.

Yet another option would be to remove the `if (ppValue > ppThresh)` condition from the else block.