### PR TITLE
Separate input, output and PWM I/O function lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,48 +4,53 @@
 
 Project based on the OpenInverter System by Johannes Huebner to provide a universal VCU (Vehicle Control Unit) for electric vehicle conversion projects. 
 
-Please visit the development thread on the Openinverter Forum for more information : https://openinverter.org/forum/viewtopic.php?f=3&t=1277
+wiki page: https://openinverter.org/wiki/ZombieVerter_VCU
 ![Screenshot from 2025-01-28 14-17-28](https://github.com/user-attachments/assets/ff066c9e-8c79-470d-aa04-bc3b34198900)
 
 ## Videos on progress
 
 Project introduction : https://vimeo.com/506480876
 
-V1.11a On dyno with GS450h / BMW E39 : https://vimeo.com/802405172
-
-V2.00a now available : https://vimeo.com/824494783?share=copy
-
-V2.15a now available : https://www.youtube.com/watch?v=iwB3wxCEFo0
-
-V2.20A now available : https://www.youtube.com/watch?v=wjlucUWX_lc
-
 # Supported components
-
+Drive trains:
 - Nissan Leaf Gen1/2/3 inverter via CAN
-- Nissan Leaf Gen1/2/3 PDM (Charger and DCDC)
-- Nissan LEAF Battery (all variants)
-- Mitsubishi Outlander Support
 - Mitsubishi Outlander drivetrain (front and rear motors/inverters) Support
-- Modular BMS / SimpBMS Support
-- OpenInverter CAN Support
-- CCS DC fast charge via BMW i3 LIM
-- CCS DC fast charging via FOCCCI https://github.com/uhi22/ccs32clara
-- Chademo DC fast charge
-- ISA Shunt / BMW SBOX / VW EBOX supported via CAN
 - Lexus GS450H inverter / gearbox via sync serial
 - Lexus GS300H inverter / gearbox via sync serial
 - Toyota Prius/Yaris/Auris Gen 3 inverters via sync serial
+
+Chargers/DCDC converters:
+- Nissan Leaf Gen1/2/3 PDM (Charger and DCDC)
+- Nissan LEAF Battery (all variants)
+- Mitsubishi Outlander OBC
+- TESLA Gen 2 DCDC Converter Can support
+- Elcon charger Support
+- CCS DC fast charge via BMW i3 LIM
+- CCS DC fast charging via FOCCCI https://github.com/uhi22/ccs32clara
+- Chademo DC fast charge
+
+BMS:
+- Modular BMS / SimpBMS Support
+- ISA Shunt / BMW SBOX / VW EBOX supported via CAN
+- can mappable
+
+Vehicles: 
 - BMW E46 CAN support
 - BMW E39 CAN support
 - BMW E65 CAN Support
 - BMW E31 CAN Support
 - Mid 2000s VAG Can support
 - Subaru vehicle support
+- classic
+
+ Heaters:
 - Opel Ampera / Chevy Volt 6.5kw cabin heater
 - VW LIN based 6.5kw cabin heater
-- Elcon charger Support
+
+CAN interface:
 - OBD2 Can support
-- TESLA Gen 2 DCDC Converter Can support
+- OpenInverter CAN Support
+
 
 
 # Contributing

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Chargers/DCDC converters:
 - CCS DC fast charge via BMW i3 LIM
 - CCS DC fast charging via FOCCCI https://github.com/uhi22/ccs32clara
 - Chademo DC fast charge
+- tesla OBC with OI replacment (gen 2/3, pcs) 
 
 BMS:
 - Modular BMS / SimpBMS Support

--- a/include/param_prj.h
+++ b/include/param_prj.h
@@ -132,19 +132,19 @@
   PARAM_ENTRY(CAT_CLOCK, Pre_Min, "Mins", 0, 59, 0, 54)                        \
   PARAM_ENTRY(CAT_CLOCK, Pre_Dur, "Mins", 0, 60, 0, 55)                        \
   PARAM_ENTRY(CAT_IOPINS, PumpPWM, PumpOutType, 0, 2, 0, 135)                  \
-  PARAM_ENTRY(CAT_IOPINS, Out1Func, PINFUNCS, 0, 18, 6, 80)                    \
-  PARAM_ENTRY(CAT_IOPINS, Out2Func, PINFUNCS, 0, 18, 7, 81)                    \
-  PARAM_ENTRY(CAT_IOPINS, Out3Func, PINFUNCS, 0, 18, 3, 82)                    \
-  PARAM_ENTRY(CAT_IOPINS, SL1Func, PINFUNCS, 0, 18, 0, 83)                     \
-  PARAM_ENTRY(CAT_IOPINS, SL2Func, PINFUNCS, 0, 18, 0, 84)                     \
-  PARAM_ENTRY(CAT_IOPINS, PWM1Func, PINFUNCS, 0, 25, 0, 85)                    \
-  PARAM_ENTRY(CAT_IOPINS, PWM2Func, PINFUNCS, 0, 25, 4, 86)                    \
-  PARAM_ENTRY(CAT_IOPINS, PWM3Func, PINFUNCS, 0, 25, 2, 87)                    \
-  PARAM_ENTRY(CAT_IOPINS, GP12VInFunc, PINFUNCS, 0, 19, 12, 98)                \
-  PARAM_ENTRY(CAT_IOPINS, HVReqFunc, PINFUNCS, 0, 19, 12, 99)                  \
-  PARAM_ENTRY(CAT_IOPINS, PB1InFunc, PINFUNCS, 0, 19, 12, 140)                 \
-  PARAM_ENTRY(CAT_IOPINS, PB2InFunc, PINFUNCS, 0, 19, 12, 141)                 \
-  PARAM_ENTRY(CAT_IOPINS, PB3InFunc, PINFUNCS, 0, 19, 12, 142)                 \
+  PARAM_ENTRY(CAT_IOPINS, Out1Func, OUTPUTPINFUNCS, 0, 18, 6, 80)              \
+  PARAM_ENTRY(CAT_IOPINS, Out2Func, OUTPUTPINFUNCS, 0, 18, 7, 81)              \
+  PARAM_ENTRY(CAT_IOPINS, Out3Func, OUTPUTPINFUNCS, 0, 18, 3, 82)              \
+  PARAM_ENTRY(CAT_IOPINS, SL1Func, OUTPUTPINFUNCS, 0, 18, 0, 83)               \
+  PARAM_ENTRY(CAT_IOPINS, SL2Func, OUTPUTPINFUNCS, 0, 18, 0, 84)               \
+  PARAM_ENTRY(CAT_IOPINS, PWM1Func, PWMPINFUNCS, 0, 25, 0, 85)                 \
+  PARAM_ENTRY(CAT_IOPINS, PWM2Func, PWMPINFUNCS, 0, 25, 4, 86)                 \
+  PARAM_ENTRY(CAT_IOPINS, PWM3Func, PWMPINFUNCS, 0, 25, 2, 87)                 \
+  PARAM_ENTRY(CAT_IOPINS, GP12VInFunc, INPUTPINFUNCS, 0, 19, 12, 98)           \
+  PARAM_ENTRY(CAT_IOPINS, HVReqFunc, INPUTPINFUNCS, 0, 19, 12, 99)             \
+  PARAM_ENTRY(CAT_IOPINS, PB1InFunc, INPUTPINFUNCS, 0, 19, 12, 140)            \
+  PARAM_ENTRY(CAT_IOPINS, PB2InFunc, INPUTPINFUNCS, 0, 19, 12, 141)            \
+  PARAM_ENTRY(CAT_IOPINS, PB3InFunc, INPUTPINFUNCS, 0, 19, 12, 142)            \
   PARAM_ENTRY(CAT_IOPINS, GPA1Func, APINFUNCS, 0, 3, 0, 110)                   \
   PARAM_ENTRY(CAT_IOPINS, GPA2Func, APINFUNCS, 0, 3, 0, 111)                   \
   PARAM_ENTRY(CAT_IOPINS, ppthresh, "dig", 0, 4095, 2500, 114)                 \
@@ -298,15 +298,22 @@
 #define VERSTR STRINGIFY(4=VER)
 // clang-format on
 
-#define PINFUNCS                                                               \
+#define OUTPUTPINFUNCS                                                         \
   "0=None, 1=ChaDeMoAlw, 2=OBCEnable, 3=HeaterEnable, 4=RunIndication, "       \
-  "5=WarnIndication,"                                                          \
-  "6=CoolantPump, 7=NegContactor, 8=BrakeLight, 9=ReverseLight, 10=HeatReq, "  \
-  "11=HVRequest,"                                                              \
-  "12=DCFCRequest, 13=BrakeVacPump, 14=CoolingFan, 15=HvActive, "              \
-  "16=ShiftLockNO, 17=PreHeatOut, 18=Switch_NoRegen, 19=HVIL,"                 \
-  "20=PwmTim3, 21=CpSpoof, 22=GS450pump, 23=PwmTempGauge, 24=PwmSocGauge,"     \
-  "25=PwmHeater"
+  "5=WarnIndication, 6=CoolantPump, 7=NegContactor, 8=BrakeLight, "            \
+  "9=ReverseLight, 13=BrakeVacPump, 14=CoolingFan, 15=HvActive, "              \
+  "16=ShiftLockNO, 17=PreHeatOut"
+
+#define INPUTPINFUNCS                                                          \
+  "0=None, 10=HeatReq, 11=HVRequest, 12=DCFCRequest, "                         \
+  "18=Switch_NoRegen, 19=HVIL"
+
+#define PWMPINFUNCS                                                            \
+  "0=None, 1=ChaDeMoAlw, 2=OBCEnable, 3=HeaterEnable, 4=RunIndication, "       \
+  "5=WarnIndication, 6=CoolantPump, 7=NegContactor, 8=BrakeLight, "            \
+  "9=ReverseLight, 13=BrakeVacPump, 14=CoolingFan, 15=HvActive, "              \
+  "16=ShiftLockNO, 17=PreHeatOut, 20=PwmTim3, 21=CpSpoof, "                    \
+  "22=GS450pump, 23=PwmTempGauge, 24=PwmSocGauge, 25=PwmHeater"
 #define APINFUNCS "0=None, 1=ProxPilot, 2=BrakeVacSensor, 3=HeaterPot"
 #define SHIFTERS "0=None, 1=BMW_F30, 2=JLR_G1, 3=JLR_G2, 4=BMW_E65, 5=PKP2300"
 #define SHNTYPE "0=None, 1=ISA, 2=SBOX, 3=VAG. 4=ISA_udcsw"


### PR DESCRIPTION
separates inputs and outputs in the drop down list in the I/O matrix. so you cant assign inputs as out puts, etc  