### PR TITLE
Add on-demand preheat feature

### DIFF
--- a/include/param_prj.h
+++ b/include/param_prj.h
@@ -118,6 +118,7 @@
   PARAM_ENTRY(CAT_HEATER, HeatPotDir, ABOVEBELOW, 0, 4, 0, 150)                \
   PARAM_ENTRY(CAT_HEATER, HeatPotOn, "dig", 0, 4095, 0, 151)                   \
   PARAM_ENTRY(CAT_HEATER, HeatPotFull, "dig", 0, 4095, 0, 152)                 \
+  PARAM_ENTRY(CAT_HEATER, PreHeatNow, ONOFF, 0, 1, 0, 161)                     \
   PARAM_ENTRY(CAT_AIRCON, Compressor, COMPRESSMODES, 0, 1, 0, 153)             \
   PARAM_ENTRY(CAT_AIRCON, AirConCtrl, ONOFF, 0, 1, 0, 154)                     \
   PARAM_ENTRY(CAT_CLOCK, Set_Day, DOW, 0, 6, 0, 46)                            \

--- a/include/preheater.h
+++ b/include/preheater.h
@@ -29,6 +29,7 @@ public:
   void Ms10Task();
   void ParamsChange();
   void SetInitByPreHeat(bool initbyPH);
+  void CancelPreHeater();
 
   bool GetRunPreHeat();
   bool GetInitByPreHeat();

--- a/src/preheater.cpp
+++ b/src/preheater.cpp
@@ -58,9 +58,16 @@ void Preheater::Task200Ms(int opmode, unsigned hours, unsigned minutes) {
           (PreHeatDur_tmp != 0)) {
         RunPreHeat = true; // if we arrive at set preheat time and duration is
                            // non zero then initiate preheat
-      } else {
+      } else if (!Param::GetBool(Param::PreHeatNow)) {
         RunPreHeat = false;
       }
+
+      // On-demand preheat: check if PreHeatNow button was pressed
+      if (Param::GetBool(Param::PreHeatNow)) {
+        RunPreHeat = true;
+        Param::SetInt(Param::PreHeatNow, 0); // Reset the button
+      }
+
       IOMatrix::GetPin(IOMatrix::PREHEATOUT)->Clear();
     }
 
@@ -97,4 +104,8 @@ void Preheater::ParamsChange() {
       (GetInt(Param::Pre_Dur) *
        300); // number of 200ms ticks that equates to preheat timer in minutes
   PreHeatDur_tmp = GetInt(Param::Pre_Dur);
+}
+void Preheater::CancelPreHeater() {
+  PreHeatDur_tmp = 0;
+  PreheatTicks = 0;
 }


### PR DESCRIPTION
### What
This feature allows users to trigger preheating immediately via the web interface, in addition to the existing timer-based preheating.

### Why
On demand preheating for preheating on demand.

### How
A new parameter PreHeatNow will kick off preheating for the amount of time set.


## Checklist

- [x] PR targets `Vehicle_Testing`
- [x] No AI was used in this PR
