### PR TITLE
Reordering of Throttle ramping eliminating ramping of limits

### DIFF
--- a/include/param_prj.h
+++ b/include/param_prj.h
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#define VER 2.22.A
+#define VER 2.30.A
 
 
 /* Entries must be ordered as follows:

--- a/src/throttle.cpp
+++ b/src/throttle.cpp
@@ -382,7 +382,7 @@ void Throttle::UdcLimitCommand(float& finalSpnt, float udc)
             }
             else if(UDCprevspnt < finalSpnt)//if out UDCprevspnt is under the final spnt increase this back up
             {
-                UDCprevspnt = RAMPUP(UDCprevspnt, UDCres, throttleRamp);
+                //UDCprevspnt = RAMPUP(UDCprevspnt, UDCres, throttleRamp);
             }
             else
             {

--- a/src/throttle.cpp
+++ b/src/throttle.cpp
@@ -145,7 +145,7 @@ float Throttle::CalcThrottle(int potval, int potIdx, bool brkpedal)
     int dir = Param::GetInt(Param::dir);
     float potnom = 0.0f;  // normalize potval against the potmin and potmax values
 
-    if(speed< 0)//make sure speed is not negative
+    if(speed < 0)//make sure speed is not negative
     {
         speed *= -1;
     }
@@ -372,23 +372,23 @@ void Throttle::UdcLimitCommand(float& finalSpnt, float udc)
             float udcErr = udc - udcmin;
             UDCres = udcErr * 3.5; // error multiplied by
             UDCres = MAX(0, UDCres); // only allow positive UDCres limit
-/*
-            if(UDCprevspnt > UDCres) //if udc limit potnom spnt is lower ramp down to it
-            {
-                UDCprevspnt = RAMPDOWN(UDCprevspnt, UDCres, throttleRamp);
-                DerateReason |= 1;
-                Param::SetInt(Param::TorqDerate,DerateReason);
-            }
-            else if(UDCprevspnt < finalSpnt)//if out UDCprevspnt is under the final spnt increase this back up
-            {
-                //UDCprevspnt = RAMPUP(UDCprevspnt, UDCres, throttleRamp);
-            }
-            else
-            {
-                UDCprevspnt = finalSpnt;
-            }
-            finalSpnt = UDCprevspnt;
-            */
+            /*//OLD - Throttle ramping reorganised in V2.30A
+                        if(UDCprevspnt > UDCres) //if udc limit potnom spnt is lower ramp down to it
+                        {
+                            UDCprevspnt = RAMPDOWN(UDCprevspnt, UDCres, throttleRamp);
+                            DerateReason |= 1;
+                            Param::SetInt(Param::TorqDerate,DerateReason);
+                        }
+                        else if(UDCprevspnt < finalSpnt)//if out UDCprevspnt is under the final spnt increase this back up
+                        {
+                            //UDCprevspnt = RAMPUP(UDCprevspnt, UDCres, throttleRamp);
+                        }
+                        else
+                        {
+                            UDCprevspnt = finalSpnt;
+                        }
+                        finalSpnt = UDCprevspnt;
+                        */
 
             finalSpnt = MIN(finalSpnt, UDCres);
         }
@@ -397,23 +397,23 @@ void Throttle::UdcLimitCommand(float& finalSpnt, float udc)
             float udcErr = udc - udcmax;
             UDCres = udcErr * 3.5;
             UDCres = MIN(0, UDCres);
-/*
-            if(UDCprevspnt < UDCres)
-            {
-                UDCprevspnt = RAMPUP(UDCprevspnt, UDCres, regenRamp);
-                DerateReason |= 2;
-                Param::SetInt(Param::TorqDerate,DerateReason);
-            }
-            else if(UDCprevspnt > finalSpnt)//if out UDCprevspnt is over the final spnt decrease to meet finalspnt
-            {
-                UDCprevspnt = RAMPDOWN(UDCprevspnt, UDCres, regenRamp);
-            }
-            else
-            {
-                UDCprevspnt = finalSpnt;
-            }
-            finalSpnt = UDCprevspnt;
-            */
+            /*//OLD - Throttle ramping reorganised in V2.30A
+                        if(UDCprevspnt < UDCres)
+                        {
+                            UDCprevspnt = RAMPUP(UDCprevspnt, UDCres, regenRamp);
+                            DerateReason |= 2;
+                            Param::SetInt(Param::TorqDerate,DerateReason);
+                        }
+                        else if(UDCprevspnt > finalSpnt)//if out UDCprevspnt is over the final spnt decrease to meet finalspnt
+                        {
+                            UDCprevspnt = RAMPDOWN(UDCprevspnt, UDCres, regenRamp);
+                        }
+                        else
+                        {
+                            UDCprevspnt = finalSpnt;
+                        }
+                        finalSpnt = UDCprevspnt;
+                        */
             finalSpnt = MAX(finalSpnt, UDCres);
 
         }
@@ -443,6 +443,7 @@ void Throttle::IdcLimitCommand(float& finalSpnt, float idc)
             IDCres = idcerr * 1;//gain needs tuning
             IDCres = MAX(0, IDCres);
 
+            /* //OLD - Throttle ramping reorganised in V2.30A
             if(IDCprevspnt> IDCres)
             {
                 IDCprevspnt = RAMPDOWN(IDCprevspnt, IDCres, throttleRamp);
@@ -458,6 +459,8 @@ void Throttle::IdcLimitCommand(float& finalSpnt, float idc)
                 IDCprevspnt = finalSpnt;
             }
             finalSpnt = IDCprevspnt;
+            */
+            finalSpnt = MIN(finalSpnt, IDCres);
         }
         else
         {
@@ -465,22 +468,23 @@ void Throttle::IdcLimitCommand(float& finalSpnt, float idc)
             float idcerr = idcmin + idcFiltered;
             IDCres = idcerr * 1;//gain needs tuning
             IDCres = MIN(0, IDCres);
-
-            if(finalSpnt < IDCres)
-            {
-                IDCprevspnt = RAMPUP(IDCprevspnt, IDCres, regenRamp);
-                DerateReason |= 4;
-                Param::SetInt(Param::TorqDerate,DerateReason);
-            }
-            else if(IDCprevspnt > finalSpnt)//if out UDCprevspnt is over the final spnt decrease to meet finalspnt
-            {
-                IDCprevspnt = RAMPDOWN(IDCprevspnt, IDCres, regenRamp);
-            }
-            else
-            {
-                IDCprevspnt = finalSpnt;
-            }
-            finalSpnt = IDCprevspnt;
+            /* //OLD - Throttle ramping reorganised in V2.30A
+                        if(finalSpnt < IDCres)
+                        {
+                            IDCprevspnt = RAMPUP(IDCprevspnt, IDCres, regenRamp);
+                            DerateReason |= 4;
+                            Param::SetInt(Param::TorqDerate,DerateReason);
+                        }
+                        else if(IDCprevspnt > finalSpnt)//if out UDCprevspnt is over the final spnt decrease to meet finalspnt
+                        {
+                            IDCprevspnt = RAMPDOWN(IDCprevspnt, IDCres, regenRamp);
+                        }
+                        else
+                        {
+                            IDCprevspnt = finalSpnt;
+                        }
+                        */
+            finalSpnt = MAX(finalSpnt, IDCres);
         }
     }
     else

--- a/src/throttle.cpp
+++ b/src/throttle.cpp
@@ -52,8 +52,8 @@ int Throttle::speedLimit;
 float Throttle::ThrotRpmFilt;
 float UDCres;
 float IDCres;
-float UDCprevspnt;
-float IDCprevspnt;
+float UDCprevspnt = 0;
+float IDCprevspnt = 0;
 
 // internal variable, reused every time the function is called
 static float throttleRamped = 0.0;
@@ -367,13 +367,12 @@ void Throttle::UdcLimitCommand(float& finalSpnt, float udc)
 
     if(udcmin>0)    //ignore if set to zero. useful for bench testing without isa shunt
     {
-        if (finalSpnt >= 0)
+        if (finalSpnt >= 0) //if we are requesting torque
         {
-
             float udcErr = udc - udcmin;
-            UDCres = udcErr * 5;
-            UDCres = MAX(0, UDCres);
-
+            UDCres = udcErr * 3.5; // error multiplied by
+            UDCres = MAX(0, UDCres); // only allow positive UDCres limit
+/*
             if(UDCprevspnt > UDCres) //if udc limit potnom spnt is lower ramp down to it
             {
                 UDCprevspnt = RAMPDOWN(UDCprevspnt, UDCres, throttleRamp);
@@ -389,13 +388,16 @@ void Throttle::UdcLimitCommand(float& finalSpnt, float udc)
                 UDCprevspnt = finalSpnt;
             }
             finalSpnt = UDCprevspnt;
+            */
+
+            finalSpnt = MIN(finalSpnt, UDCres);
         }
         else
         {
             float udcErr = udc - udcmax;
             UDCres = udcErr * 3.5;
             UDCres = MIN(0, UDCres);
-
+/*
             if(UDCprevspnt < UDCres)
             {
                 UDCprevspnt = RAMPUP(UDCprevspnt, UDCres, regenRamp);
@@ -411,6 +413,9 @@ void Throttle::UdcLimitCommand(float& finalSpnt, float udc)
                 UDCprevspnt = finalSpnt;
             }
             finalSpnt = UDCprevspnt;
+            */
+            finalSpnt = MAX(finalSpnt, UDCres);
+
         }
     }
     else

--- a/src/throttle.cpp
+++ b/src/throttle.cpp
@@ -144,7 +144,7 @@ float Throttle::CalcThrottle(int potval, int potIdx, bool brkpedal)
     int speed = Param::GetInt(Param::speed);
     int dir = Param::GetInt(Param::dir);
     float potnom = 0.0f;  // normalize potval against the potmin and potmax values
-
+/*
     if(speed< 0)//make sure speed is not negative
     {
         speed *= -1;
@@ -170,7 +170,7 @@ float Throttle::CalcThrottle(int potval, int potIdx, bool brkpedal)
     speed = SpeedFiltered;
 
     ///////////////////////
-
+*/
     if(dir == 0)//neutral no torque command
     {
         return 0;
@@ -182,6 +182,7 @@ float Throttle::CalcThrottle(int potval, int potIdx, bool brkpedal)
         {
             return 0;
         }
+        /*
         else if (speed < regenRpm)
         {
             potnom = utils::change(speed, regenendRpm, regenRpm, 0, regenBrake);//taper regen according to speed
@@ -192,6 +193,7 @@ float Throttle::CalcThrottle(int potval, int potIdx, bool brkpedal)
             potnom =  regenBrake;
             return potnom;
         }
+        */
     }
 
     // substract offset, bring potval to the potmin-potmax scale and make a percentage
@@ -208,7 +210,7 @@ float Throttle::CalcThrottle(int potval, int potIdx, bool brkpedal)
     {
         potnom = (potnom - throtdead) * (100.0f / (100.0f - throtdead));
     }
-
+/*
 //!! pedal command intent coding
 
     PedalPos = potnom; //save comparison next time to check if pedal had moved
@@ -268,6 +270,8 @@ float Throttle::CalcThrottle(int potval, int potIdx, bool brkpedal)
     }
 
     LastPedalPos = PedalPos; //Save current pedal position for next loop.
+    */
+
     return potnom;
 }
 

--- a/src/throttle.cpp
+++ b/src/throttle.cpp
@@ -415,6 +415,7 @@ void Throttle::UdcLimitCommand(float& finalSpnt, float udc)
     }
     else
     {
+        finalSpnt = UDCprevspnt;
         finalSpnt = finalSpnt;
     }
 }

--- a/src/throttle.cpp
+++ b/src/throttle.cpp
@@ -144,33 +144,33 @@ float Throttle::CalcThrottle(int potval, int potIdx, bool brkpedal)
     int speed = Param::GetInt(Param::speed);
     int dir = Param::GetInt(Param::dir);
     float potnom = 0.0f;  // normalize potval against the potmin and potmax values
-/*
-    if(speed< 0)//make sure speed is not negative
-    {
-        speed *= -1;
-    }
-
-    //limiting speed change rate
-    if(ABS(speed-SpeedFiltered)>ThrotRpmFilt)
-    {
-        if(speed > SpeedFiltered)
+    /*
+        if(speed< 0)//make sure speed is not negative
         {
-            SpeedFiltered +=  ThrotRpmFilt;
+            speed *= -1;
+        }
+
+        //limiting speed change rate
+        if(ABS(speed-SpeedFiltered)>ThrotRpmFilt)
+        {
+            if(speed > SpeedFiltered)
+            {
+                SpeedFiltered +=  ThrotRpmFilt;
+            }
+            else
+            {
+                SpeedFiltered -=  ThrotRpmFilt;
+            }
         }
         else
         {
-            SpeedFiltered -=  ThrotRpmFilt;
+            SpeedFiltered = speed;
         }
-    }
-    else
-    {
-        SpeedFiltered = speed;
-    }
 
-    speed = SpeedFiltered;
+        speed = SpeedFiltered;
 
-    ///////////////////////
-*/
+        ///////////////////////
+    */
     if(dir == 0)//neutral no torque command
     {
         return 0;
@@ -178,20 +178,22 @@ float Throttle::CalcThrottle(int potval, int potIdx, bool brkpedal)
 
     if (brkpedal)
     {
+        potnom = 0; //V2.05
+        return potnom; //V2.05
+        /*
         if(speed < 100 || speed < regenendRpm)
         {
-            return 0;
+           return 0;
         }
-        /*
         else if (speed < regenRpm)
         {
-            potnom = utils::change(speed, regenendRpm, regenRpm, 0, regenBrake);//taper regen according to speed
-            return potnom;
+           potnom = utils::change(speed, regenendRpm, regenRpm, 0, regenBrake);//taper regen according to speed
+           return potnom;
         }
         else
         {
-            potnom =  regenBrake;
-            return potnom;
+           potnom =  regenBrake;
+           return potnom;
         }
         */
     }
@@ -210,67 +212,67 @@ float Throttle::CalcThrottle(int potval, int potIdx, bool brkpedal)
     {
         potnom = (potnom - throtdead) * (100.0f / (100.0f - throtdead));
     }
-/*
-//!! pedal command intent coding
+    /*
+    //!! pedal command intent coding
 
-    PedalPos = potnom; //save comparison next time to check if pedal had moved
+        PedalPos = potnom; //save comparison next time to check if pedal had moved
 
-    float TempAvgPos = AveragePos(PedalPos); //get an rolling average pedal position over the last 50 measurements for smoothing
+        float TempAvgPos = AveragePos(PedalPos); //get an rolling average pedal position over the last 50 measurements for smoothing
 
-    PedalChange = PedalPos - TempAvgPos; //current pedal position compared to average
-
-
-    if(PedalChange < -1.0 )//Check pedal is release compared to last time
-    {
-        PedalReq = -1; //pedal is released enough - Commanding regen or slowing
-    }
-    else if(PedalChange > 1.0 )//Check pedal is increased compared to last time
-    {
-        PedalReq = 1; //pedal pressed - Commanding accelerating - thus always more power
-    }
-    else//pedal not changed
-    {
-        potnom = TempAvgPos; //use the averaged pedal
-    }
+        PedalChange = PedalPos - TempAvgPos; //current pedal position compared to average
 
 
-    //Do clever bits for regen and such.
+        if(PedalChange < -1.0 )//Check pedal is release compared to last time
+        {
+            PedalReq = -1; //pedal is released enough - Commanding regen or slowing
+        }
+        else if(PedalChange > 1.0 )//Check pedal is increased compared to last time
+        {
+            PedalReq = 1; //pedal pressed - Commanding accelerating - thus always more power
+        }
+        else//pedal not changed
+        {
+            potnom = TempAvgPos; //use the averaged pedal
+        }
 
 
-    if(speed < 100 || speed <regenendRpm)//No regen under 100 rpm or speed under regenendRpm
-    {
-        regenlim = 0;
-    }
-    else if(speed < regenRpm)
-    {
-        regenlim = utils::change(speed, regenendRpm, regenRpm, 0, regenmax);//taper regen according to speed
-    }
-    else
-    {
-        regenlim = regenmax;
-    }
+        //Do clever bits for regen and such.
 
 
-    //!!!potnom is throttle position up to this point//
-
-    if(dir == 1)//Forward
-    {
-        //change limits to uint32, multiply by 10 then 0.1 to add a decimal to remove the hard edges
-        potnom = utils::change(potnom,0,100,regenlim*10,throtmax*10);
-        potnom *= 0.1;
-    }
-    else //Reverse, as neutral already exited function
-    {
-        if(Param::GetInt(Param::revRegen) == 0)//If regen in reverse is to be off
+        if(speed < 100 || speed <regenendRpm)//No regen under 100 rpm or speed under regenendRpm
         {
             regenlim = 0;
         }
-        potnom = utils::change(potnom,0,100,regenlim*10,throtmaxRev*10);
-        potnom *= 0.1;
-    }
+        else if(speed < regenRpm)
+        {
+            regenlim = utils::change(speed, regenendRpm, regenRpm, 0, regenmax);//taper regen according to speed
+        }
+        else
+        {
+            regenlim = regenmax;
+        }
 
-    LastPedalPos = PedalPos; //Save current pedal position for next loop.
-    */
+
+        //!!!potnom is throttle position up to this point//
+
+        if(dir == 1)//Forward
+        {
+            //change limits to uint32, multiply by 10 then 0.1 to add a decimal to remove the hard edges
+            potnom = utils::change(potnom,0,100,regenlim*10,throtmax*10);
+            potnom *= 0.1;
+        }
+        else //Reverse, as neutral already exited function
+        {
+            if(Param::GetInt(Param::revRegen) == 0)//If regen in reverse is to be off
+            {
+                regenlim = 0;
+            }
+            potnom = utils::change(potnom,0,100,regenlim*10,throtmaxRev*10);
+            potnom *= 0.1;
+        }
+
+        LastPedalPos = PedalPos; //Save current pedal position for next loop.
+        */
 
     return potnom;
 }

--- a/src/throttle.cpp
+++ b/src/throttle.cpp
@@ -144,7 +144,7 @@ float Throttle::CalcThrottle(int potval, int potIdx, bool brkpedal)
     int speed = Param::GetInt(Param::speed);
     int dir = Param::GetInt(Param::dir);
     float potnom = 0.0f;  // normalize potval against the potmin and potmax values
-/*
+
     if(speed< 0)//make sure speed is not negative
     {
         speed *= -1;
@@ -170,7 +170,7 @@ float Throttle::CalcThrottle(int potval, int potIdx, bool brkpedal)
     speed = SpeedFiltered;
 
     ///////////////////////
-*/
+
     if(dir == 0)//neutral no torque command
     {
         return 0;
@@ -182,7 +182,6 @@ float Throttle::CalcThrottle(int potval, int potIdx, bool brkpedal)
         {
             return 0;
         }
-        /*
         else if (speed < regenRpm)
         {
             potnom = utils::change(speed, regenendRpm, regenRpm, 0, regenBrake);//taper regen according to speed
@@ -193,7 +192,6 @@ float Throttle::CalcThrottle(int potval, int potIdx, bool brkpedal)
             potnom =  regenBrake;
             return potnom;
         }
-        */
     }
 
     // substract offset, bring potval to the potmin-potmax scale and make a percentage
@@ -210,7 +208,7 @@ float Throttle::CalcThrottle(int potval, int potIdx, bool brkpedal)
     {
         potnom = (potnom - throtdead) * (100.0f / (100.0f - throtdead));
     }
-/*
+
 //!! pedal command intent coding
 
     PedalPos = potnom; //save comparison next time to check if pedal had moved
@@ -270,8 +268,6 @@ float Throttle::CalcThrottle(int potval, int potIdx, bool brkpedal)
     }
 
     LastPedalPos = PedalPos; //Save current pedal position for next loop.
-    */
-
     return potnom;
 }
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -405,8 +405,7 @@ float ProcessThrottle(int speed)
         finalSpnt = MAX(cruiseThrottle, finalSpnt);
     }
 */
-    finalSpnt = Throttle::RampThrottle(finalSpnt);
-
+    //finalSpnt = Throttle::RampThrottle(finalSpnt);
 
     Throttle::UdcLimitCommand(finalSpnt,Param::GetFloat(Param::udc));
     //Throttle::IdcLimitCommand(finalSpnt, ABS(Param::GetFloat(Param::idc)));
@@ -421,6 +420,8 @@ float ProcessThrottle(int speed)
     {
         ErrorMessage::Post(ERR_TMPMMAX);
     }
+
+    finalSpnt = Throttle::RampThrottle(finalSpnt); //Move ramping as last step
 
     // make sure the torque percentage is NEVER out of range
     if (finalSpnt < -100.0f)

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -394,7 +394,7 @@ float ProcessThrottle(int speed)
 
     finalSpnt = utils::GetUserThrottleCommand();
 
-    /*
+    /* No Cruise allowed
     if (Param::Get(Param::cruisespeed) > 0)
     {
         Throttle::brkcruise = 0;
@@ -405,10 +405,10 @@ float ProcessThrottle(int speed)
         finalSpnt = MAX(cruiseThrottle, finalSpnt);
     }
 */
-    //finalSpnt = Throttle::RampThrottle(finalSpnt);
+    //finalSpnt = Throttle::RampThrottle(finalSpnt); //OLD - Throttle ramping reorganised in V2.30A
 
     Throttle::UdcLimitCommand(finalSpnt,Param::GetFloat(Param::udc));
-    //Throttle::IdcLimitCommand(finalSpnt, ABS(Param::GetFloat(Param::idc)));
+    Throttle::IdcLimitCommand(finalSpnt, ABS(Param::GetFloat(Param::idc)));
     Throttle::SpeedLimitCommand(finalSpnt, ABS(speed));
 
     if (Throttle::TemperatureDerate(Param::Get(Param::tmphs), Param::Get(Param::tmphsmax), finalSpnt))
@@ -421,7 +421,7 @@ float ProcessThrottle(int speed)
         ErrorMessage::Post(ERR_TMPMMAX);
     }
 
-    finalSpnt = Throttle::RampThrottle(finalSpnt); //Move ramping as last step
+    finalSpnt = Throttle::RampThrottle(finalSpnt); //Move ramping as last step -intro V2.30A
 
     // make sure the torque percentage is NEVER out of range
     if (finalSpnt < -100.0f)

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -394,6 +394,7 @@ float ProcessThrottle(int speed)
 
     finalSpnt = utils::GetUserThrottleCommand();
 
+    /*
     if (Param::Get(Param::cruisespeed) > 0)
     {
         Throttle::brkcruise = 0;
@@ -403,13 +404,13 @@ float ProcessThrottle(int speed)
         float cruiseThrottle = Throttle::CalcCruiseSpeed(ABS(Param::GetInt(Param::speed)));
         finalSpnt = MAX(cruiseThrottle, finalSpnt);
     }
-
+*/
     finalSpnt = Throttle::RampThrottle(finalSpnt);
 
 
-    Throttle::UdcLimitCommand(finalSpnt,Param::GetFloat(Param::udc));
-    Throttle::IdcLimitCommand(finalSpnt, ABS(Param::GetFloat(Param::idc)));
-    Throttle::SpeedLimitCommand(finalSpnt, ABS(speed));
+    //Throttle::UdcLimitCommand(finalSpnt,Param::GetFloat(Param::udc));
+    //Throttle::IdcLimitCommand(finalSpnt, ABS(Param::GetFloat(Param::idc)));
+    //Throttle::SpeedLimitCommand(finalSpnt, ABS(speed));
 
     if (Throttle::TemperatureDerate(Param::Get(Param::tmphs), Param::Get(Param::tmphsmax), finalSpnt))
     {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -410,7 +410,7 @@ float ProcessThrottle(int speed)
 
     //Throttle::UdcLimitCommand(finalSpnt,Param::GetFloat(Param::udc));
     //Throttle::IdcLimitCommand(finalSpnt, ABS(Param::GetFloat(Param::idc)));
-    //Throttle::SpeedLimitCommand(finalSpnt, ABS(speed));
+    Throttle::SpeedLimitCommand(finalSpnt, ABS(speed));
 
     if (Throttle::TemperatureDerate(Param::Get(Param::tmphs), Param::Get(Param::tmphsmax), finalSpnt))
     {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -408,7 +408,7 @@ float ProcessThrottle(int speed)
     finalSpnt = Throttle::RampThrottle(finalSpnt);
 
 
-    //Throttle::UdcLimitCommand(finalSpnt,Param::GetFloat(Param::udc));
+    Throttle::UdcLimitCommand(finalSpnt,Param::GetFloat(Param::udc));
     //Throttle::IdcLimitCommand(finalSpnt, ABS(Param::GetFloat(Param::idc)));
     Throttle::SpeedLimitCommand(finalSpnt, ABS(speed));
 


### PR DESCRIPTION
IMPROVEMENT

Issue:
Small blip and instability noticed, not always log-able, when apply low throttle levels. Issue traced to IDC and UDC limiters.

Fix:
Simplification of limiters  and moving the throttle ramp to last step in PotNom calculation

Additional Change:
Cruise code potential impact on throttle removed fully disabled. Never reachable except via SDO mapping.