### PR TITLE
Add Inverter::SupportsReverseMotor() so reversemotor works per-inverter

### DIFF
--- a/include/inverter.h
+++ b/include/inverter.h
@@ -34,6 +34,9 @@ public:
   virtual float GetInverterVoltage() = 0;
   virtual float GetMotorSpeed() = 0;
   virtual int GetInverterState() = 0;
+  // Whether this inverter honours the reversemotor parameter (flips rotation).
+  // Default false; inverters that implement the flip override this to true.
+  virtual bool SupportsReverseMotor() { return false; }
   virtual void DeInit() {
   } // called when switching to another inverter, similar to a destructor
   virtual void SetCanInterface(CanHardware *c) { can = c; }

--- a/include/leafinv.h
+++ b/include/leafinv.h
@@ -38,6 +38,7 @@ public:
   float GetInverterVoltage() { return voltage; }
   float GetMotorSpeed() { return speed; }
   int GetInverterState() { return error; }
+  bool SupportsReverseMotor() override { return true; }
   void SetCanInterface(CanHardware *c);
 
 private:

--- a/include/rearoutlanderinverter.h
+++ b/include/rearoutlanderinverter.h
@@ -36,6 +36,7 @@ public:
   float GetInverterVoltage() { return voltage; }
   float GetMotorSpeed() { return speed; }
   int GetInverterState() { return error; }
+  bool SupportsReverseMotor() override { return true; }
 
 private:
   uint8_t run10ms;

--- a/src/stm32_vcu.cpp
+++ b/src/stm32_vcu.cpp
@@ -1317,12 +1317,9 @@ void Param::Change(Param::PARAM_NUM paramNum) {
     break;
   }
 
-  if (Param::GetInt(Param::reversemotor) != 0) {
-    if (Param::GetInt(Param::Inverter) == InvModes::RearOutlander) {
-
-    } else {
-      Param::SetInt(Param::reversemotor, 0);
-    }
+  if (Param::GetInt(Param::reversemotor) != 0 &&
+      !selectedInverter->SupportsReverseMotor()) {
+    Param::SetInt(Param::reversemotor, 0);
   }
 
   Throttle::potmin[0] = Param::GetInt(Param::potmin);


### PR DESCRIPTION
## Summary

Fixes #243.

`reversemotor` was force-reset to `0` for every inverter except `RearOutlander`, via a hard-coded enum check in `Param::Change()`. That block runs after the parameter `switch` on *every* parameter change (and at boot), so the toggle could never stick for the Leaf — even though `LeafINV::SetTorque()` already implements the rotation flip when `reversemotor == 1`.

## Change

Move the "does this inverter support reverse?" decision onto the inverter itself instead of a central enum list:

- Add `virtual bool SupportsReverseMotor()` to the `Inverter` base class, defaulting to `false`.
- Override it to `true` in `RearOutlanderInverter` (preserves existing behaviour) and `LeafINV` (enables the existing flip logic, which was previously dead).
- `Param::Change()` now resets `reversemotor` only when the *currently selected* inverter doesn't support it:

```cpp
if (Param::GetInt(Param::reversemotor) != 0 &&
    !selectedInverter->SupportsReverseMotor()) {
    Param::SetInt(Param::reversemotor, 0);
}
```

Ordering is safe: when the `Inverter` parameter changes, `UpdateInv()` runs first (inside the switch) and repoints `selectedInverter`, so the capability check sees the newly selected inverter.

Adding support to another inverter is now a one-line override rather than another branch in the central gate.

## Testing

- Builds clean with `make` (arm-none-eabi).

## Note: regen interaction with the Leaf torque invert

Since this is the first time `reversemotor` can actually be enabled on the Leaf, it's worth confirming the regen path behaves with the torque invert on. I had a look and I think it's fine — and it looks like it was written with this in mind.

The regen rolling-direction safety in the `MOD_RUN` torque path already has an explicit `reversemotor` branch:

```cpp
if (torquePercent < 0 && Param::Inverter != InvModes::OpenI) {
  if (Param::GetInt(Param::reversemotor) == 0)
      rollingDirection = previousSpeed >= 0 ? 1 : -1;
  else
      rollingDirection = previousSpeed >= 0 ? -1 : 1;   // flipped when reversed
  if (rollingDirection != requestedDirection)
      torquePercent = -torquePercent;
}
torquePercent *= requestedDirection;
```

`reversemotor` shows up twice on the Leaf: here (how the signed motor speed is interpreted) and again in `LeafINV::SetTorque()` (the actual torque invert). Working the signs through, the two cancel (the `reversemotor` factor squares to 1), so the regen torque always opposes the **actual** rotor direction regardless of gear or `reversemotor`. The safety that stops "braking accelerates you when you've rolled back on a hill" still holds.

Concrete worst case with `reversemotor = 1`: forward gear, braking, but rolled backward on a hill. With the motor reversed, a backward roll reads `speed > 0`, so `rollingDirection` comes out `-1`, which differs from the forward gear → the torque flips → after the `SetTorque` invert the inverter torque opposes the backward roll and slows it, rather than accelerating it. ✓

Everything else the regen path touches is magnitude-based — `ProcessThrottle(ABS(speed))`, the regen-rpm taper, and the speed limiter all use `|speed|` — so the torque-sign invert can't affect them.

@Tom-evnut you worked on the regen recently — does this match your understanding? Happy to adjust if the intended sign convention differs.
