### PR TITLE
Add 12V battery maintainer feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ OBJSL		= $(BINARY).o hwinit.o stm32scheduler.o params.o terminal.o terminal_prj.
            CPC.o ElconCharger.o RearOutlanderinverter.o linbus.o VWCoolantHeater.o JLR_G1.o JLR_G2.o Foccci.o digipot.o\
 		   OutlanderHeartBeat.o E65_Lever.o leafbms.o V_Classic.o kangoobms.o OutlanderCanHeater.o VWAirHeater.o\
 		   MGCoolantHeater.o NissLeafMng.o preheater.o MGgen2V2Lcharger.o OutlanderCompressor.o ElconDCDC.o PWMHeater.o \
-		   stwmbms.o oibms.o WebastoHVH.o InverterACP.o
+		   stwmbms.o oibms.o WebastoHVH.o InverterACP.o Maintainer12V.o
 
 
 

--- a/include/Maintainer12V.h
+++ b/include/Maintainer12V.h
@@ -1,0 +1,48 @@
+
+/*
+ * This file is part of the ZombieVerter project.
+ *
+ * Copyright (C) 2026 Jamie Jones <jamie@jamie-jones.co.uk>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef MAINTAINER12V_H
+#define MAINTAINER12V_H
+#include "params.h"
+#include <stdint.h>
+
+class Maintainer12V {
+public:
+  Maintainer12V();
+  void Task200Ms(int opmode);
+  void Ms10Task();
+  void ParamsChange();
+  void SetInitByMaintainer(bool initbyM);
+  void CancelMaintainer();
+
+  bool GetRunMaintainer();
+  bool GetInitByMaintainer();
+
+private:
+  uint8_t minsUntilAllowedAgain;
+  uint16_t minsUntilAllowedAgainTicks;
+  uint8_t preHeatSet;
+  bool runMaintainer;
+  uint32_t maintainTicks;
+  uint32_t maintainTicks_1Min;
+  uint16_t maintainDur_tmp;
+  bool initbyMaintain;
+};
+
+#endif // MAINTAINER12V_H

--- a/include/param_prj.h
+++ b/include/param_prj.h
@@ -153,6 +153,10 @@
   PARAM_ENTRY(CAT_IOPINS, DigiPot2Step, "dig", 0, 255, 0, 118)                 \
   PARAM_ENTRY(CAT_IOPINS, FanTemp, "°C", 0, 100, 40, 134)                      \
   PARAM_ENTRY(CAT_IOPINS, TachoPPR, "PPR", 0, 100, 2, 136)                     \
+  PARAM_ENTRY(CAT_12V, uauxGain, "", 0, 500, 210, 157)                         \
+  PARAM_ENTRY(CAT_12V, minVolts, "", 11, 13, 12, 158)                          \
+  PARAM_ENTRY(CAT_12V, allowWakeup, ONOFF, 0, 1, 0, 159)                       \
+  PARAM_ENTRY(CAT_12V, wakeupMin, "Mins", 0, 20, 0, 160)                       \
   PARAM_ENTRY(CAT_SHUNT, IsaInit, ONOFF, 0, 1, 0, 75)                          \
   PARAM_ENTRY(CAT_PWM, Tim3_Presc, "", 1, 72000, 719, 100)                     \
   PARAM_ENTRY(CAT_PWM, Tim3_Period, "", 1, 100000, 7200, 101)                  \
@@ -263,6 +267,8 @@
   VALUE_ENTRY(compressStat, COMP_STAT, 2111)                                   \
   VALUE_ENTRY(compressRPM, "", 2109)                                           \
   VALUE_ENTRY(PWMHeatOn, ONOFF, 2112)                                          \
+  VALUE_ENTRY(maintainWakeups, "", 2124)                                       \
+  VALUE_ENTRY(minsUntilAllowedAgain, "", 2125)                                 \
   VALUE_ENTRY(uptime, "sec", 2113)                                             \
   VALUE_ENTRY(MG1Torque, "", 2114)                                             \
   VALUE_ENTRY(MG2Torque, "", 2115)                                             \
@@ -319,7 +325,8 @@
 #define BMSMODES                                                               \
   "0=Off, 1=SimpBMS, 2=TiDaisychainSingle, 3=TiDaisychainDual, 4=LeafBms, "    \
   "5=RenaultKangoo33, 6=STW, 7=OIFlyingAdc"
-#define OPMODES "0=Off, 1=Run, 2=Precharge, 3=PchFail, 4=Charge, 5=Preheat"
+#define OPMODES                                                                \
+  "0=Off, 1=Run, 2=Precharge, 3=PchFail, 4=Charge, 5=12VMaintain, 6=Preheat"
 #define DOW "0=Sun, 1=Mon, 2=Tue, 3=Wed, 4=Thu, 5=Fri, 6=Sat"
 #define CHGTYPS "0=Off, 1=AC, 2=DCFC"
 #define DCDCTYPES "0=NoDCDC, 1=TeslaG2, 2=DCDCElcon"
@@ -372,6 +379,7 @@
 #define CAT_SHUNT "ISA Shunt Control"
 #define CAT_IOPINS "General Purpose I/O"
 #define CAT_PWM "PWM Control"
+#define CAT_12V "12V Battery"
 #define MotorsAct "0=Mg1and2, 1=Mg1, 2=Mg2, 3=BlendingMG2and1"
 #define PumpOutType "0=GS450hOil, 1=TachoOut, 2=SpeedoOut"
 #define LIMITREASON                                                            \
@@ -392,6 +400,7 @@ enum modes {
   MOD_PRECHARGE,
   MOD_PCHFAIL,
   MOD_CHARGE,
+  MOD_MAINTAIN,
   MOD_PREHEAT,
   MOD_LAST
 };

--- a/src/Maintainer12V.cpp
+++ b/src/Maintainer12V.cpp
@@ -1,0 +1,116 @@
+/*
+ * This file is part of the Zombieverter VCU project.
+ *
+ * Copyright (C) 2026  Jamie Jones <jamie@jamie-jones.co.uk>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Maintainer12V.h"
+#include "digio.h"
+#include "errormessage.h"
+#include "iomatrix.h"
+#include "utils.h"
+
+#define WAKEUP_BLOCK_MINS 90
+
+Maintainer12V::Maintainer12V() :
+  minsUntilAllowedAgain(WAKEUP_BLOCK_MINS),
+  minsUntilAllowedAgainTicks(0),
+  runMaintainer(false),
+  maintainTicks(0),
+  maintainTicks_1Min(0),
+  maintainDur_tmp(0),
+  initbyMaintain(false)
+{
+}
+
+void Maintainer12V::SetInitByMaintainer(bool initbyM) {
+  initbyMaintain = initbyM;
+}
+
+bool Maintainer12V::GetInitByMaintainer() {
+  return initbyMaintain;
+}
+
+bool Maintainer12V::GetRunMaintainer() { return runMaintainer; }
+
+void Maintainer12V::Ms10Task() {
+  Param::SetInt(Param::opmode, MOD_MAINTAIN);
+  ErrorMessage::UnpostAll();
+  if (!runMaintainer) {
+    Param::SetInt(Param::opmode, MOD_OFF);
+  }
+}
+
+void Maintainer12V::Task200Ms(int opmode) {
+  Param::SetInt(Param::minsUntilAllowedAgain, minsUntilAllowedAgain);
+
+  if (opmode == MOD_OFF) {
+    // reset every minute
+    if (minsUntilAllowedAgain > 0) {
+      minsUntilAllowedAgainTicks++;
+      if (minsUntilAllowedAgainTicks >= 300) {
+        minsUntilAllowedAgainTicks = 0;
+        minsUntilAllowedAgain--;
+      }
+    }
+    uint8_t allowWakeup = Param::GetInt(Param::allowWakeup);
+
+    float actual12V = Param::GetFloat(Param::uaux);
+    float min12V = Param::GetFloat(Param::minVolts);
+
+    maintainDur_tmp = GetInt(Param::wakeupMin);
+
+    if (allowWakeup && actual12V < min12V && minsUntilAllowedAgain < 1 &&
+        (maintainDur_tmp != 0)) {
+      minsUntilAllowedAgain = WAKEUP_BLOCK_MINS;
+      maintainTicks = (GetInt(Param::wakeupMin) * 300); // initialize timer
+      maintainTicks_1Min = 0;
+      runMaintainer = true; // if we arrive at set preheat time and duration is
+                            // non zero then initiate preheat
+    }
+  }
+
+  if (opmode == MOD_MAINTAIN) {
+    if (maintainTicks != 0) {
+      maintainTicks--; // decrement charge timer ticks
+      maintainTicks_1Min++;
+    }
+
+    if (maintainTicks == 0) {
+      runMaintainer = false; // end preheat once timer expires.
+      maintainTicks = (GetInt(Param::wakeupMin) * 300); // recharge the tick
+                                                        // timer
+    }
+
+    if (maintainTicks_1Min == 300) {
+      maintainTicks_1Min = 0;
+      maintainDur_tmp--; // countdown minutes of charge time remaining.
+    }
+  }
+}
+
+void Maintainer12V::CancelMaintainer() {
+  maintainDur_tmp = 0;
+  maintainTicks = 0;
+  minsUntilAllowedAgain = WAKEUP_BLOCK_MINS;
+}
+
+void Maintainer12V::ParamsChange() {
+  maintainTicks =
+      (GetInt(Param::wakeupMin) * 300); // number of 200ms ticks that equates to
+                                        // maintaince timer in minutes
+  maintainDur_tmp = GetInt(Param::wakeupMin);
+}

--- a/src/stm32_vcu.cpp
+++ b/src/stm32_vcu.cpp
@@ -40,6 +40,7 @@
 #include "JLR_G2.h"
 #include "MGCoolantHeater.h"
 #include "MGgen2V2Lcharger.h"
+#include "Maintainer12V.h"
 #include "NissanPDM.h"
 #include "OutlanderCanHeater.h"
 #include "OutlanderCompressor.h"
@@ -211,6 +212,7 @@ static Preheater preheater;
 static OutlanderCompressor outlanderCompressor;
 static Compressor *selectedCompressor = &UnUsed;
 static PWMHeater pwmHeater;
+static Maintainer12V maintainer12V;
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 static void Ms200Task(void) {
@@ -372,6 +374,7 @@ static void Ms200Task(void) {
     IOMatrix::GetPin(IOMatrix::BRAKEVACPUMP)->Clear();
   }
 
+  maintainer12V.Task200Ms(opmode);
   preheater.Task200Ms(opmode, hours, minutes);
 }
 
@@ -708,6 +711,7 @@ static void Ms10Task(void) {
     initbyStart = false;
     initbyCharge = false;
     preheater.SetInitByPreHeat(false);
+    maintainer12V.SetInitByMaintainer(false);
 
     DigIo::inv_out.Clear();                           // inverter power off
     IOMatrix::GetPin(IOMatrix::COOLANTPUMP)->Clear(); // Coolant pump off if
@@ -755,6 +759,12 @@ static void Ms10Task(void) {
       vehicleStartTime = rtc_get_counter_val();
       preheater.SetInitByPreHeat(true);
     }
+    if (maintainer12V.GetRunMaintainer()) {
+      opmode = MOD_PRECHARGE; // proceed to precharge if charge requested.
+      rlyDly = 25;            // Recharge sequence timer
+      vehicleStartTime = rtc_get_counter_val();
+      maintainer12V.SetInitByMaintainer(true);
+    }
     Param::SetInt(Param::opmode, opmode);
     break;
 
@@ -796,6 +806,12 @@ static void Ms10Task(void) {
         opmode = MOD_PREHEAT;
         rlyDly = 25;                         // Recharge sequence timer
         Param::SetInt(Param::TorqDerate, 0); // clear torque derate reason
+      } else if (maintainer12V.GetRunMaintainer()) {
+        opmode = MOD_MAINTAIN;
+        rlyDly = 25;                         // Recharge sequence timer
+        Param::SetInt(Param::TorqDerate, 0); // clear torque derate reason
+        Param::SetInt(Param::maintainWakeups,
+                      Param::GetInt(Param::maintainWakeups) + 1);
       }
     }
     if (initbyCharge && !chargeMode)
@@ -804,6 +820,9 @@ static void Ms10Task(void) {
     if (initbyStart && !selectedVehicle->Ready())
       opmode = MOD_OFF;
     if (preheater.GetInitByPreHeat() && !preheater.GetRunPreHeat())
+      opmode = MOD_OFF;
+    if (maintainer12V.GetInitByMaintainer() &&
+        !maintainer12V.GetRunMaintainer())
       opmode = MOD_OFF;
 
     if (udc < (Param::GetInt(Param::udcsw)) &&
@@ -858,6 +877,26 @@ static void Ms10Task(void) {
       rlyDly = 250; // Recharge sequence timer for delayed shutdown
     }
     Param::SetInt(Param::opmode, opmode);
+    break;
+
+  case MOD_MAINTAIN:
+    if (rlyDly != 0)
+      rlyDly--; // here we are going to pause before energising precharge to
+                // prevent too many contactors pulling amps at the same time
+    if (rlyDly == 0) {
+      DigIo::dcsw_out.Set();
+    }
+
+    maintainer12V.Ms10Task();
+
+    if (!maintainer12V.GetRunMaintainer()) {
+      rlyDly = 250; // Recharge sequence timer for delayed shutdown
+    }
+
+    if ((selectedVehicle->Start() && selectedVehicle->Ready())) {
+      maintainer12V.CancelMaintainer();
+    }
+
     break;
 
   case MOD_PREHEAT:
@@ -1335,6 +1374,7 @@ void Param::Change(Param::PARAM_NUM paramNum) {
   IOMatrix::AssignFromParams();
   IOMatrix::AssignFromParamsAnalogue();
 
+  maintainer12V.ParamsChange();
   preheater.ParamsChange();
 }
 


### PR DESCRIPTION
### What
This feature allows the VCU to automatically wake up and run in maintainer mode to charge the 12V battery when it drops below a configured threshold.

### Why
To prevent a dead 12v battery .

### How
Introduces a new mode, MOD_MAINTAIN, it basically brings up the HV bus and enables the DCDC for wakeupMin defined minutes if allowWakeup is ON and the 12v battery drops below minVolts. Default is OFF.
uauxGain will need to be set to correct the 12v measurement. 

After a wakeup event, a further wakeup cannot occur for another 90 minutes to avoid just boiling off a dead battery.
maintainWakeups will be incremented by 1 for each wakeup


## Checklist

- [X] PR targets `Vehicle_Testing`
- [X] No AI was used in this PR
