### PR TITLE
Throttle maps

### DIFF
--- a/include/param_prj.h
+++ b/include/param_prj.h
@@ -82,6 +82,7 @@
   PARAM_ENTRY(CAT_THROTTLE, throtmaxRev, "%", 0, 100, 30, 123)                 \
   PARAM_ENTRY(CAT_THROTTLE, throtdead, "%", 0, 50, 10, 76)                     \
   PARAM_ENTRY(CAT_THROTTLE, RegenBrakeLight, "%", -100, 0, -15, 128)           \
+  PARAM_ENTRY(CAT_THROTTLE, potlinearity, "%", 0, 100, 100, 162)               \
   PARAM_ENTRY(CAT_THROTTLE, throtrpmfilt, "rpm/10ms", 0.1, 200, 15, 131)       \
   PARAM_ENTRY(CAT_LEXUS, Gear, LOWHIGH, 0, 3, 0, 27)                           \
   PARAM_ENTRY(CAT_LEXUS, OilPump, "%", 0, 100, 50, 28)                         \

--- a/include/throttle.h
+++ b/include/throttle.h
@@ -66,6 +66,7 @@ public:
   static float regenendRpm;
   static float ThrotRpmFilt;
   static bool noregenreq;
+  static float linearity;
 
 private:
   static int speedFiltered;

--- a/src/stm32_vcu.cpp
+++ b/src/stm32_vcu.cpp
@@ -1352,6 +1352,7 @@ void Param::Change(Param::PARAM_NUM paramNum) {
   Throttle::throttleRamp = Param::GetFloat(Param::throtramp);
   Throttle::throtmaxRev = Param::GetFloat(throtmaxRev);
   Throttle::regenBrake = Param::GetFloat(Param::regenBrake);
+  Throttle::linearity = Param::GetFloat(Param::potlinearity) / 100.0f;
 
   targetCharger = static_cast<ChargeModes>(
       Param::GetInt(Param::chargemodes)); // get charger setting from menu

--- a/src/throttle.cpp
+++ b/src/throttle.cpp
@@ -51,6 +51,7 @@ float Throttle::idcmax;
 int Throttle::speedLimit;
 float Throttle::ThrotRpmFilt;
 bool Throttle::noregenreq = 0;
+float Throttle::linearity;
 float UDCres;
 float IDCres;
 float UDCprevspnt = 0;
@@ -181,6 +182,15 @@ float Throttle::CalcThrottle(int potval, int potIdx, bool brkpedal) {
     potnom = 0.0f;
   } else {
     potnom = (potnom - throtdead) * (100.0f / (100.0f - throtdead));
+  }
+
+  // Apply quadratic-linear throttle map
+  if (potnom > 0) {
+    potnom /= 100.0f;
+    float quad = potnom * potnom;
+    quad *= 1.0f - linearity;
+    float quadlinear = quad + potnom * linearity;
+    potnom = quadlinear * 100.0f;
   }
 
   //!! pedal command intent coding


### PR DESCRIPTION
### What
Merges in the quadratic throttle map from https://openinverter.org/forum/viewtopic.php?p=88283&hilit=quadratic#p88283

### Why
Allows tuning of throttle response.

### How
Use the param Param::potlinearity, defaults to 100 so no change, throttle linear, so adjust the throttle curve.

Only applies to positive throttle.

## Checklist

- [x] PR targets `Vehicle_Testing`
- [x] No AI was used in this PR
