### PR TITLE
Update libopeninv submodule to latest (jsphuebner 51a9e58)

### DIFF
--- a/src/i3LIM.cpp
+++ b/src/i3LIM.cpp
@@ -551,7 +551,8 @@ void i3LIMClass::Task100Ms() {
   bytes[5] = 0x26;
   bytes[6] = 0xf3;
   bytes[7] = 0x4b;
-  can->Send(0x431, (uint32_t *)bytes, 8); //.average 197ms but as low as 49ms.
+  can->Send(0x431, (uint32_t *)bytes,
+            8); //.average 197ms but as low as 49ms.
 
   bytes[0] = 0xf5; // Wake up message.
   bytes[1] = 0x28;

--- a/src/leafbms.cpp
+++ b/src/leafbms.cpp
@@ -55,8 +55,8 @@ void LeafBMS::DecodeCAN(int id, uint8_t *data) {
     uint16_t udc = uint16_t(bytes[2] << 2) + uint16_t(bytes[3] >> 6);
     // bool interlock = (bytes[3] & (1 << 3)) >> 3;
     // bool full = (bytes[3] & (1 << 4)) >> 4;
-    
-    if (Param::GetInt(Param::ShuntType) == 0) { 
+
+    if (Param::GetInt(Param::ShuntType) == 0) {
       // Only populate if no shunt is used
       float BattCur = cur / 2;
       float BattVoltage = udc / 2;

--- a/src/stm32_vcu.cpp
+++ b/src/stm32_vcu.cpp
@@ -86,7 +86,6 @@
 #include "preheater.h"
 #include "printf.h"
 #include "rearoutlanderinverter.h"
-#include "sdocommands.h"
 #include "shifter.h"
 #include "simpbms.h"
 #include "stm32_can.h"
@@ -1391,7 +1390,6 @@ int main(void) {
   c.AddCallback(&cb);
   c2.AddCallback(&cb);
   TerminalCommands::SetCanMap(&cm);
-  SdoCommands::SetCanMap(&cm);
   canMap = &cm;
   canSdo = &sdo;
 
@@ -1431,15 +1429,11 @@ int main(void) {
 
   while (1) {
     char c = 0;
-    CanSdo::SdoFrame *sdoFrame = sdo.GetPendingUserspaceSdo();
     t.Run();
+    // SDO requests are serviced inside CanSdo (from CanSdo::HandleRx); the loop
+    // only drives the terminal and the JSON param dump.
     if (sdo.GetPrintRequest() == PRINT_JSON) {
       TerminalCommands::PrintParamsJson(&sdo, &c);
-    }
-    if (0 != sdoFrame) {
-      SdoCommands::ProcessStandardCommands(sdoFrame);
-
-      sdo.SendSdoReply(sdoFrame);
     }
   }
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -378,7 +378,7 @@ float ProcessUdc(int motorSpeed) {
     {
       if (udc2 > Param::GetFloat(Param::udcmin)) {
         // only update UDCsw if UDC2 is above udcmin
-        Param::SetFloat(Param::udcsw, udc2 - 20); 
+        Param::SetFloat(Param::udcsw, udc2 - 20);
         // Set udcsw to 20V under battery voltage
       }
     }
@@ -395,7 +395,7 @@ float ProcessUdc(int motorSpeed) {
       Param::SetFloat(Param::udc2, udc2);
       if (udc2 > Param::GetFloat(Param::udcmin)) {
         // only update UDCsw if UDC2 is above udcmin
-        Param::SetFloat(Param::udcsw, udc2 - 20); 
+        Param::SetFloat(Param::udcsw, udc2 - 20);
         // Set udcsw to 20V under battery voltage
       }
     } else {


### PR DESCRIPTION
## Summary
Bumps the `libopeninv` submodule from the currently-pinned `3a9c0594` to the current jsphuebner tip `51a9e58`, and adapts the VCU. Hardware-validated (see Testing).

## What the bump brings
libopeninv commits since `3a9c0594` include:
- **100 kbps (`Baud100`)** CAN bit timings
- Indexed CAN-map transmit API + fix for the premature ~20-signal CAN-map limit
- SDO refactor — user-space SDO objects dispatched via `CanSdo::ProcessSDO` → `SdoCommands`

## VCU changes in this PR
1. **`CanSdo`** — drop the `GetPendingUserspaceSdo()` main-loop poll. The new `ProcessSDO` already routes user-space SDO objects (serial `0x5000` / command `0x5002`) to `SdoCommands` from `HandleRx`, so plain `CanSdo` suffices.
   - The SDO command path (incl. `parm_save`) runs in CAN-RX interrupt context — that's libopeninv's default `ProcessSDO` behaviour, not VCU code. Confirmed working on hardware (param save persists across reboot).
2. **No `Send()` call-site changes** — an earlier revision cast lengths to `uint8_t` to dodge an overload ambiguity; jsphuebner/libopeninv#56 (now in `51a9e58`) removed the ambiguous overload, so the casts are gone and `Send(id, u32buf, len)` resolves cleanly.

## clang-format
Brings `i3LIM.cpp` / `leafbms.cpp` / `utils.cpp` into line with the repo's pinned pre-commit hook (v20.1.8, `--all-files`), which flags pre-existing whitespace on every PR. Whitespace only, no functional change.

## Testing
- :white_check_mark: Builds clean for STM32F1 (`make`).
- :white_check_mark: Bench-tested on a real VCU: **Baud100 (100 kbps)** CAN init works; **Nissan Leaf inverter** runs; **SDO param save** persists across reboot.
- :white_large_square: Other peripherals (chargers, BMS, other inverters) not covered by this test.
