### PR TITLE
Fix shutdown condition logic for JLR shifters

### DIFF
--- a/src/JLR_G1.cpp
+++ b/src/JLR_G1.cpp
@@ -142,11 +142,11 @@ void JLR_G1::Task10Ms() {
 void JLR_G1::Task100Ms() {
   if (Param::GetInt(Param::opmode) == MOD_OFF)
     this->gear = NEUTRAL;
-  if (Param::GetInt(Param::opmode) == !MOD_RUN) {
+  if (Param::GetInt(Param::opmode) == MOD_RUN) {
+    ShtdwnCnt = 0;
+  } else {
     if (ShtdwnCnt < 20)
       ShtdwnCnt++;
-  } else {
-    ShtdwnCnt = 0;
   }
 }
 

--- a/src/JLR_G2.cpp
+++ b/src/JLR_G2.cpp
@@ -185,11 +185,11 @@ void JLR_G2::Task100Ms() {
 
   if (Param::GetInt(Param::opmode) == MOD_OFF)
     this->gear = NEUTRAL;
-  if (Param::GetInt(Param::opmode) == !MOD_RUN) {
+  if (Param::GetInt(Param::opmode) == MOD_RUN) {
+    ShtdwnCnt2 = 0;
+  } else {
     if (ShtdwnCnt2 < 20)
       ShtdwnCnt2++;
-  } else {
-    ShtdwnCnt2 = 0;
   }
 }
 


### PR DESCRIPTION
### What
This is a fix in the shutdown logic for the JLR shifters.

The condition on line 145 of JLR_G1.cpp evaluates `!MOD_RUN`. This is the same as `!1` which is just `0` or `MOD_OFF`. It looks like this is a typo and the intention is for the condition to be `opmode != MOD_RUN`. As in, the shifter should shut down after 2 seconds whenever you're not in `MOD_RUN`, not just when the car is off.

JLR_G2.cpp has the same thing.

Sorry, but I don't have one of these shifters so I can't test this directly myself. Hope this helps.

### Why
Shifter should be off when not driving.

### How
Fix the condition. I suggest reversing the order to make it a bit more readable.

## Checklist

- [x] PR targets `Vehicle_Testing`
- [x] No AI was used in this PR