### PR TITLE
Add Enable_Analog Heater Control and PWMHeater

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ OBJSL		= $(BINARY).o hwinit.o stm32scheduler.o params.o terminal.o terminal_prj.
            daisychainbms.o simpbms.o outlanderCharger.o Can_OBD2.o cansdo.o TeslaDCDC.o BMW_E31.o F30_Lever.o \
            CPC.o ElconCharger.o RearOutlanderinverter.o linbus.o VWCoolantHeater.o JLR_G1.o JLR_G2.o Foccci.o digipot.o\
 	   OutlanderHeartBeat.o E65_Lever.o leafbms.o V_Classic.o kangoobms.o OutlanderCanHeater.o VWAirHeater.o\
-	   MGCoolantHeater.o NissLeafMng.o
+	   MGCoolantHeater.o NissLeafMng.o  PWMHeater.o
            
 OBJS     = $(patsubst %.o,$(OUT_DIR)/%.o, $(OBJSL))
 vpath %.c src/ libopeninv/src/

--- a/include/PWMHeater.h
+++ b/include/PWMHeater.h
@@ -1,0 +1,34 @@
+/*
+ * This file is part of the ZombieVerter project.
+ *
+ * Copyright (C) 2018 Johannes Huebner <dev@johanneshuebner.com>
+ *               2021-2022 Damien Maguire <info@evbmw.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef PWMHEATER_H
+#define PWMHEATER_H
+
+#include <heater.h>
+#include <libopencm3/stm32/timer.h>
+
+class PWMHeater : public Heater {
+public:
+  /** Default constructor */
+  PWMHeater();
+  void SetTargetTemperature(float temp) { (void)temp; } // Not supported (yet)?
+  void SetPower(uint16_t power, bool HeatReq);
+};
+
+#endif // PWMHEATER_H

--- a/include/iomatrix.h
+++ b/include/iomatrix.h
@@ -53,7 +53,13 @@ public: // order of these matters!
     LAST
   };
   // order of these matters!
-  enum analoguepinfuncs { NONE_ANAL, PILOT_PROX, VAC_SENSOR, LAST_ANAL };
+  enum analoguepinfuncs {
+    NONE_ANAL,
+    PILOT_PROX,
+    VAC_SENSOR,
+    CAB_HEAT_TEMP,
+    LAST_ANAL
+  };
 
   static void AssignFromParams();
   static void AssignFromParamsAnalogue();

--- a/include/param_prj.h
+++ b/include/param_prj.h
@@ -26,7 +26,7 @@
    2. Temporary parameters (id = 0)
    3. Display values
  */
-// Next param id (increase when adding new parameter!): 149
+// Next param id (increase when adding new parameter!): 153
 /*              category     name         unit       min     max     default id
  */
 #define PARAM_LIST                                                             \
@@ -108,10 +108,13 @@
   PARAM_ENTRY(CAT_BMS, BMS_VmaxLimit, "V", 0, 10, 4.2, 93)                     \
   PARAM_ENTRY(CAT_BMS, BMS_TminLimit, "°C", -100, 100, 5, 94)                  \
   PARAM_ENTRY(CAT_BMS, BMS_TmaxLimit, "°C", -100, 100, 50, 95)                 \
-  PARAM_ENTRY(CAT_HEATER, Heater, HTTYPE, 0, 5, 0, 57)                         \
-  PARAM_ENTRY(CAT_HEATER, Control, HTCTRL, 0, 2, 0, 58)                        \
+  PARAM_ENTRY(CAT_HEATER, Heater, HTTYPE, 0, 6, 0, 57)                         \
+  PARAM_ENTRY(CAT_HEATER, Control, HTCTRL, 0, 3, 0, 58)                        \
   PARAM_ENTRY(CAT_HEATER, HeatPwr, "W", 0, 6500, 0, 59)                        \
   PARAM_ENTRY(CAT_HEATER, HeatPercnt, "%", 0, 100, 0, 124)                     \
+  PARAM_ENTRY(CAT_HEATER, HeatTempMax, "dig", 0, 4096, 0, 150)                 \
+  PARAM_ENTRY(CAT_HEATER, HeatTempMin, "dig", 0, 4096, 2048, 151)              \
+  PARAM_ENTRY(CAT_HEATER, HeatPWMCh, PWM_CH, 0, 2, 0, 152)                     \
   PARAM_ENTRY(CAT_CLOCK, Set_Day, DOW, 0, 6, 0, 46)                            \
   PARAM_ENTRY(CAT_CLOCK, Set_Hour, "Hours", 0, 23, 0, 47)                      \
   PARAM_ENTRY(CAT_CLOCK, Set_Min, "Mins", 0, 59, 0, 48)                        \
@@ -136,8 +139,8 @@
   PARAM_ENTRY(CAT_IOPINS, PB1InFunc, PINFUNCS, 0, 13, 12, 140)                 \
   PARAM_ENTRY(CAT_IOPINS, PB2InFunc, PINFUNCS, 0, 13, 12, 141)                 \
   PARAM_ENTRY(CAT_IOPINS, PB3InFunc, PINFUNCS, 0, 13, 12, 142)                 \
-  PARAM_ENTRY(CAT_IOPINS, GPA1Func, APINFUNCS, 0, 2, 0, 110)                   \
-  PARAM_ENTRY(CAT_IOPINS, GPA2Func, APINFUNCS, 0, 2, 0, 111)                   \
+  PARAM_ENTRY(CAT_IOPINS, GPA1Func, APINFUNCS, 0, 3, 0, 110)                   \
+  PARAM_ENTRY(CAT_IOPINS, GPA2Func, APINFUNCS, 0, 3, 0, 111)                   \
   PARAM_ENTRY(CAT_IOPINS, ppthresh, "dig", 0, 4095, 2500, 114)                 \
   PARAM_ENTRY(CAT_IOPINS, BrkVacThresh, "dig", 0, 4095, 2500, 115)             \
   PARAM_ENTRY(CAT_IOPINS, BrkVacHyst, "dig", 0, 4095, 2500, 116)               \
@@ -250,9 +253,11 @@
   VALUE_ENTRY(tmpheater, "°C", 2096)                                           \
   VALUE_ENTRY(udcheater, "V", 2097)                                            \
   VALUE_ENTRY(powerheater, "W", 2098)                                          \
-  VALUE_ENTRY(VehLockSt, ONOFF, 2100)
+  VALUE_ENTRY(VehLockSt, ONOFF, 2100)                                          \
+  VALUE_ENTRY(HeatTemp, "dig", 2109)                                           \
+  VALUE_ENTRY(PWMHeatOn, ONOFF, 2110)
 
-// Next value Id: 2109
+// Next value Id: 2111
 
 // Dead params
 /*
@@ -271,7 +276,7 @@
   "12=DCFCRequest, 13=BrakeVacPump, 14=CoolingFan, 15=HvActive, "              \
   "16=ShiftLockNO, 17=PwmTim3, 18=CpSpoof,"                                    \
   "19=GS450pump, 20=PwmTempGauge, 21=PwmSocGauge"
-#define APINFUNCS "0=None, 1=ProxPilot, 2=BrakeVacSensor"
+#define APINFUNCS "0=None, 1=ProxPilot, 2=BrakeVacSensor, 3=CabHeatTemp"
 #define SHIFTERS "0=None, 1=BMW_F30, 2=JLR_G1, 3=JLR_G2, 4=BMW_E65"
 #define SHNTYPE "0=None, 1=ISA, 2=SBOX, 3=VAG"
 #define DMODES "0=CLOSED, 1=OPEN, 2=ERROR, 3=INVALID"
@@ -313,8 +318,8 @@
   "1=Charging, 2=Malfunction, 4=ConnLock, 8=BatIncomp, 16=SystemMalfunction, " \
   "32=Stop"
 #define HTTYPE                                                                 \
-  "0=None, 1=Ampera, 2=VWCoolant, 3=VWAir, 4=OutlanderCan, 5=MGCoolant"
-#define HTCTRL "0=Disable, 1=Enable, 2=Timer"
+  "0=None, 1=Ampera, 2=VWCoolant, 3=VWAir, 4=OutlanderCan, 5=MGCoolant, 6=PWM"
+#define HTCTRL "0=Disable, 1=Enable, 2=Timer, 3=Enable_Analog"
 #define CHGMODS                                                                \
   "0=Off, 1=EXT_DIGI, 2=Volt_Ampera, 3=Leaf_PDM, 4=TeslaOI, 5=Out_lander, "    \
   "6=Elcon"
@@ -323,6 +328,7 @@
 #define CAN3SPD "0=k33.3, 1=k500, 2=k100"
 #define TRNMODES "0=Manual, 1=Auto"
 #define CAN_DEV "0=CAN1, 1=CAN2"
+#define PWM_CH "0=PWM1, 1=PWM2, 2=PWM3"
 #define CAT_THROTTLE "Throttle"
 #define CAT_POWER "Power Limit"
 #define CAT_CONTACT "Contactor Control"
@@ -407,7 +413,8 @@ enum HeatType {
   VWCoolant = 2,
   VWAir = 3,
   OutlanderHeater = 4,
-  MGCoolant = 5
+  MGCoolant = 5,
+  PWM = 6
 };
 
 enum BMSModes {

--- a/src/PWMHeater.cpp
+++ b/src/PWMHeater.cpp
@@ -1,0 +1,39 @@
+/*
+ * This file is part of the ZombieVerter project.
+ *
+ * Copyright (C) 2018 Johannes Huebner <dev@johanneshuebner.com>
+ *               2021-2022 Damien Maguire <info@evbmw.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <PWMHeater.h>
+#include <iomatrix.h>
+#include <libopencm3/stm32/timer.h>
+
+PWMHeater::PWMHeater() {}
+
+void PWMHeater::SetPower(uint16_t power, bool HeatReq) {
+  if (HeatReq && (power > 0)) {
+    Param::SetInt(Param::PWMHeatOn, 1);
+    // Use the HeatPercent as the duty cycle for the PWM signal.
+    timer_set_oc_value(TIM3,
+                       static_cast<tim_oc_id>(Param::GetInt(Param::HeatPWMCh)),
+                       utils::change(Param::GetInt(Param::HeatPercnt), 0, 100,
+                                     0, Param::GetInt(Param::Tim3_Period)));
+  } else {
+    Param::SetInt(Param::PWMHeatOn, 0);
+    timer_set_oc_value(
+        TIM3, static_cast<tim_oc_id>(Param::GetInt(Param::HeatPWMCh)), 0);
+  }
+}


### PR DESCRIPTION
Control the heater with one of the analog inputs.  Uses the raw analog values to avoid thermistor math.
Drive a PWM based heater.
Tested very similar code with a Tesla Battery Heater and it's built-in thermistor. 
https://github.com/streber42/Stm32-vcu/tree/pwm_heater