### PR TITLE
Update libopeninv submodule to latest (jsphuebner 51a9e58)

### DIFF
--- a/src/stm32_vcu.cpp
+++ b/src/stm32_vcu.cpp
@@ -89,7 +89,6 @@
 #include "preheater.h"
 #include "printf.h"
 #include "rearoutlanderinverter.h"
-#include "sdocommands.h"
 #include "shifter.h"
 #include "simpbms.h"
 #include "stm32_can.h"
@@ -1495,7 +1494,6 @@ int main(void) {
   c.AddCallback(&cb);
   c2.AddCallback(&cb);
   TerminalCommands::SetCanMap(&cm);
-  SdoCommands::SetCanMap(&cm);
   canMap = &cm;
   canSdo = &sdo;
 
@@ -1536,15 +1534,11 @@ int main(void) {
 
   while (1) {
     char c = 0;
-    CanSdo::SdoFrame *sdoFrame = sdo.GetPendingUserspaceSdo();
     t.Run();
+    // SDO requests are serviced inside CanSdo (from CanSdo::HandleRx); the loop
+    // only drives the terminal and the JSON param dump.
     if (sdo.GetPrintRequest() == PRINT_JSON) {
       TerminalCommands::PrintParamsJson(&sdo, &c);
-    }
-    if (0 != sdoFrame) {
-      SdoCommands::ProcessStandardCommands(sdoFrame);
-
-      sdo.SendSdoReply(sdoFrame);
     }
   }
 


### PR DESCRIPTION
## Summary
Bumps the `libopeninv` submodule from Vehicle_Testing's pinned `3a9c0594` to the current jsphuebner tip `51a9e58`, and adapts the VCU. (Re-targeted from master to `Vehicle_Testing` per CONTRIBUTING.md — replaces #239.)

## What the bump brings
- **100 kbps (`Baud100`)**  CAN bit timings
- Indexed CAN-map transmit API + fix for the premature ~20-signal CAN-map limit
- SDO refactor — user-space SDO objects dispatched via `CanSdo::ProcessSDO` → `SdoCommands`

## VCU changes (2 files)
1. **`CanSdo`** — drop the `GetPendingUserspaceSdo()` main-loop poll (plus the now-redundant `SdoCommands::SetCanMap` + its include). The new `ProcessSDO` routes user-space SDO objects (serial `0x5000` / command `0x5002`) to `SdoCommands` from `HandleRx`, so plain `CanSdo` suffices.
   - The SDO command path (incl. `parm_save`) runs in CAN-RX interrupt context — that's libopeninv's default `ProcessSDO` behaviour, not VCU code. Confirmed working on hardware (param save persists across reboot).
2. **No `Send()` call-site changes** — `51a9e58` includes https://github.com/jsphuebner/libopeninv/pull/56 so `Send(id, u32buf, len)` resolves cleanly without casts.

## Testing
- :white_check_mark: Builds clean for STM32F1 (`make`).
- :white_check_mark: Bench-tested on a real VCU: **Baud100 (100 kbps)** works; **Nissan Leaf inverter** runs; **SDO param save** persists across reboot.

(The pre-commit clang-format job is red on pre-existing `Vehicle_Testing` whitespace — `WebastoHVH`, `Maintainer12V`, `oibms`, `notused.h` — unrelated to this PR; it fails on every PR via `--all-files`. This PR's own files are clang-clean.)
