### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# Dependabot checks for new versions of the dependencies used in the GitHub Actions used in this repository.
+# Dependabot will raise pull requests for version updates for any outdated actions that it finds. After the initial
+# version updates, Dependabot will continue to check for outdated versions of actions according to the schedule defined.
+
+version: 2
+updates:
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"


### PR DESCRIPTION
## What
This pull request adds Dependabot. Dependabot regularly checks, in this case weekly, versions of dependencies of GitHub Actions.

## How
More details on how to implement Dependabot are found on [Keeping your actions up to date with Dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot).

## Why
To not have problems at some point in the future with outdated dependencies used in GitHub Actions, it is useful to keep the dependencies updated. Dependabot checks the versions of dependencies automatically on a regular basis, and will raise pull requests for version updates for any outdated actions that it finds.

[Example of dependabot in action](https://github.com/dalathegreat/Battery-Emulator/pulls?q=is%3Apr+is%3Aclosed+dependabot)
