### PR TITLE
Chademo and pp compatibility update

### DIFF
--- a/include/param_prj.h
+++ b/include/param_prj.h
@@ -194,7 +194,7 @@
     VALUE_ENTRY(FrontRearBal,  "%",                 2082 ) \
     VALUE_ENTRY(cruisespeed,   "rpm",               2033 ) \
     VALUE_ENTRY(cruisestt,     CRUISESTATES,        2034 ) \
-    VALUE_ENTRY(din_cruise,    ONOFF,               2035 ) \
+    VALUE_ENTRY(din_HVreq,     ONOFF,               2035 ) \
     VALUE_ENTRY(din_start,     ONOFF,               2036 ) \
     VALUE_ENTRY(din_brake,     ONOFF,               2037 ) \
     VALUE_ENTRY(din_forward,   ONOFF,               2038 ) \

--- a/include/param_prj.h
+++ b/include/param_prj.h
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#define VER 2.30.A
+#define VER 2.31.A
 
 
 /* Entries must be ordered as follows:

--- a/src/chademo.cpp
+++ b/src/chademo.cpp
@@ -43,219 +43,219 @@ uCAN_MSG txMessage;
 #define FLASH_DELAY 8000
 static void delay(void)
 {
-   int i;
-   for (i = 0; i < FLASH_DELAY; i++)       /* Wait a bit. */
-      __asm__("nop");
+    int i;
+    for (i = 0; i < FLASH_DELAY; i++)       /* Wait a bit. */
+        __asm__("nop");
 }
 
 void FCChademo::DecodeCAN(int id, uint32_t data[2])
 {
-if (id == 0x108)
-{
-    chargerMaxCurrent = data[0] >> 24;
-    chargerMaxVoltage = data[0] >> 8;
-}
+    if (id == 0x108)
+    {
+        chargerMaxCurrent = data[0] >> 24;
+        chargerMaxVoltage = data[0] >> 8;
+    }
 
 
-if (id == 0x109)
-{
-   chargerOutputVoltage = data[0] >> 8;
-   chargerOutputCurrent = data[0] >> 24;
-   chargerStatus = (data[1] >> 8) & 0x3F;
-}
+    if (id == 0x109)
+    {
+        chargerOutputVoltage = data[0] >> 8;
+        chargerOutputCurrent = data[0] >> 24;
+        chargerStatus = (data[1] >> 8) & 0x3F;
+    }
 }
 
 
 void FCChademo::SetEnabled(bool enabled)
 {
-   chargeEnabled = enabled;
+    chargeEnabled = enabled;
 
-   if (!chargeEnabled)
-   {
-      rampedCurReq = 0;
-      vtgTimeout = 0;
-      curTimeout = 0;
-   }
+    if (!chargeEnabled)
+    {
+        rampedCurReq = 0;
+        vtgTimeout = 0;
+        curTimeout = 0;
+    }
 }
 
 void FCChademo::SetChargeCurrent(uint8_t current)
 {
-   chargeCurrentRequest = MIN(current, chargerMaxCurrent);
+    chargeCurrentRequest = MIN(current, chargerMaxCurrent);
 
-   if (chargeCurrentRequest > rampedCurReq)
-      rampedCurReq++;
-   else if (chargeCurrentRequest < rampedCurReq)
-      rampedCurReq--;
+    if (chargeCurrentRequest > rampedCurReq)
+        rampedCurReq++;
+    else if (chargeCurrentRequest < rampedCurReq)
+        rampedCurReq--;
 }
 
 void FCChademo::CheckSensorDeviation(uint16_t internalVoltage)
 {
-   int vtgDev = (int)internalVoltage - (int)chargerOutputVoltage;
+    int vtgDev = (int)internalVoltage - (int)chargerOutputVoltage;
 
-   vtgDev = ABS(vtgDev);
+    vtgDev = ABS(vtgDev);
 
-   if (vtgDev > 10 && chargerOutputVoltage > 50)
-   {
-      vtgTimeout++;
-   }
-   else
-   {
-      vtgTimeout = 0;
-   }
+    if (vtgDev > 10 && chargerOutputVoltage > 50)
+    {
+        vtgTimeout++;
+    }
+    else
+    {
+        vtgTimeout = 0;
+    }
 
-   if (chargerOutputCurrent > (rampedCurReq + 12))
-   {
-      curTimeout++;
-   }
-   else
-   {
-      curTimeout = 0;
-   }
+    if (chargerOutputCurrent > (rampedCurReq + 12))
+    {
+        curTimeout++;
+    }
+    else
+    {
+        curTimeout = 0;
+    }
 }
 
 void FCChademo::Task100Ms()//sends chademo messages every 100ms
 {
-   uint32_t data[2];
-   bool curSensFault = curTimeout > 10;
-   bool vtgSensFault = vtgTimeout > 50;
+    uint32_t data[2];
+    bool curSensFault = curTimeout > 10;
+    bool vtgSensFault = vtgTimeout > 50;
 
-   //Capacity fixed to 200 - so SoC resolution is 0.5
-   data[0] = 0;
-   data[1] = (targetBatteryVoltage + 40) | 200 << 16;
+    //Capacity fixed to 200 - so SoC resolution is 0.5
+    data[0] = 0;
+    data[1] = (targetBatteryVoltage + 40) | 200 << 16;
 
-   txMessage.frame.idType = dSTANDARD_CAN_MSG_ID_2_0B;
-   txMessage.frame.id = 0x100;
-   txMessage.frame.dlc = 8;
-   txMessage.frame.data0 = (data[0] & 0xFF);
-   txMessage.frame.data1 = (data[0]>>8 & 0xFF);
-   txMessage.frame.data2 = (data[0]>>16 & 0xFF);
-   txMessage.frame.data3 = (data[0]>>24 & 0xFF);
-   txMessage.frame.data4 = (data[1] & 0xFF);
-   txMessage.frame.data5 = (data[1]>>8 & 0xFF);
-   txMessage.frame.data6 = (data[1]>>16 & 0xFF);
-   txMessage.frame.data7 = (data[1]>>24 & 0xFF);
-   CANSPI_Transmit(&txMessage);
-   delay();
+    txMessage.frame.idType = dSTANDARD_CAN_MSG_ID_2_0B;
+    txMessage.frame.id = 0x100;
+    txMessage.frame.dlc = 8;
+    txMessage.frame.data0 = (data[0] & 0xFF);
+    txMessage.frame.data1 = (data[0]>>8 & 0xFF);
+    txMessage.frame.data2 = (data[0]>>16 & 0xFF);
+    txMessage.frame.data3 = (data[0]>>24 & 0xFF);
+    txMessage.frame.data4 = (data[1] & 0xFF);
+    txMessage.frame.data5 = (data[1]>>8 & 0xFF);
+    txMessage.frame.data6 = (data[1]>>16 & 0xFF);
+    txMessage.frame.data7 = (data[1]>>24 & 0xFF);
+    CANSPI_Transmit(&txMessage);
+    delay();
 
-   data[0] = 0x00FEFF00;
-   data[1] = 0;
+    data[0] = 0x00FEFF00;
+    data[1] = 0;
 
-   txMessage.frame.idType = dSTANDARD_CAN_MSG_ID_2_0B;
-   txMessage.frame.id = 0x101;
-   txMessage.frame.dlc = 8;
-   txMessage.frame.data0 = (data[0] & 0xFF);
-   txMessage.frame.data1 = (data[0]>>8 & 0xFF);
-   txMessage.frame.data2 = (data[0]>>16 & 0xFF);
-   txMessage.frame.data3 = (data[0]>>24 & 0xFF);
-   txMessage.frame.data4 = (data[1] & 0xFF);
-   txMessage.frame.data5 = (data[1]>>8 & 0xFF);
-   txMessage.frame.data6 = (data[1]>>16 & 0xFF);
-   txMessage.frame.data7 = (data[1]>>24 & 0xFF);
-   CANSPI_Transmit(&txMessage);
-   delay();
+    txMessage.frame.idType = dSTANDARD_CAN_MSG_ID_2_0B;
+    txMessage.frame.id = 0x101;
+    txMessage.frame.dlc = 8;
+    txMessage.frame.data0 = (data[0] & 0xFF);
+    txMessage.frame.data1 = (data[0]>>8 & 0xFF);
+    txMessage.frame.data2 = (data[0]>>16 & 0xFF);
+    txMessage.frame.data3 = (data[0]>>24 & 0xFF);
+    txMessage.frame.data4 = (data[1] & 0xFF);
+    txMessage.frame.data5 = (data[1]>>8 & 0xFF);
+    txMessage.frame.data6 = (data[1]>>16 & 0xFF);
+    txMessage.frame.data7 = (data[1]>>24 & 0xFF);
+    CANSPI_Transmit(&txMessage);
+    delay();
 
 
-   data[0] = 1 | ((uint32_t)targetBatteryVoltage << 8) | ((uint32_t)rampedCurReq << 24);
-   data[1] = (uint32_t)curSensFault << 2 |
-             (uint32_t)vtgSensFault << 4 |
-             (uint32_t)chargeEnabled << 8 |
-             (uint32_t)parkingPosition << 9 |
-             (uint32_t)fault << 10 |
-             (uint32_t)contactorOpen << 11 |
-             (uint32_t)soc << 16;
+    data[0] = 1 | ((uint32_t)targetBatteryVoltage << 8) | ((uint32_t)rampedCurReq << 24);
+    data[1] = (uint32_t)curSensFault << 2 |
+              (uint32_t)vtgSensFault << 4 |
+              (uint32_t)chargeEnabled << 8 |
+              (uint32_t)parkingPosition << 9 |
+              (uint32_t)fault << 10 |
+              (uint32_t)contactorOpen << 11 |
+              (uint32_t)soc << 16;
 
-   txMessage.frame.idType = dSTANDARD_CAN_MSG_ID_2_0B;
-   txMessage.frame.id = 0x102;
-   txMessage.frame.dlc = 8;
-   txMessage.frame.data0 = (data[0] & 0xFF);
-   txMessage.frame.data1 = (data[0]>>8 & 0xFF);
-   txMessage.frame.data2 = (data[0]>>16 & 0xFF);
-   txMessage.frame.data3 = (data[0]>>24 & 0xFF);
-   txMessage.frame.data4 = (data[1] & 0xFF);
-   txMessage.frame.data5 = (data[1]>>8 & 0xFF);
-   txMessage.frame.data6 = (data[1]>>16 & 0xFF);
-   txMessage.frame.data7 = (data[1]>>24 & 0xFF);
-   CANSPI_Transmit(&txMessage);
+    txMessage.frame.idType = dSTANDARD_CAN_MSG_ID_2_0B;
+    txMessage.frame.id = 0x102;
+    txMessage.frame.dlc = 8;
+    txMessage.frame.data0 = (data[0] & 0xFF);
+    txMessage.frame.data1 = (data[0]>>8 & 0xFF);
+    txMessage.frame.data2 = (data[0]>>16 & 0xFF);
+    txMessage.frame.data3 = (data[0]>>24 & 0xFF);
+    txMessage.frame.data4 = (data[1] & 0xFF);
+    txMessage.frame.data5 = (data[1]>>8 & 0xFF);
+    txMessage.frame.data6 = (data[1]>>16 & 0xFF);
+    txMessage.frame.data7 = (data[1]>>24 & 0xFF);
+    CANSPI_Transmit(&txMessage);
 }
 
 
 void FCChademo::Task200Ms()
 {
-   //formally the runchademo routine.
-   static int32_t controlledCurrent = 0;
-   if (chademoStartTime == 0)// && Param::GetInt(Param::opmode) != MOD_CHARGE)
-   {
-      chademoStartTime = rtc_get_counter_val();
-      FCChademo::SetChargeCurrent(0);
-   }
+    //formally the runchademo routine.
+    static int32_t controlledCurrent = 0;
+    if (chademoStartTime == 0)// && Param::GetInt(Param::opmode) != MOD_CHARGE)
+    {
+        chademoStartTime = rtc_get_counter_val();
+        FCChademo::SetChargeCurrent(0);
+    }
 
-   if ((rtc_get_counter_val() - chademoStartTime) > 4 && (rtc_get_counter_val() - chademoStartTime) < 8)
-   {
-      FCChademo::SetEnabled(true);
-      IOMatrix::GetPin(IOMatrix::CHADEMOALLOW)->Set();//never gets here ...
-   }
+    if ((rtc_get_counter_val() - chademoStartTime) > 4 && (rtc_get_counter_val() - chademoStartTime) < 8)
+    {
+        FCChademo::SetEnabled(true);
+        IOMatrix::GetPin(IOMatrix::CHADEMOALLOW)->Set();//never gets here ...
+    }
 
-   if (Param::GetInt(Param::opmode) == MOD_CHARGE && FCChademo::ConnectorLocked())
-   {
-      Param::SetInt(Param::chgtyp,DCFC);
-      chargeMode = true;   //DC charge mode
-   }
+    if (Param::GetInt(Param::opmode) == MOD_CHARGE && FCChademo::ConnectorLocked())
+    {
+        Param::SetInt(Param::chgtyp,DCFC);
+        chargeMode = true;   //DC charge mode
+    }
 
-   if (chargeMode)
-   {
-      int udc = Param::GetInt(Param::udc);
-      int udcspnt = Param::GetInt(Param::Voltspnt);
-      int chargeLim = Param::GetInt(Param::CCS_ILim);
-      chargeLim = MIN(150, chargeLim);
+    if (chargeMode)
+    {
+        int udc = Param::GetInt(Param::udc);
+        int udcspnt = Param::GetInt(Param::Voltspnt);
+        int chargeLim = Param::GetInt(Param::CCS_ILim);
+        chargeLim = MIN(150, chargeLim);
 
-      chargeLim = MIN(Param::GetInt(Param::BMS_ChargeLim), chargeLim);//BMS charge current limit for chademo
-      //Note: No need to worry about bms type as if none selected sets to 999.
-      //If chargeLim==0 chademo session will end.
+        chargeLim = MIN(Param::GetInt(Param::BMS_ChargeLim), chargeLim);//BMS charge current limit for chademo
+        //Note: No need to worry about bms type as if none selected sets to 999.
+        //If chargeLim==0 chademo session will end.
 
-      if (udc < udcspnt && controlledCurrent <= chargeLim)
-         controlledCurrent++;
-      if (udc > udcspnt && controlledCurrent > 0)
-         controlledCurrent--;
-      if(controlledCurrent>chargeLim)
-         controlledCurrent--;
+        if (udc < udcspnt && controlledCurrent <= chargeLim)
+            controlledCurrent++;
+        if (udc > udcspnt && controlledCurrent > 0)
+            controlledCurrent--;
+        if(controlledCurrent>chargeLim)
+            controlledCurrent--;
 
-      FCChademo::SetChargeCurrent(controlledCurrent);
-      //TODO: fix this to not false trigger
-      //FCChademo::CheckSensorDeviation(Param::GetInt(Param::udc));
-   }
+        FCChademo::SetChargeCurrent(controlledCurrent);
+        //TODO: fix this to not false trigger
+        //FCChademo::CheckSensorDeviation(Param::GetInt(Param::udc));
+    }
 
-   FCChademo::SetTargetBatteryVoltage(Param::GetInt(Param::Voltspnt)+10);
-   FCChademo::SetSoC(Param::GetFloat(Param::SOCFC));
-   Param::SetInt(Param::CCS_Ireq, FCChademo::GetRampedCurrentRequest());
+    FCChademo::SetTargetBatteryVoltage(Param::GetInt(Param::Voltspnt)+10);
+    FCChademo::SetSoC(Param::GetFloat(Param::SOCFC));
+    Param::SetInt(Param::CCS_Ireq, FCChademo::GetRampedCurrentRequest());
 
-   if (Param::GetInt(Param::CCS_ILim) == 0)
-   {
-      FCChademo::SetChargeCurrent(0);
-      FCChademo::SetEnabled(false);
-      IOMatrix::GetPin(IOMatrix::CHADEMOALLOW)->Clear();//FCChademo charge allow off
-      chargeMode = false;
-   }
+    if (Param::GetInt(Param::CCS_ILim) == 0)
+    {
+        FCChademo::SetChargeCurrent(0);
+        FCChademo::SetEnabled(false);
+        IOMatrix::GetPin(IOMatrix::CHADEMOALLOW)->Clear();//FCChademo charge allow off
+        chargeMode = false;
+    }
 
-   Param::SetInt(Param::CCS_V, FCChademo::GetChargerOutputVoltage());
-   Param::SetInt(Param::CCS_I, FCChademo::GetChargerOutputCurrent());
-   Param::SetInt(Param::CCS_State, FCChademo::GetChargerStatus());
-   Param::SetInt(Param::CCS_I_Avail, FCChademo::GetChargerMaxCurrent());
-   Param::SetInt(Param::CCS_V_Avail, FCChademo::GetChargerMaxVoltage());
+    Param::SetInt(Param::CCS_V, FCChademo::GetChargerOutputVoltage());
+    Param::SetInt(Param::CCS_I, FCChademo::GetChargerOutputCurrent());
+    Param::SetInt(Param::CCS_State, FCChademo::GetChargerStatus());
+    Param::SetInt(Param::CCS_I_Avail, FCChademo::GetChargerMaxCurrent());
+    Param::SetInt(Param::CCS_V_Avail, FCChademo::GetChargerMaxVoltage());
 }
 
 bool FCChademo::DCFCRequest(bool RunCh)
 {
-if ((RunCh) && (IOMatrix::GetPin(IOMatrix::DCFCREQUEST)->Get()))
-{
-   return true;
-}
-else
-{
+    if (RunCh)
+    {
+        if (IOMatrix::GetPin(IOMatrix::DCFCREQUEST) != &DigIo::dummypin &&IOMatrix::GetPin(IOMatrix::DCFCREQUEST)->Get()) //
+        {
+            return true;
+        }
+    }
+
     FCChademo::SetChargeCurrent(0);
     FCChademo::SetEnabled(false);
     IOMatrix::GetPin(IOMatrix::CHADEMOALLOW)->Clear();//FCChademo charge allow off
     chademoStartTime=0;
     return false;
-}
-
 }

--- a/src/stm32_vcu.cpp
+++ b/src/stm32_vcu.cpp
@@ -244,22 +244,26 @@ static void Ms200Task(void)
     if(ChgSet==0 && !ChgLck) RunChg=true;//enable from webui if we are not locked out from an auto termination
     if(ChgSet==1) RunChg=false;//disable from webui
 
-    //Handle PP on the Charging port
-    if(Param::GetInt(Param::GPA1Func) == IOMatrix::PILOT_PROX || Param::GetInt(Param::GPA2Func) == IOMatrix::PILOT_PROX )
+    //If we detect we are getting a hardwired DCFC request (chademo ect.) DO NOT run PP detect
+    if(IOMatrix::GetPin(IOMatrix::DCFCREQUEST) != &DigIo::dummypin && !(IOMatrix::GetPin(IOMatrix::DCFCREQUEST)->Get()))
     {
-        int ppThresh = Param::GetInt(Param::ppthresh);
-        int ppValue = IOMatrix::GetAnaloguePin(IOMatrix::PILOT_PROX)->Get();
-        Param::SetInt(Param::PPVal, ppValue);
+        //Handle PP on the Charging port
+        if(Param::GetInt(Param::GPA1Func) == IOMatrix::PILOT_PROX || Param::GetInt(Param::GPA2Func) == IOMatrix::PILOT_PROX )
+        {
+            int ppThresh = Param::GetInt(Param::ppthresh);
+            int ppValue = IOMatrix::GetAnaloguePin(IOMatrix::PILOT_PROX)->Get();
+            Param::SetInt(Param::PPVal, ppValue);
 
-        // If PP is at or below threshold and currently disabled and not already finished
-        if (ppValue <= ppThresh && ChgSet==1 && !ChgLck)
-        {
-            RunChg=true;
-        }
-        else if (ppValue > ppThresh)
-        {
-            //even if timer was enabled, change to disabled, we've unplugged
-            RunChg=false;
+            // If PP is at or below threshold and currently disabled and not already finished
+            if (ppValue <= ppThresh && ChgSet==1 && !ChgLck)
+            {
+                RunChg=true;
+            }
+            else if (ppValue > ppThresh)
+            {
+                //even if timer was enabled, change to disabled, we've unplugged
+                RunChg=false;
+            }
         }
     }
 
@@ -303,8 +307,6 @@ static void Ms200Task(void)
             RunChg=false;//end charge
             ChgLck=true;//set charge lockout flag
         }
-
-
     }
     if(opmode==MOD_RUN)
     {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -63,7 +63,7 @@ void GetDigInputs(CanHardware* can)
         ErrorMessage::Post(ERR_CANTIMEOUT);
     }
 
-    Param::SetInt(Param::din_cruise, ((canio & CAN_IO_CRUISE) != 0));
+    Param::SetInt(Param::din_HVreq, DigIo::HV_req.Get());
     Param::SetInt(Param::din_start, DigIo::start_in.Get() | ((canio & CAN_IO_START) != 0));
     Param::SetInt(Param::din_brake, DigIo::brake_in.Get() | ((canio & CAN_IO_BRAKE) != 0));
     Param::SetInt(Param::din_forward, DigIo::fwd_in.Get() | ((canio & CAN_IO_FWD) != 0));


### PR DESCRIPTION
Chademo and PP compatibility Update
-PP detect is bypassed if DCFCrequest input is active
-Chademo clean up on reading input to stop always high if un specified
-din_cruise reused for HVreq input