### PR TITLE
Added heatreq to VW coolant heater control

### DIFF
--- a/src/VWCoolantHeater.cpp
+++ b/src/VWCoolantHeater.cpp
@@ -46,8 +46,7 @@ void vwCoolantHeater::SetPower(uint16_t power, bool HeatReq) {
   if (TenCount == 5) // slow down to 50ms as this is called in 10ms task.
   {
     TenCount = 0;
-    HeatReq = HeatReq;
-    // going to ignore heatreq just for test.
+    HeatReq = Param::GetInt(Param::HeatReq);
 
     if (power >= 255)
       power = 255;          // Constrain power to max for VW heater.
@@ -79,7 +78,7 @@ void vwCoolantHeater::SetPower(uint16_t power, bool HeatReq) {
       lindata[0] = Param::GetInt(
           Param::HeatPercnt); // VW heater uses a % setting as opposed to a set
                               // power val. Regulates its temps to this.
-      lindata[1] = 1;         // Always on for test. Can use heatreq here.
+      lindata[1] = HeatReq;      
       lindata[2] = 0;
       lindata[3] = 0;
       lin->Request(28, lindata, sizeof(lindata)); // 0x1C hex address


### PR DESCRIPTION
Without this it would still pull a bit of power when the heater pot was below the cut off.