### PR TITLE
Add Leaf resolver-offset read/write terminal command (leafres)

### DIFF
--- a/include/leafinv.h
+++ b/include/leafinv.h
@@ -26,6 +26,33 @@
 #include "my_fp.h"
 #include <stdint.h>
 
+/* Resolver-offset diagnostics over raw CAN (req 0x784 / resp 0x78C), using the
+ * Nissan KWP2000-style services 0x10/0x21/0x3B. The full code is the
+ * concatenation of the records the inverter actually answers: record 01 (1
+ * byte) plus, on older cars, records 03 and 04 (2 bytes big-endian each). It is
+ * response-driven, not year-coded: ZE1/2018+ inverters answer only record 01
+ * (2-digit code), earlier inverters answer 01+03+04 (10-digit code). */
+struct ResolverCode {
+  uint8_t
+      bytes[5]; // rec01(1) + rec03(2) + rec04(2), in order, only present recs
+  uint8_t recordMask; // bit0=rec01 present, bit1=rec03, bit2=rec04
+  uint8_t length; // total bytes present (1 for 2-digit cars, 5 for 10-digit)
+};
+
+enum class ResolverStatus {
+  OK,
+  Moving,           // motor turning - refused
+  ThrottleApplied,  // torque requested - refused
+  NotNeutral,       // selector not in Neutral - refused
+  NoResponse,       // inverter did not answer (unpowered / wrong bus)
+  NegativeResponse, // inverter returned 7F
+  WriteStaged       // write ack'd but not active yet (power-cycle to apply)
+};
+
+#define RESOLVER_REC01 0x01
+#define RESOLVER_REC03 0x02
+#define RESOLVER_REC04 0x04
+
 class LeafINV : public Inverter {
 public:
   void DecodeCAN(int id, uint32_t data[2]);
@@ -40,9 +67,36 @@ public:
   int GetInverterState() { return error; }
   void SetCanInterface(CanHardware *c);
 
+  // Resolver offset diagnostics. Both self-gate on the safety interlock
+  // (stationary + no throttle + Neutral) and always exit the diag session.
+  ResolverStatus ResolverRead(ResolverCode &out);
+  ResolverStatus ResolverWrite(const uint8_t *bytes, uint8_t mask,
+                               ResolverCode &verifyOut);
+
+  // Debug: send one raw single frame to 0x784 and capture the 0x78C reply
+  // (no session handling - caller drives the full sequence). Self-gates on the
+  // interlock. Returns OK with rxOut filled if any frame came back, NoResponse
+  // on timeout, or the interlock status.
+  ResolverStatus ResolverRaw(const uint8_t *tx, uint8_t txLen, uint8_t *rxOut);
+  // Copy the last 0x78C frame captured (8 bytes) - for negative-response
+  // detail.
+  void GetLastDiagFrame(uint8_t *out8) const;
+
 private:
   uint8_t nissan_crc(uint8_t *data);
   static int8_t fahrenheit_to_celsius(uint16_t fahrenheit);
+
+  // ---- Resolver diag helpers ----
+  ResolverStatus InterlockCheck();
+  ResolverStatus DiagSession(); // enter Nissan session (10 AA)
+  void EndDiagSession(); // return to default session (10 81), best-effort
+  // Send one single-frame request on 0x784 and wait for the 0x78C reply.
+  // Returns NoResponse on timeout, NegativeResponse on 7F, OK otherwise (rx
+  // filled).
+  ResolverStatus DiagExchange(const uint8_t *tx, uint8_t txLen,
+                              uint8_t expectPos, uint8_t *rx);
+  ResolverStatus ReadRecords(ResolverCode &out);
+
   uint32_t lastRecv;
   int16_t speed;
   int16_t inv_temp;
@@ -50,6 +104,10 @@ private:
   bool error;
   uint16_t voltage;
   int16_t final_torque_request;
+
+  // Diagnostic RX capture: written from CAN RX interrupt, polled in main loop.
+  volatile bool diagRxValid;
+  volatile uint8_t diagRxData[8];
 };
 
 #endif // LEAFINV_H

--- a/src/leafinv.cpp
+++ b/src/leafinv.cpp
@@ -22,11 +22,22 @@
 
 #include "leafinv.h"
 #include "NissLeafMng.h"
+#include "delay.h"
 #include "my_fp.h"
 #include "my_math.h"
 #include "params.h"
 #include "stm32_can.h"
 #include "utils.h"
+
+/* Resolver-offset diagnostics for the Nissan traction-inverter ECU.
+ * Request frames go to 0x784, responses come back on 0x78C, ISO-TP single-frame
+ * (byte 0 = PCI/length). All exchanges below are synchronous: we send a frame
+ * then busy-wait for the 0x78C reply (captured in DecodeCAN from the CAN RX
+ * interrupt). Only valid while stationary, in Neutral, with no torque request.
+ */
+#define RESOLVER_REQ_ID 0x784
+#define RESOLVER_RSP_ID 0x78C
+#define RESOLVER_TIMEOUT_LOOPS 200 // x 500us busy-wait = ~100ms per exchange
 
 /*Info on running Leaf Gen 2 PDM
 IDs required :
@@ -50,8 +61,9 @@ void LeafINV::SetCanInterface(CanHardware *c) {
       c); // set Leaf VCM messages on same bus as Inverter
   can = c;
 
-  can->RegisterUserMessage(0x1DA); // Leaf inv msg
-  can->RegisterUserMessage(0x55A); // Leaf inv msg
+  can->RegisterUserMessage(0x1DA);           // Leaf inv msg
+  can->RegisterUserMessage(0x55A);           // Leaf inv msg
+  can->RegisterUserMessage(RESOLVER_RSP_ID); // Resolver diag response (0x78C)
 }
 
 void LeafINV::DecodeCAN(int id, uint32_t data[2]) {
@@ -81,6 +93,13 @@ void LeafINV::DecodeCAN(int id, uint32_t data[2]) {
   {
     inv_temp = fahrenheit_to_celsius(bytes[2]);   // INVERTER TEMP
     motor_temp = fahrenheit_to_celsius(bytes[1]); // MOTOR TEMP
+  } else if (id == RESOLVER_RSP_ID)               // Resolver diag reply (0x78C)
+  {
+    // Captured here from CAN RX interrupt; the resolver routines poll
+    // diagRxValid.
+    for (int i = 0; i < 8; i++)
+      diagRxData[i] = bytes[i];
+    diagRxValid = true;
   }
 }
 
@@ -117,4 +136,218 @@ int8_t LeafINV::fahrenheit_to_celsius(uint16_t fahrenheit) {
   if (result > 127)
     return 127;
   return result;
+}
+
+/*===========================================================================
+ * Resolver-offset diagnostics
+ *===========================================================================*/
+
+// Safety interlock: only allow resolver access when the car cannot lurch.
+ResolverStatus LeafINV::InterlockCheck() {
+  if (ABS(speed) >= 100)
+    return ResolverStatus::Moving;
+  if (final_torque_request != 0)
+    return ResolverStatus::ThrottleApplied;
+  if (Param::GetInt(Param::dir) != 0) // 0 = Neutral (see DIRS)
+    return ResolverStatus::NotNeutral;
+  return ResolverStatus::OK;
+}
+
+// Send one ISO-TP single frame on 0x784 and wait for the 0x78C reply.
+// expectPos is the expected positive-response service byte (0x50/0x61/0x7B).
+ResolverStatus LeafINV::DiagExchange(const uint8_t *tx, uint8_t txLen,
+                                     uint8_t expectPos, uint8_t *rx) {
+  if (!can)
+    return ResolverStatus::NoResponse;
+
+  uint8_t buf[8] = {0};
+  for (uint8_t i = 0; i < txLen && i < 8; i++)
+    buf[i] = tx[i];
+
+  diagRxValid = false;
+  can->Send(RESOLVER_REQ_ID, buf, 8);
+
+  uint8_t pendingCount = 0;
+  for (int i = 0; i < RESOLVER_TIMEOUT_LOOPS; i++) {
+    if (diagRxValid) {
+      for (int j = 0; j < 8; j++)
+        rx[j] = diagRxData[j];
+
+      // 7F <sid> 78 = responsePending: the ECU is busy and will send the real
+      // reply shortly. Keep waiting (fresh window) instead of failing.
+      if (rx[1] == 0x7F && rx[3] == 0x78 && pendingCount < 50) {
+        pendingCount++;
+        diagRxValid = false;
+        i = 0;
+        continue;
+      }
+
+      if (rx[1] == 0x7F) // negative response: 7F <sid> <nrc>
+        return ResolverStatus::NegativeResponse;
+      if (rx[1] != expectPos)
+        return ResolverStatus::NegativeResponse;
+      return ResolverStatus::OK;
+    }
+    uDelay(500);
+  }
+  return ResolverStatus::NoResponse;
+}
+
+// Debug helper: send one raw frame, return whatever comes back (no judgement).
+ResolverStatus LeafINV::ResolverRaw(const uint8_t *tx, uint8_t txLen,
+                                    uint8_t *rxOut) {
+  ResolverStatus s = InterlockCheck();
+  if (s != ResolverStatus::OK)
+    return s;
+  if (!can)
+    return ResolverStatus::NoResponse;
+
+  uint8_t buf[8] = {0};
+  for (uint8_t i = 0; i < txLen && i < 8; i++)
+    buf[i] = tx[i];
+
+  diagRxValid = false;
+  can->Send(RESOLVER_REQ_ID, buf, 8);
+
+  for (int i = 0; i < RESOLVER_TIMEOUT_LOOPS && !diagRxValid; i++)
+    uDelay(500);
+
+  if (!diagRxValid)
+    return ResolverStatus::NoResponse;
+
+  for (int j = 0; j < 8; j++)
+    rxOut[j] = diagRxData[j];
+  return ResolverStatus::OK;
+}
+
+void LeafINV::GetLastDiagFrame(uint8_t *out8) const {
+  for (int i = 0; i < 8; i++)
+    out8[i] = diagRxData[i];
+}
+
+// Enter Nissan manufacturer session (10 AA) — unlocks the resolver records.
+ResolverStatus LeafINV::DiagSession() {
+  static const uint8_t req[] = {0x02, 0x10, 0xAA};
+  uint8_t rx[8];
+  return DiagExchange(req, sizeof(req), 0x50, rx);
+}
+
+// Return to default session (10 81). Best-effort — the session also times out
+// on its own, so a missing/negative reply is ignored.
+void LeafINV::EndDiagSession() {
+  static const uint8_t req[] = {0x02, 0x10, 0x81};
+  uint8_t rx[8];
+  DiagExchange(req, sizeof(req), 0x50, rx);
+}
+
+// Probe records 01 (required), 03 and 04 (optional), packing whatever replies
+// 61 contiguously into out.bytes. Assumes the diag session is already open.
+ResolverStatus LeafINV::ReadRecords(ResolverCode &out) {
+  uint8_t rx[8];
+  out.recordMask = 0;
+  out.length = 0;
+  for (int i = 0; i < 5; i++)
+    out.bytes[i] = 0;
+
+  // Record 01 (1 byte) — must be present on every car.
+  static const uint8_t req01[] = {0x02, 0x21, 0x01};
+  ResolverStatus s = DiagExchange(req01, sizeof(req01), 0x61, rx);
+  if (s != ResolverStatus::OK)
+    return s;
+  out.bytes[out.length++] = rx[3];
+  out.recordMask |= RESOLVER_REC01;
+
+  // Record 03 (2 bytes BE) — present on 10-digit cars only.
+  static const uint8_t req03[] = {0x02, 0x21, 0x03};
+  if (DiagExchange(req03, sizeof(req03), 0x61, rx) == ResolverStatus::OK) {
+    out.bytes[out.length++] = rx[3];
+    out.bytes[out.length++] = rx[4];
+    out.recordMask |= RESOLVER_REC03;
+  }
+
+  // Record 04 (2 bytes BE) — present on 10-digit cars only.
+  static const uint8_t req04[] = {0x02, 0x21, 0x04};
+  if (DiagExchange(req04, sizeof(req04), 0x61, rx) == ResolverStatus::OK) {
+    out.bytes[out.length++] = rx[3];
+    out.bytes[out.length++] = rx[4];
+    out.recordMask |= RESOLVER_REC04;
+  }
+
+  return ResolverStatus::OK;
+}
+
+ResolverStatus LeafINV::ResolverRead(ResolverCode &out) {
+  ResolverStatus s = InterlockCheck();
+  if (s != ResolverStatus::OK)
+    return s;
+
+  // Session is best-effort: some inverters (per the LeafSpy-era docs) require
+  // 10 AA to unlock the records, others (e.g. 2-digit ZE1-style) reject it and
+  // read/write fine without any session. Proceed regardless and let the actual
+  // 61/7B responses be the real success signal.
+  (void)DiagSession();
+
+  s = ReadRecords(out);
+  EndDiagSession();
+  return s;
+}
+
+// Write the records named by mask (bytes packed contiguously in the same order
+// as ReadRecords produces), then re-read and verify. The caller is expected to
+// pass exactly the record set that a preceding ResolverRead reported present.
+ResolverStatus LeafINV::ResolverWrite(const uint8_t *bytes, uint8_t mask,
+                                      ResolverCode &verifyOut) {
+  ResolverStatus s = InterlockCheck();
+  if (s != ResolverStatus::OK)
+    return s;
+
+  (void)DiagSession(); // best-effort, see ResolverRead
+
+  uint8_t rx[8];
+  uint8_t idx = 0;
+
+  if (mask & RESOLVER_REC01) {
+    uint8_t req[] = {0x03, 0x3B, 0x01, bytes[idx]};
+    s = DiagExchange(req, sizeof(req), 0x7B, rx);
+    if (s != ResolverStatus::OK) {
+      EndDiagSession();
+      return s;
+    }
+    idx += 1;
+  }
+  if (mask & RESOLVER_REC03) {
+    uint8_t req[] = {0x04, 0x3B, 0x03, bytes[idx], bytes[idx + 1]};
+    s = DiagExchange(req, sizeof(req), 0x7B, rx);
+    if (s != ResolverStatus::OK) {
+      EndDiagSession();
+      return s;
+    }
+    idx += 2;
+  }
+  if (mask & RESOLVER_REC04) {
+    uint8_t req[] = {0x04, 0x3B, 0x04, bytes[idx], bytes[idx + 1]};
+    s = DiagExchange(req, sizeof(req), 0x7B, rx);
+    if (s != ResolverStatus::OK) {
+      EndDiagSession();
+      return s;
+    }
+    idx += 2;
+  }
+
+  // Re-read to verify. Some inverters apply the new offset immediately (the
+  // re-read matches → OK). Others stage it and only make it active after a
+  // power cycle, so an immediate re-read still shows the old value — that is
+  // WriteStaged, not a failure (the 7B acks above confirm the write landed).
+  s = ReadRecords(verifyOut);
+  EndDiagSession();
+  if (s != ResolverStatus::OK)
+    return s;
+
+  if (verifyOut.recordMask != mask || verifyOut.length != idx)
+    return ResolverStatus::WriteStaged;
+  for (uint8_t i = 0; i < idx; i++) {
+    if (verifyOut.bytes[i] != bytes[i])
+      return ResolverStatus::WriteStaged;
+  }
+  return ResolverStatus::OK;
 }

--- a/src/stm32_vcu.cpp
+++ b/src/stm32_vcu.cpp
@@ -75,6 +75,7 @@
 #include "leafinv.h"
 #include "linbus.h"
 #include "my_math.h"
+#include "my_string.h"
 #include "noHeater.h"
 #include "no_Lever.h"
 #include "nocharger.h"
@@ -1273,6 +1274,325 @@ void Param::Change(Param::PARAM_NUM paramNum) {
   IOMatrix::AssignFromParamsAnalogue();
 
   preheater.ParamsChange();
+}
+
+/*===========================================================================
+ * leafres — Leaf resolver-offset read/write terminal command
+ *
+ * Reads/writes the traction-inverter resolver offset over raw CAN
+ * (req 0x784 / resp 0x78C). Writes are two-step: a
+ * preview ("leafres write <code>") stores a pending request, then
+ * "leafres write <code> confirm" applies it and verifies by re-reading.
+ * All bus access is gated on LeafINV's stationary + Neutral + no-throttle
+ * interlock, and the diagnostic session is always closed afterwards.
+ *===========================================================================*/
+static bool resPendingValid = false;
+static char resPendingCode[16];
+static uint8_t resPendingBytes[5];
+static uint8_t resPendingMask;
+
+static int ResHexNibble(char c) {
+  if (c >= '0' && c <= '9')
+    return c - '0';
+  if (c >= 'a' && c <= 'f')
+    return c - 'a' + 10;
+  if (c >= 'A' && c <= 'F')
+    return c - 'A' + 10;
+  return -1;
+}
+
+// Parse an even-length hex string into bytes. Returns count, or -1 on error.
+static int ResHexToBytes(const char *s, uint8_t *out, int maxOut) {
+  int len = my_strlen(s);
+  if (len == 0 || (len & 1))
+    return -1;
+  int n = len / 2;
+  if (n > maxOut)
+    return -1;
+  for (int i = 0; i < n; i++) {
+    int hi = ResHexNibble(s[2 * i]);
+    int lo = ResHexNibble(s[2 * i + 1]);
+    if (hi < 0 || lo < 0)
+      return -1;
+    out[i] = (uint8_t)((hi << 4) | lo);
+  }
+  return n;
+}
+
+static void ResPrintCode(Terminal *t, const ResolverCode &c) {
+  for (uint8_t i = 0; i < c.length; i++)
+    fprintf(t, "%02X", c.bytes[i]);
+}
+
+static void ResRecordList(Terminal *t, uint8_t mask) {
+  fprintf(t, "[");
+  if (mask & RESOLVER_REC01)
+    fprintf(t, "01");
+  if (mask & RESOLVER_REC03)
+    fprintf(t, " 03");
+  if (mask & RESOLVER_REC04)
+    fprintf(t, " 04");
+  fprintf(t, "]");
+}
+
+// Decode the common UDS negative-response codes (ISO 14229).
+static const char *ResNrcName(uint8_t nrc) {
+  switch (nrc) {
+  case 0x10:
+    return "general reject";
+  case 0x11:
+    return "service not supported";
+  case 0x12:
+    return "subfunction not supported";
+  case 0x13:
+    return "bad length/format";
+  case 0x22:
+    return "conditions not correct";
+  case 0x31:
+    return "request out of range";
+  case 0x33:
+    return "security access denied";
+  case 0x35:
+    return "invalid key";
+  case 0x7E:
+    return "subfunc not supported in session";
+  case 0x7F:
+    return "service not supported in session";
+  default:
+    return "see ISO 14229";
+  }
+}
+
+// Print a message for a non-OK status. Returns true only if status was OK.
+static bool ResReportStatus(Terminal *t, ResolverStatus s) {
+  switch (s) {
+  case ResolverStatus::OK:
+    return true;
+  case ResolverStatus::Moving:
+    fprintf(t, "leafres: refused - vehicle is moving\r\n");
+    break;
+  case ResolverStatus::ThrottleApplied:
+    fprintf(
+        t, "leafres: refused - release throttle (torque request not zero)\r\n");
+    break;
+  case ResolverStatus::NotNeutral:
+    fprintf(t, "leafres: refused - selector must be in Neutral\r\n");
+    break;
+  case ResolverStatus::NoResponse:
+    fprintf(t, "leafres: no reply - power on the inverter (key to RUN), "
+               "keep stationary in Neutral\r\n");
+    break;
+  case ResolverStatus::NegativeResponse: {
+    uint8_t f[8];
+    leafInv.GetLastDiagFrame(f);
+    fprintf(t,
+            "leafres: inverter rejected request [%02X %02X %02X %02X %02X %02X "
+            "%02X %02X]\r\n",
+            f[0], f[1], f[2], f[3], f[4], f[5], f[6], f[7]);
+    // Negative frame layout: [0]=len [1]=7F [2]=service [3]=NRC
+    if (f[1] == 0x7F)
+      fprintf(t, "         service %02X, NRC %02X (%s)\r\n", f[2], f[3],
+              ResNrcName(f[3]));
+    else
+      fprintf(t, "         unexpected response byte %02X (wanted 50/61/7B)\r\n",
+              f[1]);
+    break;
+  }
+  case ResolverStatus::WriteStaged:
+    fprintf(t, "leafres: write accepted (acked) - value is staged. Power-cycle "
+               "the inverter, then 'leafres read' to confirm it applied.\r\n");
+    break;
+  }
+  return false;
+}
+
+void LeafResolverCommand(Terminal *t, char *arg) {
+  if (Param::GetInt(Param::Inverter) != InvModes::Leaf_Gen1) {
+    fprintf(t, "leafres: Leaf inverter not selected (set Inverter=1)\r\n");
+    return;
+  }
+
+  arg = my_trim(arg);
+  char *sp = (char *)my_strchr(arg, ' ');
+  char *rest = (char *)"";
+  if (*sp != 0) {
+    *sp = 0;
+    rest = my_trim(sp + 1);
+  }
+
+  if (my_strcmp(arg, "read") == 0) {
+    ResolverCode cur;
+    if (!ResReportStatus(t, leafInv.ResolverRead(cur)))
+      return;
+    fprintf(t, "leafres: code = ");
+    ResPrintCode(t, cur);
+    fprintf(t, "  records ");
+    ResRecordList(t, cur.recordMask);
+    fprintf(t, "\r\n");
+    return;
+  }
+
+  if (my_strcmp(arg, "raw") == 0) {
+    // Low-level probe: send one frame, print the raw reply. e.g.
+    //   leafres raw 0210AA   (enter session)   leafres raw 022101   (read 01)
+    if (*rest == 0) {
+      fprintf(t, "usage: leafres raw <hexframe>   e.g. leafres raw 0210AA\r\n");
+      return;
+    }
+    uint8_t tx[8];
+    int n = ResHexToBytes(rest, tx, 8);
+    if (n < 0) {
+      fprintf(t, "leafres: bad hex frame '%s' (contiguous hex, no spaces)\r\n",
+              rest);
+      return;
+    }
+    uint8_t rx[8];
+    ResolverStatus s = leafInv.ResolverRaw(tx, (uint8_t)n, rx);
+    if (s != ResolverStatus::OK) {
+      ResReportStatus(t,
+                      s); // Moving / ThrottleApplied / NotNeutral / NoResponse
+      return;
+    }
+    fprintf(t, "leafres raw reply: %02X %02X %02X %02X %02X %02X %02X %02X\r\n",
+            rx[0], rx[1], rx[2], rx[3], rx[4], rx[5], rx[6], rx[7]);
+    return;
+  }
+
+  if (my_strcmp(arg, "probe") == 0) {
+    // Discover which diagnostic session this inverter accepts. First check if
+    // record 01 reads with no session at all, then sweep candidate session
+    // sub-functions; on a positive (50) reply, immediately try reading rec 01.
+    // Only changes the diagnostic session (benign, auto-expires).
+    uint8_t rx[8];
+    uint8_t rd[] = {0x02, 0x21, 0x01};
+
+    ResolverStatus s = leafInv.ResolverRaw(rd, sizeof(rd), rx);
+    if (s == ResolverStatus::Moving || s == ResolverStatus::ThrottleApplied ||
+        s == ResolverStatus::NotNeutral) {
+      ResReportStatus(t, s);
+      return;
+    }
+    if (s == ResolverStatus::NoResponse)
+      fprintf(t, "no-session 21 01: no reply\r\n");
+    else
+      fprintf(t, "no-session 21 01: %02X %02X %02X %02X\r\n", rx[0], rx[1],
+              rx[2], rx[3]);
+
+    static const uint8_t subs[] = {0x01, 0x03, 0x40, 0x81, 0x85, 0x87,
+                                   0x92, 0xA0, 0xAA, 0xC0, 0xFA, 0xFB};
+    for (unsigned k = 0; k < sizeof(subs); k++) {
+      uint8_t tx[] = {0x02, 0x10, subs[k]};
+      s = leafInv.ResolverRaw(tx, sizeof(tx), rx);
+      if (s == ResolverStatus::Moving || s == ResolverStatus::ThrottleApplied ||
+          s == ResolverStatus::NotNeutral) {
+        ResReportStatus(t, s);
+        return;
+      }
+      if (s == ResolverStatus::NoResponse) {
+        fprintf(t, "10 %02X: no reply\r\n", subs[k]);
+        continue;
+      }
+      if (rx[1] == 0x50) {
+        uint8_t r2[8];
+        leafInv.ResolverRaw(rd, sizeof(rd), r2);
+        fprintf(t, "10 %02X: SESSION OK -> 21 01 = %02X %02X %02X %02X\r\n",
+                subs[k], r2[0], r2[1], r2[2], r2[3]);
+      } else if (rx[1] == 0x7F) {
+        fprintf(t, "10 %02X: 7F NRC %02X\r\n", subs[k], rx[3]);
+      } else {
+        fprintf(t, "10 %02X: ? %02X\r\n", subs[k], rx[1]);
+      }
+    }
+    fprintf(t, "leafres: probe done\r\n");
+    return;
+  }
+
+  if (my_strcmp(arg, "write") == 0) {
+    // Split rest into <code> and optional "confirm".
+    char *code = rest;
+    char *sp2 = (char *)my_strchr(rest, ' ');
+    bool confirm = false;
+    if (*sp2 != 0) {
+      *sp2 = 0;
+      confirm = (my_strcmp(my_trim(sp2 + 1), "confirm") == 0);
+    }
+    if (*code == 0) {
+      fprintf(t, "usage: leafres write <hexcode> [confirm]\r\n");
+      return;
+    }
+
+    if (confirm) {
+      // Confirm step: must match the previewed code exactly.
+      if (!resPendingValid || my_strcmp(resPendingCode, code) != 0) {
+        fprintf(
+            t,
+            "leafres: no matching preview - run 'leafres write %s' first\r\n",
+            code);
+        return;
+      }
+      ResolverCode verified;
+      ResolverStatus s =
+          leafInv.ResolverWrite(resPendingBytes, resPendingMask, verified);
+      resPendingValid = false; // single-shot, even on failure
+      if (!ResReportStatus(t, s))
+        return;
+      fprintf(t, "leafres: write OK, verified ");
+      ResPrintCode(t, verified);
+      fprintf(t, "\r\n");
+      return;
+    }
+
+    // Preview step: read current to learn the present record set + values.
+    ResolverCode cur;
+    if (!ResReportStatus(t, leafInv.ResolverRead(cur)))
+      return;
+
+    uint8_t newBytes[5];
+    int n = ResHexToBytes(code, newBytes, 5);
+    if (n < 0) {
+      fprintf(t, "leafres: bad hex code '%s'\r\n", code);
+      return;
+    }
+    if ((uint8_t)n != cur.length) {
+      fprintf(t, "leafres: this car expects %d hex digits (records ",
+              cur.length * 2);
+      ResRecordList(t, cur.recordMask);
+      fprintf(t, "), got %d\r\n", n * 2);
+      return;
+    }
+
+    fprintf(t, "leafres WRITE preview:\r\n");
+    uint8_t idx = 0;
+    if (cur.recordMask & RESOLVER_REC01) {
+      fprintf(t, "  rec01: %02X -> %02X\r\n", cur.bytes[idx], newBytes[idx]);
+      idx += 1;
+    }
+    if (cur.recordMask & RESOLVER_REC03) {
+      fprintf(t, "  rec03: %02X%02X -> %02X%02X\r\n", cur.bytes[idx],
+              cur.bytes[idx + 1], newBytes[idx], newBytes[idx + 1]);
+      idx += 2;
+    }
+    if (cur.recordMask & RESOLVER_REC04) {
+      fprintf(t, "  rec04: %02X%02X -> %02X%02X\r\n", cur.bytes[idx],
+              cur.bytes[idx + 1], newBytes[idx], newBytes[idx + 1]);
+      idx += 2;
+    }
+
+    my_strcpy(resPendingCode, code);
+    for (int i = 0; i < n; i++)
+      resPendingBytes[i] = newBytes[i];
+    resPendingMask = cur.recordMask;
+    resPendingValid = true;
+
+    fprintf(t, "to APPLY:   leafres write %s confirm\r\n", code);
+    fprintf(t, "to RESTORE: leafres write ");
+    ResPrintCode(t, cur);
+    fprintf(t, " confirm\r\n");
+    return;
+  }
+
+  fprintf(t, "usage: leafres read | leafres write <hexcode> [confirm] | "
+             "leafres probe | leafres raw <hexframe>\r\n");
 }
 
 static bool CanCallback(

--- a/src/terminal_prj.cpp
+++ b/src/terminal_prj.cpp
@@ -36,6 +36,8 @@ static void PrintList(Terminal *t, char *arg);
 static void PrintAtr(Terminal *t, char *arg);
 static void PrintSerial(Terminal *t, char *arg);
 static void PrintErrors(Terminal *t, char *arg);
+// Leaf resolver-offset read/write (defined in stm32_vcu.cpp).
+extern void LeafResolverCommand(Terminal *t, char *arg);
 
 extern const TERM_CMD TermCmds[] = {{"set", TerminalCommands::ParamSet},
                                     {"get", TerminalCommands::ParamGet},
@@ -52,6 +54,7 @@ extern const TERM_CMD TermCmds[] = {{"set", TerminalCommands::ParamSet},
                                     {"serial", PrintSerial},
                                     {"errors", PrintErrors},
                                     {"reset", TerminalCommands::Reset},
+                                    {"leafres", LeafResolverCommand},
                                     {NULL, NULL}};
 
 static void PrintList(Terminal *t, char *arg) {


### PR DESCRIPTION
## Summary
Adds a `leafres` VCU terminal command to read and write the Nissan Leaf traction-inverter **resolver offset** over raw CAN (req `0x784` / resp `0x78C`, KWP2000-style services `0x10`/`0x21`/`0x3B`). Lets the offset be set from the VCU console after a motor/inverter swap, with no extra diag tool. Self-contained in `LeafINV` (synchronous request/response, reply captured from the CAN-RX interrupt); terminal glue in `stm32_vcu.cpp`; registered in `TermCmds[]`.
Big thanks to @dalathegreat for the original research on this!

## Subcommands
- `leafres read` — probe records 01/03/04, print the code
- `leafres write <code>` — preview current→new + a restore line
- `leafres write <code> confirm` — apply (exact code must be repeated), then verify by re-reading
- `leafres probe` / `leafres raw <hexframe>` — diagnostics (session sweep / single raw frame)

## Behaviour
- **Response-driven:** handles 10-digit (01+03+04) and 2-digit (01-only, ZE1-style) inverters — keeps whatever answers `0x61`.
- Diagnostic session is **best-effort** (some inverters need `10 AA`, others read/write without it; the `61`/`7B` responses are the real success signal).
- Writes **verify by re-reading**; inverters that *stage* the value (apply on power-cycle) report "staged" with guidance rather than a false failure.
- **Safety interlock:** allowed only when stationary (`|rpm| < 100`), in Neutral, and with zero torque request; the diag session is always closed afterwards.

## Independent of the libopeninv version
Uses only `can->Send` (uint8_t buffers), `RegisterUserMessage`, `DecodeCAN`, and `uDelay` — all present in the currently-pinned libopeninv. This PR does **not** bump the submodule; it builds clean against the current pin (`3a9c0594`) and is independent of #239.

## Testing
- :white_check_mark: Builds clean for STM32F1 (`make`).
- :white_check_mark: Bench-tested on a real 2-digit (ZE1-style) Leaf inverter: `read` returns the offset; `write` → `confirm` writes and the value persists across a power cycle.

(The pre-commit clang-format job will show red on pre-existing `leafbms.cpp`/`utils.cpp` whitespace — unrelated to this PR; it fails on every PR via `--all-files`. This PR's own files are clang-clean.)
